### PR TITLE
Harden xorb decoding and validation against malformed input

### DIFF
--- a/xorb/decoder.go
+++ b/xorb/decoder.go
@@ -92,6 +92,14 @@ func (d *Decoder) Read(p []byte) (int, error) {
 	compressedSize := uint32(headerBuf[1]) | uint32(headerBuf[2])<<8 | uint32(headerBuf[3])<<16
 	ct := compressionType(headerBuf[4])
 	uncompressedSize := uint32(headerBuf[5]) | uint32(headerBuf[6])<<8 | uint32(headerBuf[7])<<16
+	if compressedSize > uint32(len(p)) {
+		d.err = fmt.Errorf("input buffer too small for compressed chunk: need %d bytes, have %d", compressedSize, len(p))
+		return 0, d.err
+	}
+	if uncompressedSize > xet.MaxChunkSize {
+		d.err = fmt.Errorf("invalid uncompressed chunk size: %d exceeds maximum %d", uncompressedSize, xet.MaxChunkSize)
+		return 0, d.err
+	}
 
 	if _, err := io.ReadFull(d.r, p[:compressedSize]); err != nil {
 		d.err = fmt.Errorf("failed to read chunk data: %w", err)
@@ -110,13 +118,12 @@ func (d *Decoder) Read(p []byte) (int, error) {
 	d.chunkHashes = append(d.chunkHashes, h)
 	d.chunkSizes = append(d.chunkSizes, uint64(uncompressedSize))
 
-	copied := copy(p, uncompressed)
-	if copied < len(uncompressed) {
+	if len(uncompressed) > len(p) {
 		d.err = fmt.Errorf("output buffer too small: need %d bytes", len(uncompressed))
-		return copied, d.err
+		return 0, d.err
 	}
 
-	return copied, nil
+	return copy(p, uncompressed), nil
 }
 
 // SummoryHash returns the overall xorb hash.

--- a/xorb/validate.go
+++ b/xorb/validate.go
@@ -28,9 +28,12 @@ func Validate(r io.Reader, xorbHash xet.Hash) error {
 
 	for {
 		n, err := io.ReadFull(r, headerBuf[:])
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
+		if err == io.EOF {
 			// Chunk-only format: structural validation passed.
 			return nil
+		}
+		if err == io.ErrUnexpectedEOF {
+			return fmt.Errorf("failed to read chunk header: %w", err)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to read chunk header: %w", err)
@@ -47,6 +50,12 @@ func Validate(r io.Reader, xorbHash xet.Hash) error {
 		compressedSize := uint32(headerBuf[1]) | uint32(headerBuf[2])<<8 | uint32(headerBuf[3])<<16
 		ct := compressionType(headerBuf[4])
 		uncompressedSize := uint32(headerBuf[5]) | uint32(headerBuf[6])<<8 | uint32(headerBuf[7])<<16
+		if compressedSize > uint32(len(tmp)) {
+			return fmt.Errorf("invalid compressed chunk size: %d exceeds maximum %d", compressedSize, len(tmp))
+		}
+		if uncompressedSize > xet.MaxChunkSize {
+			return fmt.Errorf("invalid uncompressed chunk size: %d exceeds maximum %d", uncompressedSize, xet.MaxChunkSize)
+		}
 
 		if _, err := io.ReadFull(r, tmp[:compressedSize]); err != nil {
 			return fmt.Errorf("failed to read compressed chunk data: %w", err)
@@ -95,11 +104,19 @@ func validateWithFooter(
 	}
 
 	numChunks := binary.LittleEndian.Uint32(fixedBuf[40:44])
+	if numChunks > xet.MaxChunksPerXorb {
+		return fmt.Errorf("invalid footer: chunk count %d exceeds maximum %d", numChunks, xet.MaxChunksPerXorb)
+	}
 
 	// Remaining: chunk hashes (32*N) + boundary section (12 + 8*N) + trailer (28) + length field (4)
 	// = 40*N + 44 bytes.
 	remainingSize := int(numChunks)*40 + 44
-	remaining := buf[:remainingSize]
+	remaining := buf
+	if remainingSize > len(remaining) {
+		remaining = make([]byte, remainingSize)
+	} else {
+		remaining = remaining[:remainingSize]
+	}
 	if _, err := io.ReadFull(r, remaining); err != nil {
 		return fmt.Errorf("invalid footer: failed to read remaining footer data: %w", err)
 	}

--- a/xorb/validate_test.go
+++ b/xorb/validate_test.go
@@ -1,0 +1,71 @@
+package xorb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/wzshiming/xet"
+)
+
+func TestValidateRejectsTruncatedChunkHeader(t *testing.T) {
+	err := Validate(bytes.NewReader([]byte{0, 1, 2}), xet.Hash{})
+	if err == nil || !strings.Contains(err.Error(), "unexpected EOF") {
+		t.Fatalf("Validate() error = %v, want unexpected EOF", err)
+	}
+}
+
+func TestValidateRejectsOversizedChunkLengths(t *testing.T) {
+	tests := []struct {
+		name   string
+		header [8]byte
+		want   string
+	}{
+		{
+			name:   "compressed",
+			header: [8]byte{0, 1, 0, 3}, // 196609 bytes, larger than MaxChunkSize.
+			want:   "invalid compressed chunk size",
+		},
+		{
+			name:   "uncompressed",
+			header: [8]byte{0, 0, 0, 0, 0, 1, 0, 3},
+			want:   "invalid uncompressed chunk size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(bytes.NewReader(tt.header[:]), xet.Hash{})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecoderRejectsChunkLargerThanCallerBuffer(t *testing.T) {
+	header := [8]byte{0, 2, 0, 0, 0, 2, 0, 0}
+	decoder := NewDecoder(bytes.NewReader(header[:]), false)
+
+	if _, err := decoder.Read(make([]byte, 1)); err == nil || !strings.Contains(err.Error(), "input buffer too small") {
+		t.Fatalf("Decoder.Read() error = %v, want input-buffer error", err)
+	}
+}
+
+func TestValidateRejectsFooterChunkCountAboveProtocolLimit(t *testing.T) {
+	var data bytes.Buffer
+	data.Write(xorbIdentifier[:])
+	data.WriteByte(1)
+	data.Write(make([]byte, 32))
+	data.Write(hashSectionIdent[:])
+	data.WriteByte(0)
+	if err := binary.Write(&data, binary.LittleEndian, uint32(xet.MaxChunksPerXorb+1)); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Validate(&data, xet.Hash{})
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("Validate() error = %v, want chunk-count limit error", err)
+	}
+}


### PR DESCRIPTION
### Motivation

- Prevent malformed or adversarial xorb streams from being accepted or causing panics by making the validator and decoder strictly enforce protocol bounds. 
- Align behavior with the expectation that truncated headers are reported as an error instead of being treated as valid footerless xorbs.

### Description

- Make `Validate` stricter by returning an error on `io.ErrUnexpectedEOF` for truncated headers and by checking encoded `compressedSize` and `uncompressedSize` against safe limits before slicing buffers. 
- Add a footer safety check that enforces `numChunks` does not exceed `xet.MaxChunksPerXorb` and allocate a suitably sized buffer when the pooled buffer is too small. 
- Harden `Decoder.Read` to validate declared compressed/uncompressed sizes against caller buffers and `xet.MaxChunkSize`, and return clear errors instead of producing partial output or panicking. 
- Add regression tests in `xorb/validate_test.go` covering truncated headers, oversized compressed/uncompressed lengths, decoder buffer-too-small condition, and footer chunk-count limits.

### Testing

- Ran `go test ./xorb ./...` and the xorb package tests (including new tests) passed. 
- Ran `go vet ./...` and `git diff --check` with no issues reported. 
- Broader conformance client/server tests that exercise the Rust FFI (`test/conformance/...`) failed in this environment due to external `xet-go` requests being rejected (HTTP 403 via the environment tunnel), so integration comparisons were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c421886f8832e98a4e63ced19c95a)