### PR TITLE
feat: add mirror mode bridging xet and plain hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Implemented in this repository:
 - Shard and xorb encode/decode paths
 - Upload and download client workflows
 - CAS server implementation for local or self-hosted usage
+- Mirror mode: full-cache middle layer bridging xet and plain hubs
 - Hugging Face token/LFS based integration helpers
 - Conformance and unit tests for key protocol paths
 

--- a/client/download.go
+++ b/client/download.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,7 +32,7 @@ func (c *Client) DownloadFile(ctx context.Context, fileHash xet.FileHash, w io.W
 func (c *Client) DownloadFileWithAuthProvider(ctx context.Context, provider AuthProvider, fileHash xet.FileHash, w io.WriteSeeker) error {
 	err := c.DownloadFileV2WithAuthProvider(ctx, provider, fileHash, w)
 	if err != nil {
-		if err == errNotFound {
+		if errors.Is(err, errNotFound) {
 			return c.DownloadFileV1WithAuthProvider(ctx, provider, fileHash, w)
 		}
 		return err
@@ -110,7 +111,10 @@ func (c *Client) newDownloadReader(ctx context.Context, provider AuthProvider, f
 func (c *Client) newDownloadReaderV1(ctx context.Context, provider AuthProvider, fileHash xet.FileHash, header http.Header, resumeOffset int64, w io.WriteSeeker) (io.ReadCloser, int64, error) {
 	reconstructionResp, err := c.GetReconstructionV1WithAuthProvider(ctx, provider, fileHash, header)
 	if err != nil {
-		if resumeOffset > 0 {
+		// Only a rejected Range query warrants restarting from scratch; a 404
+		// means the file is absent and rewinding would just lose the resume
+		// offset.
+		if resumeOffset > 0 && !errors.Is(err, errNotFound) {
 			if _, seekErr := w.Seek(0, io.SeekStart); seekErr == nil {
 				resumeOffset = 0
 				reconstructionResp, err = c.GetReconstructionV1WithAuthProvider(ctx, provider, fileHash, nil)
@@ -131,7 +135,9 @@ func (c *Client) newDownloadReaderV1(ctx context.Context, provider AuthProvider,
 func (c *Client) newDownloadReaderV2(ctx context.Context, provider AuthProvider, fileHash xet.FileHash, header http.Header, resumeOffset int64, w io.WriteSeeker) (io.ReadCloser, int64, error) {
 	reconstructionResp, err := c.GetReconstructionV2WithAuthProvider(ctx, provider, fileHash, header)
 	if err != nil {
-		if resumeOffset > 0 {
+		// A missing V2 endpoint must not rewind w: the caller falls back to
+		// V1, which resumes from the same offset.
+		if resumeOffset > 0 && !errors.Is(err, errNotFound) {
 			if _, seekErr := w.Seek(0, io.SeekStart); seekErr == nil {
 				resumeOffset = 0
 				reconstructionResp, err = c.GetReconstructionV2WithAuthProvider(ctx, provider, fileHash, nil)

--- a/cmd/xetd/main.go
+++ b/cmd/xetd/main.go
@@ -5,10 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/gorilla/handlers"
+	"github.com/wzshiming/xet/mirror"
 	"github.com/wzshiming/xet/server"
 	"github.com/wzshiming/xet/storage"
+	"github.com/wzshiming/xet/token"
 )
 
 func main() {
@@ -16,7 +20,9 @@ func main() {
 	addr := flag.String("addr", ":8080", "Server address (host:port)")
 	storageDir := flag.String("storage", "./xet-data", "Storage directory for xorbs and shards")
 	baseURL := flag.String("base-url", "", "Base URL for serving xorb data (optional)")
-	authToken := flag.String("token", "", "Authentication token (optional, if set, clients must provide this token)")
+	authToken := flag.String("token", "", "Authentication token; also the secret for minted short-lived tokens (optional, if set, clients must provide this token or a minted one)")
+	upstream := flag.String("upstream", "", "Upstream hub URL to mirror, e.g. https://huggingface.co (enables mirror mode)")
+	upstreamToken := flag.String("upstream-token", "", "Bearer token the mirror uses against the upstream hub")
 	flag.Parse()
 
 	// Create storage
@@ -29,11 +35,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create authentication function if token is provided
+	// Create authentication function if token is provided. The token doubles
+	// as the issuer secret, so minted short-lived tokens are deterministic:
+	// they survive restarts and validate across instances sharing the token.
+	// Without a token the issuer falls back to a random per-process secret.
+	issuer, err := token.NewIssuer([]byte(*authToken), 15*time.Minute)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create token issuer: %v\n", err)
+		os.Exit(1)
+	}
+
 	var authFn server.AuthFunc
 	if *authToken != "" {
-		authFn = func(token string) bool {
-			return token == *authToken
+		authFn = func(tok string) bool {
+			return tok == *authToken
 		}
 		fmt.Println("Authentication enabled")
 	} else {
@@ -41,6 +56,26 @@ func main() {
 	}
 
 	var next http.Handler
+
+	if *upstream != "" {
+		// Mirror mode: full-cache middle layer in front of the upstream hub.
+		// The mirror handles resolve/token requests and proxies the rest to
+		// the upstream; the CAS server below matches its own routes first.
+		next, err = mirror.NewHandler(
+			mirror.WithStorage(storage),
+			mirror.WithUpstream(*upstream),
+			mirror.WithUpstreamToken(*upstreamToken),
+			mirror.WithExternalURL(*baseURL),
+			mirror.WithCacheDir(filepath.Join(*storageDir, "mirror")),
+			mirror.WithMintToken(issuer.Mint),
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create mirror: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Mirror mode enabled, upstream: %s\n", *upstream)
+	}
 
 	// Create server
 	next = server.NewHandler(

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/wzshiming/httpseek v0.6.1
 	github.com/zeebo/blake3 v0.2.4
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCR
 github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
 github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/hf/download.go
+++ b/hf/download.go
@@ -51,7 +51,7 @@ func ResolveResponse(ctx context.Context, httpClient *http.Client, resp *http.Re
 		return xet.FileHash{}, nil, fmt.Errorf("unexpected status from resolve: %d", resp.StatusCode)
 	}
 
-	linkMap := parseLinkHeaders(resp.Header.Values("Link"))
+	linkMap := ParseLinkHeaders(resp.Header.Values("Link"))
 	reconURLStr := linkMap["xet-reconstruction-info"]
 	if reconURLStr == "" {
 		return xet.FileHash{}, nil, fmt.Errorf("missing xet-reconstruction-info link")
@@ -108,7 +108,8 @@ func normalizeRepoType(repoType string) string {
 	}
 }
 
-func parseLinkHeaders(values []string) map[string]string {
+// ParseLinkHeaders extracts rel -> URL pairs from Link header values.
+func ParseLinkHeaders(values []string) map[string]string {
 	result := make(map[string]string)
 	for _, value := range values {
 		parts := strings.SplitSeq(value, ",")

--- a/mirror/index.go
+++ b/mirror/index.go
@@ -1,0 +1,89 @@
+package mirror
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type entryState string
+
+const (
+	stateReady  entryState = "ready"
+	stateFailed entryState = "failed"
+)
+
+// fileEntry is the per-(repo, rev, path) state record. Only ready entries are
+// persisted; failures and in-flight ingests are process-local.
+type fileEntry struct {
+	Key   string     `json:"key"`
+	State entryState `json:"state"`
+
+	FileHash string `json:"file_hash,omitempty"`
+	SHA256   string `json:"sha256,omitempty"`
+	Size     int64  `json:"size"`
+	ETag     string `json:"etag,omitempty"`
+	Commit   string `json:"commit,omitempty"`
+
+	CheckedAt time.Time `json:"checked_at"`
+
+	// in-memory only
+	failures  int
+	nextRetry time.Time
+	lastErr   error
+	notFound  bool
+}
+
+func indexEntryPath(dir, key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return filepath.Join(dir, hex.EncodeToString(sum[:])+".json")
+}
+
+// persistEntry writes a ready entry to disk so it survives restarts.
+func persistEntry(dir string, e *fileEntry) error {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("marshal index entry: %w", err)
+	}
+	path := indexEntryPath(dir, e.Key)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("write index entry: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("finalize index entry: %w", err)
+	}
+	return nil
+}
+
+// loadIndex reads all persisted entries from dir.
+func loadIndex(dir string) (map[string]*fileEntry, error) {
+	files := make(map[string]*fileEntry)
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return files, nil
+		}
+		return nil, fmt.Errorf("read index dir: %w", err)
+	}
+	for _, de := range dirEntries {
+		if de.IsDir() || filepath.Ext(de.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, de.Name()))
+		if err != nil {
+			continue
+		}
+		var e fileEntry
+		if err := json.Unmarshal(data, &e); err != nil || e.Key == "" || e.State != stateReady {
+			continue
+		}
+		files[e.Key] = &e
+	}
+	return files, nil
+}

--- a/mirror/localcas.go
+++ b/mirror/localcas.go
@@ -1,0 +1,78 @@
+package mirror
+
+import (
+	"context"
+	"io"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/shard"
+	"github.com/wzshiming/xet/storage"
+	"github.com/wzshiming/xet/upload"
+)
+
+// localCAS adapts storage.Storage to upload.ClientAdapter so the standard
+// upload pipeline writes xorbs and shards straight into local storage without
+// any HTTP hop.
+type localCAS struct {
+	storage   storage.Storage
+	namespace string
+}
+
+var _ upload.ClientAdapter = (*localCAS)(nil)
+
+func (l *localCAS) HasXorb(ctx context.Context, xorbHash xet.XorbHash) (bool, error) {
+	return l.storage.HasXorb(ctx, l.namespace, xorbHash)
+}
+
+func (l *localCAS) UploadXorb(ctx context.Context, xorbHash xet.XorbHash, reader io.ReadSeeker) (*upload.XorbUploadResponse, error) {
+	wasInserted, err := l.storage.PutXorb(ctx, l.namespace, xorbHash, reader)
+	if err != nil {
+		return nil, err
+	}
+	return &upload.XorbUploadResponse{WasInserted: wasInserted}, nil
+}
+
+func (l *localCAS) UploadShard(ctx context.Context, shardObj *shard.Shard) (*upload.ShardUploadResponse, error) {
+	wasInserted, err := l.storage.PutShard(ctx, shardObj)
+	if err != nil {
+		return nil, err
+	}
+	result := 0
+	if wasInserted {
+		result = 1
+	}
+	return &upload.ShardUploadResponse{Result: result}, nil
+}
+
+func (l *localCAS) QueryDedupShards(ctx context.Context, chunkHashes []xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
+	results := make(map[xet.ChunkHash]*upload.DeduplicationResult, len(chunkHashes))
+	for _, chunkHash := range chunkHashes {
+		if _, ok := results[chunkHash]; ok {
+			continue
+		}
+		shardObj, err := l.storage.GetShardByChunkHash(ctx, l.namespace, chunkHash)
+		if err != nil || shardObj == nil {
+			results[chunkHash] = &upload.DeduplicationResult{ChunkHash: chunkHash, IsNew: true}
+			continue
+		}
+		// Register every chunk of the found shard, matching the remote
+		// global-dedup behavior where one probe yields the whole shard.
+		for _, casBlock := range shardObj.CASInfos {
+			for i, casChunk := range casBlock.Chunks {
+				if _, ok := results[casChunk.ChunkHash]; ok {
+					continue
+				}
+				results[casChunk.ChunkHash] = &upload.DeduplicationResult{
+					ChunkHash:  casChunk.ChunkHash,
+					IsNew:      false,
+					XorbHash:   casBlock.CASHash,
+					ChunkIndex: uint32(i),
+				}
+			}
+		}
+		if _, ok := results[chunkHash]; !ok {
+			results[chunkHash] = &upload.DeduplicationResult{ChunkHash: chunkHash, IsNew: true}
+		}
+	}
+	return results, nil
+}

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -1,0 +1,838 @@
+// Package mirror implements a full-cache middle layer that sits between a hub
+// upstream (huggingface.co, an HF mirror, modelscope.cn, ...) and downstream
+// clients, bridging every combination of xet-capable and plain peers.
+//
+// Upstream capability is detected per response and only from headers: the
+// presence of the xet-reconstruction-info / xet-auth Link headers on the
+// upstream resolve response. Downstream needs no detection: once a file is
+// ready, the resolve response carries both the xet Link headers (pointing at
+// the mirror's own CAS and token endpoints) and the normal plain redirect,
+// so xet clients follow the links while plain clients ignore them.
+//
+// All bytes flow through the mirror and land in local storage as xorbs and
+// shards. The first request for a file starts the one background ingestion
+// download; concurrent requests (including the first) are served plain HTTP
+// from the growing spool as bytes arrive. A client disconnect never cancels
+// ingestion, and partial spool bytes survive task failures and process
+// restarts: the next task resumes from them when the upstream etag still
+// matches.
+package mirror
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/wzshiming/httpseek"
+	"github.com/wzshiming/xet/client"
+	"github.com/wzshiming/xet/hf"
+	"github.com/wzshiming/xet/storage"
+	"github.com/wzshiming/xet/upload"
+	"golang.org/x/sync/singleflight"
+)
+
+// resolveRe matches hub-style download paths. The prefix before /resolve/ is
+// treated as an opaque repo identity, so no platform-specific routing exists.
+var resolveRe = regexp.MustCompile(`^/(.+?)/resolve/([^/]+)/(.+)$`)
+
+// commitRevRe matches revision strings that pin an immutable commit.
+var commitRevRe = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+const (
+	tokenEndpointPath  = "/xet-token"
+	maxFetchAttempts   = 5
+	failureBackoffBase = 10 * time.Second
+	failureBackoffCap  = 10 * time.Minute
+	maxFailureShift    = 6
+)
+
+var (
+	errUpstreamNotFound = errors.New("upstream file not found")
+	// errSpoolCorrupt marks spooled bytes that failed verification; the spool
+	// must be discarded rather than kept for resume.
+	errSpoolCorrupt = errors.New("spool corrupt")
+)
+
+// Handler is the mirror HTTP front end: resolve requests are served from the
+// local cache (ingesting on miss) and the token endpoint hands downstream
+// clients their CAS credential. Everything else falls through to next, which
+// defaults to a reverse proxy that forwards to the upstream with the mirror's
+// credentials injected (control plane only, never file bytes). Mount the
+// Handler as the CAS server's next; token minting and validation are wired by
+// the caller through WithMintToken and the server's AuthFunc.
+type Handler struct {
+	storage            storage.Storage
+	upstreamRaw        string
+	upstream           *url.URL
+	upstreamToken      string
+	external           string
+	cacheDir           string
+	indexDir           string
+	spoolDir           string
+	revalidateInterval time.Duration
+	mintToken          func(now time.Time) (token string, exp int64)
+
+	probeClient  *http.Client // does not follow redirects; used for metadata probes
+	fetchClient  *http.Client // follows redirects; body drops resume via httpseek
+	xetClient    *client.Client
+	next         http.Handler
+	localAdapter *localCAS
+
+	mu      sync.Mutex
+	flight  singleflight.Group
+	entries map[string]*fileEntry
+	tasks   map[string]*task
+}
+
+// Option configures the Handler.
+type Option func(*Handler)
+
+// WithStorage sets the storage backend shared with the embedded CAS server. Required.
+func WithStorage(s storage.Storage) Option {
+	return func(h *Handler) { h.storage = s }
+}
+
+// WithUpstream sets the upstream hub base URL, e.g. https://huggingface.co. Required.
+func WithUpstream(upstream string) Option {
+	return func(h *Handler) { h.upstreamRaw = upstream }
+}
+
+// WithUpstreamToken sets the credential the mirror uses against the upstream
+// hub. Downstream Authorization headers are never forwarded upstream.
+func WithUpstreamToken(token string) Option {
+	return func(h *Handler) { h.upstreamToken = token }
+}
+
+// WithCacheDir sets the directory holding the persisted index, in-flight
+// spool files, and the xet chunk cache. Defaults to ./xet-mirror.
+func WithCacheDir(dir string) Option {
+	return func(h *Handler) { h.cacheDir = dir }
+}
+
+// WithExternalURL sets the externally visible base URL used in Link headers
+// and minted tokens. When empty it is derived from each request.
+func WithExternalURL(external string) Option {
+	return func(h *Handler) { h.external = strings.TrimRight(external, "/") }
+}
+
+// WithMintToken sets the function the token endpoint uses to mint downstream
+// CAS tokens, typically the Mint of a token.Issuer shared with the CAS
+// server's AuthFunc. When unset the endpoint returns an empty anonymous
+// token, suitable for an unauthenticated CAS.
+func WithMintToken(mint func(now time.Time) (token string, exp int64)) Option {
+	return func(h *Handler) { h.mintToken = mint }
+}
+
+// WithNext sets the handler for requests that are neither resolve nor token
+// requests. When unset it defaults to a reverse proxy that forwards to the
+// upstream with the mirror's credentials injected.
+func WithNext(next http.Handler) Option {
+	return func(h *Handler) { h.next = next }
+}
+
+// WithRevalidateInterval sets how often ready entries for branch (non-commit)
+// revisions are re-checked against the upstream. Zero revalidates on every
+// request; negative disables revalidation. Defaults to 5 minutes.
+func WithRevalidateInterval(d time.Duration) Option {
+	return func(h *Handler) { h.revalidateInterval = d }
+}
+
+// NewHandler creates a mirror handler.
+func NewHandler(opts ...Option) (*Handler, error) {
+	h := &Handler{
+		cacheDir:           "./xet-mirror",
+		revalidateInterval: 5 * time.Minute,
+		entries:            map[string]*fileEntry{},
+		tasks:              map[string]*task{},
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	if h.storage == nil {
+		return nil, fmt.Errorf("mirror: storage is required")
+	}
+	if h.upstreamRaw == "" {
+		return nil, fmt.Errorf("mirror: upstream is required")
+	}
+	u, err := url.Parse(h.upstreamRaw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("mirror: invalid upstream URL %q", h.upstreamRaw)
+	}
+	h.upstream = u
+
+	h.indexDir = filepath.Join(h.cacheDir, "index")
+	h.spoolDir = filepath.Join(h.cacheDir, "spool")
+	chunkCacheDir := filepath.Join(h.cacheDir, "chunks")
+	for _, dir := range []string{h.indexDir, h.spoolDir, chunkCacheDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("mirror: create %s: %w", dir, err)
+		}
+	}
+
+	h.entries, err = loadIndex(h.indexDir)
+	if err != nil {
+		return nil, fmt.Errorf("mirror: load index: %w", err)
+	}
+
+	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
+	injecting := &authInjector{inner: baseTransport, host: u.Host, token: h.upstreamToken}
+	h.probeClient = &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: injecting,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	h.fetchClient = &http.Client{
+		Transport: httpseek.NewMustReaderTransport(injecting, func(r *http.Request, retry int, err error) error {
+			if retry >= maxFetchAttempts {
+				return fmt.Errorf("max retries reached: %w", err)
+			}
+			return nil
+		}),
+	}
+
+	// Without an explicit cache dir the client would fall back to a shared
+	// location under os.TempDir; keep the chunk cache with the mirror data.
+	h.xetClient, err = client.NewClient(client.WithCacheDir(chunkCacheDir))
+	if err != nil {
+		return nil, fmt.Errorf("mirror: create xet client: %w", err)
+	}
+
+	h.localAdapter = &localCAS{storage: h.storage, namespace: "default"}
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(u)
+			pr.Out.Host = u.Host
+			pr.Out.Header.Del("Authorization")
+			if h.upstreamToken != "" {
+				pr.Out.Header.Set("Authorization", "Bearer "+h.upstreamToken)
+			}
+		},
+	}
+	if h.next == nil {
+		h.next = proxy
+	}
+
+	return h, nil
+}
+
+// ServeHTTP handles resolve and token requests; everything else falls through
+// to next (the upstream proxy by default).
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.EscapedPath()
+	if p == tokenEndpointPath && r.Method == http.MethodGet {
+		h.handleToken(w, r)
+		return
+	}
+	if (r.Method == http.MethodGet || r.Method == http.MethodHead) && resolveRe.MatchString(p) {
+		h.handleResolve(w, r, p)
+		return
+	}
+	h.next.ServeHTTP(w, r)
+}
+
+// handleToken hands out a short-lived CAS token in the same JSON shape as the
+// hub token endpoint, pointing casUrl at the mirror itself.
+func (h *Handler) handleToken(w http.ResponseWriter, r *http.Request) {
+	now := time.Now()
+	var tok string
+	exp := now.Add(15 * time.Minute).Unix()
+	if h.mintToken != nil {
+		tok, exp = h.mintToken(now)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"casUrl":      h.externalBase(r),
+		"accessToken": tok,
+		"exp":         exp,
+	})
+}
+
+// externalBase returns the mirror's externally visible base URL.
+func (h *Handler) externalBase(r *http.Request) string {
+	if h.external != "" {
+		return h.external
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	}
+	return scheme + "://" + r.Host
+}
+
+// upstreamURL maps a local resolve path to the upstream equivalent.
+func (h *Handler) upstreamURL(key string) string {
+	return strings.TrimRight(h.upstream.String(), "/") + key
+}
+
+// task tracks one in-flight ingestion. All concurrent requests for the same
+// key attach to it, so the upstream is downloaded exactly once per file.
+type task struct {
+	spool    *spool        // set by runTask before probed closes (when the probe succeeded)
+	probed   chan struct{} // closed once probe metadata (or probeErr) is set
+	sized    chan struct{} // closed once size is known or no early source remains
+	sizeOnce sync.Once
+	probeErr error
+	notFound bool
+	probe    *probeResult
+	size     atomic.Int64 // final content length, -1 until known
+}
+
+// setSize records the content length once known (first value wins) and
+// unblocks resolve replies waiting on it; n < 0 only signals.
+func (t *task) setSize(n int64) {
+	if n >= 0 {
+		t.size.CompareAndSwap(-1, n)
+	}
+	t.sizeOnce.Do(func() { close(t.sized) })
+}
+
+// handleResolve serves GET/HEAD for hub-style download paths.
+func (h *Handler) handleResolve(w http.ResponseWriter, r *http.Request, key string) {
+	m := resolveRe.FindStringSubmatch(key)
+	rev := m[2]
+
+	h.mu.Lock()
+	t := h.tasks[key]
+	e := h.entries[key]
+	h.mu.Unlock()
+
+	if t != nil {
+		h.serveTaskOrEntry(w, r, key, t)
+		return
+	}
+	if e != nil {
+		switch e.State {
+		case stateReady:
+			if h.needsRevalidate(e, rev) {
+				e = h.revalidate(r.Context(), key, e)
+			}
+			if e != nil {
+				h.serveReady(w, r, e)
+				return
+			}
+			// stale: fall through and re-ingest
+		case stateFailed:
+			if time.Now().Before(e.nextRetry) {
+				h.serveFailed(w, e)
+				return
+			}
+		}
+	}
+
+	t, e, err := h.startTask(key)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if e != nil {
+		// Lost the race: another request finished (or failed) the ingest first.
+		h.serveEntry(w, r, e)
+		return
+	}
+	h.serveTaskOrEntry(w, r, key, t)
+}
+
+// serveEntry answers from a completed entry, ready or failed.
+func (h *Handler) serveEntry(w http.ResponseWriter, r *http.Request, e *fileEntry) {
+	if e.State == stateReady {
+		h.serveReady(w, r, e)
+	} else {
+		h.serveFailed(w, e)
+	}
+}
+
+// serveTaskOrEntry streams from the in-flight task, falling back to the entry
+// published by a completed ingest when the spool was drained and removed
+// before this request could attach.
+func (h *Handler) serveTaskOrEntry(w http.ResponseWriter, r *http.Request, key string, t *task) {
+	if h.serveFromTask(w, r, t) {
+		return
+	}
+	h.mu.Lock()
+	e := h.entries[key]
+	h.mu.Unlock()
+	if e == nil {
+		http.Error(w, "File not found", http.StatusNotFound)
+		return
+	}
+	h.serveEntry(w, r, e)
+}
+
+// startTask returns the in-flight ingestion task for key, or the entry when
+// the ingest already completed (or failed and is backing off). Only the task
+// startup itself runs inside the singleflight, so the task is registered
+// exactly once per key.
+func (h *Handler) startTask(key string) (*task, *fileEntry, error) {
+	v, err, _ := h.flight.Do(key, func() (any, error) {
+		// A previous flight may have registered a task, or finished the whole
+		// ingest, between the caller's check and this one.
+		h.mu.Lock()
+		t := h.tasks[key]
+		e := h.entries[key]
+		h.mu.Unlock()
+		if t != nil {
+			return t, nil
+		}
+		if e != nil {
+			if e.State == stateReady {
+				return e, nil
+			}
+			if e.State == stateFailed && time.Now().Before(e.nextRetry) {
+				return e, nil
+			}
+		}
+		nt := &task{probed: make(chan struct{}), sized: make(chan struct{})}
+		nt.size.Store(-1)
+		h.mu.Lock()
+		h.tasks[key] = nt
+		h.mu.Unlock()
+		go h.runTask(key, nt)
+		return nt, nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if t, ok := v.(*task); ok {
+		return t, nil, nil
+	}
+	return nil, v.(*fileEntry), nil
+}
+
+// runTask executes one ingestion end to end on a background context; client
+// disconnects never cancel it. The spool opens after the probe so partial
+// bytes from a previous failed task (or a previous process) are resumed when
+// the upstream etag still matches.
+func (h *Handler) runTask(key string, t *task) {
+	ctx := context.Background()
+
+	pr, err := h.probe(ctx, key)
+	if err == nil {
+		switch {
+		case pr.status == http.StatusNotFound:
+			err = errUpstreamNotFound
+		case pr.status < 200 || pr.status >= 300:
+			err = fmt.Errorf("upstream status %d", pr.status)
+		}
+	}
+	if err != nil {
+		t.probeErr = err
+		t.notFound = errors.Is(err, errUpstreamNotFound)
+		close(t.probed)
+		h.failTask(key, t, err)
+		return
+	}
+
+	sp, err := openSpool(h.spoolDir, key, pr.etag, pr.size)
+	if err != nil {
+		t.probeErr = err
+		close(t.probed)
+		h.failTask(key, t, err)
+		return
+	}
+	t.spool = sp
+	sp.acquire() // held by runTask until ingest completes
+	defer sp.release()
+
+	t.probe = pr
+	if pr.size >= 0 {
+		t.setSize(pr.size)
+	}
+	close(t.probed)
+	defer t.setSize(-1) // unblock size waiters at the latest when the task ends
+
+	switch {
+	case pr.size >= 0 && sp.size() == pr.size:
+		// A previous task already spooled the whole file (e.g. it failed
+		// between fetch and ingest); skip the refetch.
+	case pr.xet:
+		// The xet ingest reports no size before completion; when the probe
+		// found none there is no early source, so stop replies waiting for one.
+		t.setSize(-1)
+		err = h.fetchXet(ctx, t, key)
+	default:
+		err = h.fetchPlain(ctx, t, key)
+	}
+	if err == nil {
+		if want := t.size.Load(); want >= 0 && t.spool.size() != want {
+			err = fmt.Errorf("upstream size mismatch: got %d bytes, want %d", t.spool.size(), want)
+			if t.spool.size() > want {
+				t.spool.markRemove()
+			}
+		}
+	}
+	if err != nil {
+		t.spool.finish(err)
+		h.failTask(key, t, err)
+		return
+	}
+	t.size.Store(t.spool.size())
+	t.setSize(-1) // definitive size stored above; signal any waiters
+	t.spool.finish(nil)
+
+	entry, err := h.ingestSpool(ctx, t, key)
+	if err != nil {
+		if errors.Is(err, errSpoolCorrupt) {
+			t.spool.markRemove()
+		}
+		h.failTask(key, t, err)
+		return
+	}
+
+	h.mu.Lock()
+	h.entries[key] = entry
+	delete(h.tasks, key)
+	h.mu.Unlock()
+	t.spool.markRemove() // bytes now live in storage; drop the spool when drained
+}
+
+// failTask records a failure with exponential backoff and clears the task.
+func (h *Handler) failTask(key string, t *task, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	failures := 1
+	if prev := h.entries[key]; prev != nil && prev.State == stateFailed {
+		failures = prev.failures + 1
+	}
+	shift := min(failures-1, maxFailureShift)
+	backoff := min(failureBackoffBase<<shift, failureBackoffCap)
+	h.entries[key] = &fileEntry{
+		Key:       key,
+		State:     stateFailed,
+		failures:  failures,
+		nextRetry: time.Now().Add(backoff),
+		lastErr:   err,
+		notFound:  t.notFound,
+	}
+	delete(h.tasks, key)
+}
+
+// fetchXet downloads the file through the upstream xet CAS into the spool,
+// resuming from the current spool offset on retries. Resolve and token
+// handling reuse the hf package: the returned provider refreshes short-lived
+// CAS tokens from the upstream's xet-auth endpoint, and term fetches resume
+// dropped bodies via the client's built-in httpseek transport. The resolve
+// itself runs inside the retry loop so a transient failure there does not
+// fail the whole task.
+func (h *Handler) fetchXet(ctx context.Context, t *task, key string) error {
+	return fetchWithRetries(ctx, "xet download", func() error {
+		fileHash, provider, err := hf.ResolveDownload(ctx, h.probeClient, h.upstreamURL(key))
+		if err != nil {
+			return fmt.Errorf("resolve upstream xet download: %w", err)
+		}
+		return h.xetClient.DownloadFileWithAuthProvider(ctx, provider, fileHash, t.spool)
+	})
+}
+
+// fetchPlain downloads the file bytes over plain HTTP into the spool, resuming
+// from the current spool offset with Range requests on retries.
+func (h *Handler) fetchPlain(ctx context.Context, t *task, key string) error {
+	return fetchWithRetries(ctx, "plain download", func() error {
+		return h.fetchPlainOnce(ctx, t, key)
+	})
+}
+
+func fetchWithRetries(ctx context.Context, operation string, fetch func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < maxFetchAttempts; attempt++ {
+		if err := sleepBackoff(ctx, attempt); err != nil {
+			return err
+		}
+		lastErr = fetch()
+		if lastErr == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s failed after %d attempts: %w", operation, maxFetchAttempts, lastErr)
+}
+
+func (h *Handler) fetchPlainOnce(ctx context.Context, t *task, key string) error {
+	offset := t.spool.size()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.upstreamURL(key), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept-Encoding", "identity")
+	if offset > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
+	}
+
+	resp, err := h.fetchClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body := io.Reader(resp.Body)
+	switch {
+	case offset == 0 && resp.StatusCode == http.StatusOK:
+		if resp.ContentLength >= 0 {
+			t.setSize(resp.ContentLength)
+		}
+	case offset > 0 && resp.StatusCode == http.StatusPartialContent:
+		if total := parseContentRangeTotal(resp.Header.Get("Content-Range")); total >= 0 {
+			t.setSize(total)
+		}
+	case offset > 0 && resp.StatusCode == http.StatusOK:
+		// Upstream ignored the Range; skip what the spool already holds.
+		if _, err := io.CopyN(io.Discard, body, offset); err != nil {
+			return fmt.Errorf("skip resumed bytes: %w", err)
+		}
+	default:
+		return fmt.Errorf("upstream fetch status %d", resp.StatusCode)
+	}
+
+	_, err = io.Copy(t.spool, body)
+	return err
+}
+
+func parseContentRangeTotal(value string) int64 {
+	// Format: bytes <start>-<end>/<total>
+	idx := strings.LastIndexByte(value, '/')
+	if idx < 0 {
+		return -1
+	}
+	total, err := strconv.ParseInt(value[idx+1:], 10, 64)
+	if err != nil {
+		return -1
+	}
+	return total
+}
+
+func sleepBackoff(ctx context.Context, attempt int) error {
+	if attempt == 0 {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(time.Duration(attempt) * 500 * time.Millisecond):
+		return nil
+	}
+}
+
+// ingestSpool verifies the spooled bytes and runs the standard upload pipeline
+// against local storage, then returns the ready index entry.
+func (h *Handler) ingestSpool(ctx context.Context, t *task, key string) (*fileEntry, error) {
+	f, err := os.Open(t.spool.f.Name())
+	if err != nil {
+		return nil, fmt.Errorf("open spool: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	hasher := sha256.New()
+	size, err := io.Copy(hasher, f)
+	if err != nil {
+		return nil, fmt.Errorf("hash spool: %w", err)
+	}
+	digest := hex.EncodeToString(hasher.Sum(nil))
+	if t.probe.sha256 != "" && digest != t.probe.sha256 {
+		return nil, fmt.Errorf("%w: sha256 mismatch: got %s, upstream advertised %s", errSpoolCorrupt, digest, t.probe.sha256)
+	}
+
+	entry := &fileEntry{
+		Key:       key,
+		State:     stateReady,
+		SHA256:    digest,
+		Size:      size,
+		ETag:      t.probe.etag,
+		Commit:    t.probe.commit,
+		CheckedAt: time.Now(),
+	}
+
+	if size > 0 {
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return nil, fmt.Errorf("rewind spool: %w", err)
+		}
+		fileHash, err := upload.UploadFile(ctx, h.localAdapter, f,
+			upload.WithEnableSHA256(true),
+			upload.WithConcurrency(4),
+			upload.WithCacheDir(h.spoolDir),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("ingest into storage: %w", err)
+		}
+		entry.FileHash = fileHash.String()
+	}
+
+	if err := persistEntry(h.indexDir, entry); err != nil {
+		return nil, err
+	}
+	return entry, nil
+}
+
+// needsRevalidate reports whether a ready entry must be re-checked upstream.
+func (h *Handler) needsRevalidate(e *fileEntry, rev string) bool {
+	if h.revalidateInterval < 0 || commitRevRe.MatchString(rev) {
+		return false
+	}
+	return time.Since(e.CheckedAt) >= h.revalidateInterval
+}
+
+// revalidate re-probes the upstream. It returns the entry to serve, or nil
+// when the entry went stale and must be re-ingested. Upstream errors keep
+// serving the cached copy.
+func (h *Handler) revalidate(ctx context.Context, key string, e *fileEntry) *fileEntry {
+	pr, err := h.probe(ctx, key)
+	if err != nil || pr.status < 200 || pr.status >= 300 {
+		return e
+	}
+	if pr.etag == e.ETag {
+		e.CheckedAt = time.Now()
+		_ = persistEntry(h.indexDir, e)
+		return e
+	}
+	h.mu.Lock()
+	if h.entries[key] == e {
+		delete(h.entries, key)
+	}
+	h.mu.Unlock()
+	_ = os.Remove(indexEntryPath(h.indexDir, key))
+	return nil
+}
+
+// serveReady answers a resolve request for a fully cached file: metadata plus
+// xet Link headers for capable clients, and a redirect to the sha256 bridge
+// for everyone else.
+func (h *Handler) serveReady(w http.ResponseWriter, r *http.Request, e *fileEntry) {
+	base := h.externalBase(r)
+	writeMetadataHeaders(w, e.ETag, e.Size, e.Commit)
+	if e.FileHash != "" {
+		w.Header().Add("Link", fmt.Sprintf("<%s%s>; rel=\"xet-auth\", <%s/v1/reconstructions/%s>; rel=\"xet-reconstruction-info\"", base, tokenEndpointPath, base, e.FileHash))
+		w.Header().Set("X-Xet-Hash", e.FileHash)
+	}
+	if e.Size == 0 {
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// The Location must be absolute: hub clients follow relative redirects
+	// before reading metadata, which would strip the xet headers off the
+	// response they end up looking at.
+	http.Redirect(w, r, base+"/xet-bridge/"+e.SHA256, http.StatusFound)
+}
+
+func (h *Handler) serveFailed(w http.ResponseWriter, e *fileEntry) {
+	serveFetchError(w, e.notFound, e.lastErr)
+}
+
+// serveFetchError maps a failed ingest to its HTTP response: 404 when the
+// upstream lacks the file, 502 with the underlying error otherwise.
+func serveFetchError(w http.ResponseWriter, notFound bool, err error) {
+	if notFound {
+		http.Error(w, "File not found upstream", http.StatusNotFound)
+		return
+	}
+	msg := "upstream fetch failed"
+	if err != nil {
+		msg = err.Error()
+	}
+	http.Error(w, msg, http.StatusBadGateway)
+}
+
+// serveFromTask streams a file that is still being ingested. Bytes are served
+// from the growing spool; range requests for regions not yet spooled block
+// until the data lands. It reports false when the ingest finished and the
+// spool was already drained before this request could attach.
+func (h *Handler) serveFromTask(w http.ResponseWriter, r *http.Request, t *task) bool {
+	select {
+	case <-t.probed:
+	case <-r.Context().Done():
+		return true
+	}
+	if t.probeErr != nil {
+		serveFetchError(w, t.notFound, t.probeErr)
+		return true
+	}
+
+	pr := t.probe
+	// The size may only be learned from the ingest download's first response
+	// headers (e.g. modelscope.cn sends none on HEAD); downstream hub clients
+	// refuse metadata without it, so wait rather than answer size-less.
+	select {
+	case <-t.sized:
+	case <-r.Context().Done():
+		return true
+	}
+	size := t.size.Load()
+	if r.Method == http.MethodHead {
+		writeMetadataHeaders(w, pr.etag, size, pr.commit)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		if size >= 0 {
+			w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+		}
+		w.WriteHeader(http.StatusOK)
+		return true
+	}
+
+	if size < 0 {
+		// Total size unknown until the ingest completes (xet upstream whose
+		// probe carried no size): ServeContent cannot handle that, so stream
+		// the whole body as it lands, ignoring Range.
+		rc := t.spool.newReader(r.Context(), 0)
+		if rc == nil {
+			return false
+		}
+		defer func() {
+			_ = rc.Close()
+		}()
+		writeMetadataHeaders(w, pr.etag, size, pr.commit)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = io.Copy(w, rc)
+		return true
+	}
+
+	rs := t.spool.newSeekReader(r.Context(), size)
+	if rs == nil {
+		return false
+	}
+	defer func() {
+		_ = rs.Close()
+	}()
+	writeMetadataHeaders(w, pr.etag, size, pr.commit)
+	w.Header().Set("Content-Type", "application/octet-stream")
+	http.ServeContent(w, r, "", time.Time{}, rs)
+	return true
+}
+
+// writeMetadataHeaders emits the header set downstream tooling relies on,
+// mirroring what the upstream hub advertised.
+func writeMetadataHeaders(w http.ResponseWriter, etag string, size int64, commit string) {
+	if etag != "" {
+		quoted := `"` + etag + `"`
+		w.Header().Set("ETag", quoted)
+		w.Header().Set("X-Linked-Etag", quoted)
+	}
+	if size >= 0 {
+		w.Header().Set("X-Linked-Size", strconv.FormatInt(size, 10))
+	}
+	if commit != "" {
+		w.Header().Set("X-Repo-Commit", commit)
+	}
+	w.Header().Set("Accept-Ranges", "bytes")
+}

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -1,0 +1,823 @@
+package mirror
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wzshiming/xet/client"
+	"github.com/wzshiming/xet/hf"
+	"github.com/wzshiming/xet/server"
+	"github.com/wzshiming/xet/storage"
+	"github.com/wzshiming/xet/token"
+	"github.com/wzshiming/xet/upload"
+)
+
+func TestSpoolTailRead(t *testing.T) {
+	sp, err := openSpool(t.TempDir(), "k", "", -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, 64*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+
+	rc := sp.newReader(context.Background(), 0)
+	got := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(rc)
+		_ = rc.Close()
+		got <- b
+	}()
+
+	// Write in pieces so the reader has to wait repeatedly.
+	for i := 0; i < len(data); i += 8192 {
+		if _, err := sp.Write(data[i : i+8192]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sp.finish(nil)
+
+	if b := <-got; !bytes.Equal(b, data) {
+		t.Fatalf("tail read mismatch: got %d bytes, want %d", len(b), len(data))
+	}
+
+	t.Run("canceled context unblocks reader", func(t *testing.T) {
+		sp, err := openSpool(t.TempDir(), "k", "", -1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer sp.finish(nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		rc := sp.newReader(ctx, 0)
+		defer rc.Close()
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := rc.Read(make([]byte, 1))
+			errCh <- err
+		}()
+		cancel()
+		if err := <-errCh; err != context.Canceled {
+			t.Fatalf("read err = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("no readers after removal", func(t *testing.T) {
+		sp, err := openSpool(t.TempDir(), "k", "", -1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sp.finish(nil) // no refs: the file is removed immediately
+		if rc := sp.newReader(context.Background(), 0); rc != nil {
+			t.Fatal("expected nil reader after removal")
+		}
+		if rs := sp.newSeekReader(context.Background(), 0); rs != nil {
+			t.Fatal("expected nil seek reader after removal")
+		}
+	})
+}
+
+// mirrorFixture wires a mirror handler on an httptest server whose URL is also
+// the storage base URL and external URL.
+type mirrorFixture struct {
+	srv     *httptest.Server
+	handler *Handler
+	stor    storage.Storage
+	issuer  *token.Issuer
+}
+
+func newMirrorFixture(t *testing.T, upstream string, storageDir, cacheDir string, opts ...Option) *mirrorFixture {
+	t.Helper()
+	var inner atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inner.Load().(http.Handler).ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	stor, err := storage.NewFileStorage(
+		storage.WithBasePath(storageDir),
+		storage.WithBaseURL(srv.URL),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	issuer, err := token.NewIssuer(nil, 15*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := NewHandler(append([]Option{
+		WithStorage(stor),
+		WithUpstream(upstream),
+		WithExternalURL(srv.URL),
+		WithCacheDir(cacheDir),
+		WithMintToken(issuer.Mint),
+	}, opts...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same composition as cmd/xetd: the CAS server matches its routes first
+	// and falls through to the mirror; the shared issuer ties minting to
+	// validation.
+	inner.Store(http.Handler(server.NewHandler(
+		server.WithStorage(stor),
+		server.WithAuthFunc(func(tok string) bool { return issuer.Validate(tok, time.Now()) }),
+		server.WithNext(h),
+	)))
+	return &mirrorFixture{srv: srv, handler: h, stor: stor, issuer: issuer}
+}
+
+// noRedirect returns a client that surfaces 3xx responses instead of following.
+func noRedirect() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// waitReady polls a resolve URL until the mirror answers with the ready-state
+// redirect, returning that response.
+func waitReady(t *testing.T, resolveURL string) *http.Response {
+	t.Helper()
+	c := noRedirect()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := c.Get(resolveURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusFound {
+			return resp
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("mirror never reached ready state")
+	return nil
+}
+
+func downloadViaXet(t *testing.T, resolveURL string) []byte {
+	t.Helper()
+	ctx := context.Background()
+	fileHash, provider, err := hf.ResolveDownload(ctx, nil, resolveURL)
+	if err != nil {
+		t.Fatalf("resolve download: %v", err)
+	}
+	c, err := client.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.CreateTemp(t.TempDir(), "dl-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := c.DownloadFileWithAuthProvider(ctx, provider, fileHash, f); err != nil {
+		t.Fatalf("xet download: %v", err)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// plainUpstream is a hub without xet support: resolve requests redirect to a
+// CDN path that serves the raw bytes with Range support.
+type plainUpstream struct {
+	mu       sync.Mutex
+	files    map[string][]byte
+	commit   string
+	dataGETs atomic.Int64
+	seenAuth sync.Map // Authorization values observed on any request
+	gate     chan struct{}
+	gateHit  chan struct{}
+}
+
+func newPlainUpstream() *plainUpstream {
+	return &plainUpstream{files: map[string][]byte{}, commit: "commit-1"}
+}
+
+func (u *plainUpstream) set(path string, data []byte) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.files[path] = data
+}
+
+func (u *plainUpstream) get(path string) ([]byte, bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	data, ok := u.files[path]
+	return data, ok
+}
+
+func (u *plainUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if auth := r.Header.Get("Authorization"); auth != "" {
+		u.seenAuth.Store(auth, true)
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/cdn") {
+		data, ok := u.get(strings.TrimPrefix(r.URL.Path, "/cdn"))
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method == http.MethodGet {
+			u.dataGETs.Add(1)
+		}
+		if u.gate != nil && r.Method == http.MethodGet && r.Header.Get("Range") == "" {
+			// Stream in two halves so tests can observe serve-while-caching.
+			w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+			w.WriteHeader(http.StatusOK)
+			half := len(data) / 2
+			w.(http.Flusher).Flush()
+			if _, err := w.Write(data[:half]); err != nil {
+				return
+			}
+			w.(http.Flusher).Flush()
+			close(u.gateHit)
+			<-u.gate
+			_, _ = w.Write(data[half:])
+			return
+		}
+		http.ServeContent(w, r, "", time.Time{}, bytes.NewReader(data))
+		return
+	}
+
+	data, ok := u.get(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	sum := sha256.Sum256(data)
+	etag := hex.EncodeToString(sum[:])
+	w.Header().Set("ETag", `"`+etag+`"`)
+	w.Header().Set("X-Linked-Etag", `"`+etag+`"`)
+	w.Header().Set("X-Linked-Size", fmt.Sprint(len(data)))
+	w.Header().Set("X-Repo-Commit", u.commit)
+	http.Redirect(w, r, "/cdn"+r.URL.Path, http.StatusFound)
+}
+
+func TestMirrorPlainUpstream(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	data := make([]byte, 256*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	const resolvePath = "/org/repo/resolve/main/model.bin"
+	upstream.set(resolvePath, data)
+
+	storageDir, cacheDir := t.TempDir(), t.TempDir()
+	fx := newMirrorFixture(t, upstreamSrv.URL, storageDir, cacheDir, WithUpstreamToken("up-secret"))
+	resolveURL := fx.srv.URL + resolvePath
+
+	t.Run("serve while caching with singleflight", func(t *testing.T) {
+		const concurrent = 4
+		var wg sync.WaitGroup
+		bodies := make([][]byte, concurrent)
+		errs := make([]error, concurrent)
+		for i := range concurrent {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				req, _ := http.NewRequest(http.MethodGet, resolveURL, nil)
+				req.Header.Set("Authorization", "Bearer downstream-junk")
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					errs[i] = err
+					return
+				}
+				defer resp.Body.Close()
+				bodies[i], errs[i] = io.ReadAll(resp.Body)
+			}(i)
+		}
+		wg.Wait()
+		for i := range concurrent {
+			if errs[i] != nil {
+				t.Fatalf("request %d: %v", i, errs[i])
+			}
+			if !bytes.Equal(bodies[i], data) {
+				t.Fatalf("request %d: body mismatch (%d bytes, want %d)", i, len(bodies[i]), len(data))
+			}
+		}
+		if got := upstream.dataGETs.Load(); got != 1 {
+			t.Fatalf("upstream data GETs = %d, want 1", got)
+		}
+	})
+
+	t.Run("downstream credentials never forwarded upstream", func(t *testing.T) {
+		if _, ok := upstream.seenAuth.Load("Bearer downstream-junk"); ok {
+			t.Fatal("downstream Authorization leaked to upstream")
+		}
+		if _, ok := upstream.seenAuth.Load("Bearer up-secret"); !ok {
+			t.Fatal("mirror did not use its upstream credential")
+		}
+	})
+
+	t.Run("ready state redirects to bridge with xet links", func(t *testing.T) {
+		resp := waitReady(t, resolveURL)
+		sum := sha256.Sum256(data)
+		wantLoc := fx.srv.URL + "/xet-bridge/" + hex.EncodeToString(sum[:])
+		if loc := resp.Header.Get("Location"); loc != wantLoc {
+			t.Fatalf("Location = %q, want %q", loc, wantLoc)
+		}
+		links := strings.Join(resp.Header.Values("Link"), ", ")
+		if !strings.Contains(links, "xet-reconstruction-info") || !strings.Contains(links, "xet-auth") {
+			t.Fatalf("Link headers missing xet rels: %q", links)
+		}
+		if resp.Header.Get("X-Xet-Hash") == "" {
+			t.Fatal("missing X-Xet-Hash header")
+		}
+		if got := resp.Header.Get("X-Linked-Size"); got != fmt.Sprint(len(data)) {
+			t.Fatalf("X-Linked-Size = %q, want %d", got, len(data))
+		}
+
+		// Plain client follows the redirect to the sha256 bridge.
+		followed, err := http.Get(resolveURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer followed.Body.Close()
+		body, err := io.ReadAll(followed.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(body, data) {
+			t.Fatal("bridge body mismatch")
+		}
+		if got := upstream.dataGETs.Load(); got != 1 {
+			t.Fatalf("upstream data GETs after ready = %d, want 1", got)
+		}
+	})
+
+	t.Run("HEAD answered from metadata", func(t *testing.T) {
+		resp, err := noRedirect().Head(resolveURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if got := resp.Header.Get("X-Linked-Size"); got != fmt.Sprint(len(data)) {
+			t.Fatalf("X-Linked-Size = %q, want %d", got, len(data))
+		}
+		if got := resp.Header.Get("X-Repo-Commit"); got != "commit-1" {
+			t.Fatalf("X-Repo-Commit = %q, want commit-1", got)
+		}
+	})
+
+	t.Run("xet downstream downloads through mirror CAS", func(t *testing.T) {
+		got := downloadViaXet(t, resolveURL)
+		if !bytes.Equal(got, data) {
+			t.Fatal("xet downstream body mismatch")
+		}
+		if got := upstream.dataGETs.Load(); got != 1 {
+			t.Fatalf("upstream data GETs = %d, want 1", got)
+		}
+	})
+
+	t.Run("range on ready file via bridge", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, resolveURL, nil)
+		req.Header.Set("Range", "bytes=100-199")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusPartialContent {
+			t.Fatalf("status = %d, want 206", resp.StatusCode)
+		}
+		if !bytes.Equal(body, data[100:200]) {
+			t.Fatal("range body mismatch")
+		}
+	})
+
+	t.Run("ready state survives restart", func(t *testing.T) {
+		before := upstream.dataGETs.Load()
+		fx2 := newMirrorFixture(t, upstreamSrv.URL, storageDir, cacheDir)
+		resp := waitReady(t, fx2.srv.URL+resolvePath)
+		if resp.StatusCode != http.StatusFound {
+			t.Fatalf("status = %d, want 302", resp.StatusCode)
+		}
+		if got := upstream.dataGETs.Load(); got != before {
+			t.Fatalf("restart refetched upstream: %d -> %d", before, got)
+		}
+	})
+}
+
+func TestMirrorRangeWhileIngesting(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstream.gate = make(chan struct{})
+	upstream.gateHit = make(chan struct{})
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	data := make([]byte, 128*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	const resolvePath = "/org/repo/resolve/main/slow.bin"
+	upstream.set(resolvePath, data)
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := fx.srv.URL + resolvePath
+
+	// Open the gate once the upstream has streamed the first half.
+	go func() {
+		<-upstream.gateHit
+		close(upstream.gate)
+	}()
+
+	// Request a region in the second half before it has been spooled; the
+	// mirror must hold the request until the bytes land.
+	start, end := len(data)-4096, len(data)-1
+	req, _ := http.NewRequest(http.MethodGet, resolveURL, nil)
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", resp.StatusCode)
+	}
+	if !bytes.Equal(body, data[start:end+1]) {
+		t.Fatal("range-while-ingesting body mismatch")
+	}
+	if got, want := resp.Header.Get("Content-Range"), fmt.Sprintf("bytes %d-%d/%d", start, end, len(data)); got != want {
+		t.Fatalf("Content-Range = %q, want %q", got, want)
+	}
+}
+
+// xetUpstream is a hub with xet support: resolve responses carry the xet link
+// headers pointing at a real CAS server backed by the upload pipeline.
+type xetUpstream struct {
+	hubURL   string
+	casURL   string
+	stor     storage.Storage
+	mu       sync.Mutex
+	files    map[string]xetUpstreamFile
+	xorbGETs atomic.Int64
+	omitSize bool          // advertise no size on resolve responses
+	gate     chan struct{} // when set, the first xorb GET blocks until closed
+	gateHit  chan struct{}
+	gateOnce sync.Once
+}
+
+type xetUpstreamFile struct {
+	fileHash string
+	sha256   string
+	size     int
+}
+
+func newXetUpstream(t *testing.T) *xetUpstream {
+	t.Helper()
+	u := &xetUpstream{files: map[string]xetUpstreamFile{}}
+
+	var casInner atomic.Value
+	casSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/xorbs/") {
+			u.xorbGETs.Add(1)
+			if u.gate != nil {
+				u.gateOnce.Do(func() { close(u.gateHit) })
+				<-u.gate
+			}
+		}
+		casInner.Load().(http.Handler).ServeHTTP(w, r)
+	}))
+	t.Cleanup(casSrv.Close)
+
+	stor, err := storage.NewFileStorage(
+		storage.WithBasePath(t.TempDir()),
+		storage.WithBaseURL(casSrv.URL),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	casInner.Store(http.Handler(server.NewHandler(server.WithStorage(stor))))
+
+	hubSrv := httptest.NewServer(http.HandlerFunc(u.serveHub))
+	t.Cleanup(hubSrv.Close)
+
+	u.stor = stor
+	u.casURL = casSrv.URL
+	u.hubURL = hubSrv.URL
+	return u
+}
+
+func (u *xetUpstream) add(t *testing.T, path string, data []byte) {
+	t.Helper()
+	fileHash, err := upload.UploadFile(context.Background(),
+		&localCAS{storage: u.stor, namespace: "default"},
+		bytes.NewReader(data),
+		upload.WithEnableSHA256(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(data)
+	u.mu.Lock()
+	u.files[path] = xetUpstreamFile{
+		fileHash: fileHash.String(),
+		sha256:   hex.EncodeToString(sum[:]),
+		size:     len(data),
+	}
+	u.mu.Unlock()
+}
+
+func (u *xetUpstream) serveHub(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/api/xet-read-token" {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"casUrl":      u.casURL,
+			"accessToken": "upstream-cas-token",
+			"exp":         time.Now().Add(time.Hour).Unix(),
+		})
+		return
+	}
+
+	u.mu.Lock()
+	f, ok := u.files[r.URL.Path]
+	u.mu.Unlock()
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("ETag", `"`+f.sha256+`"`)
+	w.Header().Set("X-Linked-Etag", `"`+f.sha256+`"`)
+	if !u.omitSize {
+		w.Header().Set("X-Linked-Size", fmt.Sprint(f.size))
+	}
+	w.Header().Set("X-Repo-Commit", "xet-commit-1")
+	w.Header().Set("X-Xet-Hash", f.fileHash)
+	w.Header().Add("Link", fmt.Sprintf("<%s/v1/reconstructions/%s>; rel=\"xet-reconstruction-info\"", u.casURL, f.fileHash))
+	w.Header().Add("Link", fmt.Sprintf("<%s/api/xet-read-token>; rel=\"xet-auth\"", u.hubURL))
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestMirrorXetUpstream(t *testing.T) {
+	upstream := newXetUpstream(t)
+
+	data := make([]byte, 256*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	const resolvePath = "/org/repo/resolve/main/weights.bin"
+	upstream.add(t, resolvePath, data)
+
+	fx := newMirrorFixture(t, upstream.hubURL, t.TempDir(), t.TempDir())
+	resolveURL := fx.srv.URL + resolvePath
+
+	t.Run("serve while caching from xet upstream", func(t *testing.T) {
+		resp, err := http.Get(resolveURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		if !bytes.Equal(body, data) {
+			t.Fatal("body mismatch")
+		}
+	})
+
+	t.Run("ready serves both plain and xet downstream", func(t *testing.T) {
+		waitReady(t, resolveURL)
+		ingestGETs := upstream.xorbGETs.Load()
+		if ingestGETs == 0 {
+			t.Fatal("expected the mirror to fetch xorbs from the upstream CAS")
+		}
+
+		followed, err := http.Get(resolveURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer followed.Body.Close()
+		body, err := io.ReadAll(followed.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(body, data) {
+			t.Fatal("plain downstream body mismatch")
+		}
+
+		if got := downloadViaXet(t, resolveURL); !bytes.Equal(got, data) {
+			t.Fatal("xet downstream body mismatch")
+		}
+
+		if got := upstream.xorbGETs.Load(); got != ingestGETs {
+			t.Fatalf("upstream CAS hit again after ready: %d -> %d", ingestGETs, got)
+		}
+	})
+}
+
+func TestMirrorXetUpstreamUnknownSize(t *testing.T) {
+	upstream := newXetUpstream(t)
+	upstream.omitSize = true
+	upstream.gate = make(chan struct{})
+	upstream.gateHit = make(chan struct{})
+
+	data := make([]byte, 128*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	const resolvePath = "/org/repo/resolve/main/nosize.bin"
+	upstream.add(t, resolvePath, data)
+
+	fx := newMirrorFixture(t, upstream.hubURL, t.TempDir(), t.TempDir())
+	resolveURL := fx.srv.URL + resolvePath
+
+	// Hold the first xorb fetch until it is observed, so the GET below is
+	// served mid-ingest while the total size is still unknown.
+	go func() {
+		<-upstream.gateHit
+		close(upstream.gate)
+	}()
+
+	resp, err := http.Get(resolveURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !bytes.Equal(body, data) {
+		t.Fatalf("body mismatch: got %d bytes, want %d", len(body), len(data))
+	}
+	waitReady(t, resolveURL)
+}
+
+func TestMirrorUpstreamNotFound(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := fx.srv.URL + "/org/repo/resolve/main/missing.bin"
+
+	for i := range 2 {
+		resp, err := http.Get(resolveURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("request %d: status = %d, want 404", i, resp.StatusCode)
+		}
+	}
+}
+
+func TestMirrorRevalidateStale(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	v1 := []byte(strings.Repeat("version-one ", 4096))
+	const resolvePath = "/org/repo/resolve/main/data.txt"
+	upstream.set(resolvePath, v1)
+
+	// Revalidate on every request.
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir(), WithRevalidateInterval(0))
+	resolveURL := fx.srv.URL + resolvePath
+
+	resp, err := http.Get(resolveURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !bytes.Equal(body, v1) {
+		t.Fatal("initial body mismatch")
+	}
+	waitReady(t, resolveURL)
+
+	// Same etag: revalidation keeps serving the cached copy.
+	resp = waitReady(t, resolveURL)
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+
+	// Change the content: the next request goes stale and re-ingests.
+	v2 := []byte(strings.Repeat("version-two!", 4096))
+	upstream.set(resolvePath, v2)
+	upstream.commit = "commit-2"
+
+	resp, err = http.Get(resolveURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !bytes.Equal(body, v2) {
+		t.Fatalf("stale body not refreshed: got %d bytes, want %d", len(body), len(v2))
+	}
+	waitReady(t, resolveURL)
+}
+
+func TestMirrorControlPlaneProxy(t *testing.T) {
+	var upstreamSawAuth atomic.Value
+	upstreamSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/models/org/repo" {
+			upstreamSawAuth.Store(r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"org/repo"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer upstreamSrv.Close()
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir(), WithUpstreamToken("up-secret"))
+
+	req, _ := http.NewRequest(http.MethodGet, fx.srv.URL+"/api/models/org/repo", nil)
+	req.Header.Set("Authorization", "Bearer downstream-junk")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "org/repo") {
+		t.Fatalf("unexpected proxy body: %q", body)
+	}
+	if got := upstreamSawAuth.Load(); got != "Bearer up-secret" {
+		t.Fatalf("upstream saw Authorization %q, want injected mirror credential", got)
+	}
+}
+
+func TestMirrorTokenEndpoint(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+
+	resp, err := http.Get(fx.srv.URL + "/xet-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var tok struct {
+		CASURL string `json:"casUrl"`
+		Token  string `json:"accessToken"`
+		Exp    int64  `json:"exp"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+		t.Fatal(err)
+	}
+	if tok.CASURL != fx.srv.URL {
+		t.Fatalf("casUrl = %q, want %q", tok.CASURL, fx.srv.URL)
+	}
+	if tok.Exp <= time.Now().Unix() {
+		t.Fatalf("exp = %d, want in the future", tok.Exp)
+	}
+	if !fx.issuer.Validate(tok.Token, time.Now()) {
+		t.Fatal("minted token does not validate")
+	}
+}

--- a/mirror/resume_test.go
+++ b/mirror/resume_test.go
@@ -1,0 +1,542 @@
+package mirror
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The spool file name must embed the content identity (etag + size), so a
+// reopen with the same validators resumes from the file length and different
+// validators land in a different, swept-clean file.
+func TestSpoolNamedByValidatorsResume(t *testing.T) {
+	dir := t.TempDir()
+	const key = "/org/repo/resolve/main/a.bin"
+	etag := strings.Repeat("ab", 32) // hex sha256-style etag
+
+	sp, err := openSpool(dir, key, etag, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sp.Write(make([]byte, 40)); err != nil {
+		t.Fatal(err)
+	}
+	name := filepath.Base(sp.f.Name())
+	if want := spoolKeyPrefix(key) + etag + "-100.spool"; name != want {
+		t.Fatalf("spool name = %q, want %q", name, want)
+	}
+	sp.finish(fmt.Errorf("interrupted"))
+
+	// Same validators: resume from the partial length.
+	sp2, err := openSpool(dir, key, etag, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sp2.size(); got != 40 {
+		t.Fatalf("resumed size = %d, want 40", got)
+	}
+	sp2.finish(fmt.Errorf("interrupted again"))
+
+	// Changed etag: new file from zero, stale sibling swept.
+	etag2 := strings.Repeat("cd", 32)
+	sp3, err := openSpool(dir, key, etag2, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sp3.size(); got != 0 {
+		t.Fatalf("size after etag change = %d, want 0", got)
+	}
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var spools []string
+	for _, e := range ents {
+		if strings.HasSuffix(e.Name(), ".spool") {
+			spools = append(spools, e.Name())
+		}
+	}
+	if len(spools) != 1 || spools[0] != spoolKeyPrefix(key)+etag2+"-100.spool" {
+		t.Fatalf("stale spool not swept: %v", spools)
+	}
+	sp3.finish(nil)
+
+	// No etag: nothing trustworthy in the name, always start fresh.
+	sp4, err := openSpool(dir, key, "", -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sp4.Write(make([]byte, 8)); err != nil {
+		t.Fatal(err)
+	}
+	sp4.finish(fmt.Errorf("interrupted"))
+	sp5, err := openSpool(dir, key, "", -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sp5.size(); got != 0 {
+		t.Fatalf("etag-less spool resumed (%d bytes), want truncation", got)
+	}
+	sp5.finish(nil)
+}
+
+// Reproduction for: a client disconnects mid-download, then a new client
+// arrives. The new client must immediately receive the already-spooled bytes
+// (the ingest keeps running in the background) instead of starting from a
+// fresh, empty download.
+func TestMirrorClientDisconnectThenNewClient(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstream.gate = make(chan struct{})
+	upstream.gateHit = make(chan struct{})
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	data := make([]byte, 128*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	const resolvePath = "/org/repo/resolve/main/interrupted.bin"
+	upstream.set(resolvePath, data)
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := fx.srv.URL + resolvePath
+	half := len(data) / 2
+
+	// Client 1: start the download, read the first half, then disconnect.
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	req1, _ := http.NewRequestWithContext(ctx1, http.MethodGet, resolveURL, nil)
+	resp1, err := http.DefaultClient.Do(req1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf1 := make([]byte, half)
+	if _, err := io.ReadFull(resp1.Body, buf1); err != nil {
+		t.Fatalf("client1 read first half: %v", err)
+	}
+	if !bytes.Equal(buf1, data[:half]) {
+		t.Fatal("client1 first-half mismatch")
+	}
+	cancel1() // simulate the client aborting mid-download
+	resp1.Body.Close()
+
+	// The upstream is now stalled at the half-way gate; the ingest is still
+	// running in the background holding the first half in the spool.
+	<-upstream.gateHit
+
+	// Client 2: a fresh request. The first half must arrive promptly from the
+	// spool even though the upstream is still stalled.
+	req2, _ := http.NewRequest(http.MethodGet, resolveURL, nil)
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+
+	buf2 := make([]byte, half)
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := io.ReadFull(resp2.Body, buf2)
+		readDone <- err
+	}()
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("client2 read spooled half: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("client2 did not receive the already-spooled bytes while upstream stalled: progress restarted from scratch")
+	}
+	if !bytes.Equal(buf2, data[:half]) {
+		t.Fatal("client2 first-half mismatch")
+	}
+
+	// Unstall the upstream; client 2 must receive the rest.
+	close(upstream.gate)
+	rest, err := io.ReadAll(resp2.Body)
+	if err != nil {
+		t.Fatalf("client2 read rest: %v", err)
+	}
+	if !bytes.Equal(rest, data[half:]) {
+		t.Fatal("client2 second-half mismatch")
+	}
+	waitReady(t, resolveURL)
+	if got := upstream.dataGETs.Load(); got != 1 {
+		t.Fatalf("upstream data GETs = %d, want 1 (no restart)", got)
+	}
+}
+
+// Reproduction for the resume-with-Range variant (huggingface_hub style):
+// client 2 resumes with a Range request for the not-yet-complete region.
+func TestMirrorClientDisconnectThenRangeResume(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstream.gate = make(chan struct{})
+	upstream.gateHit = make(chan struct{})
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	data := make([]byte, 128*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	const resolvePath = "/org/repo/resolve/main/interrupted2.bin"
+	upstream.set(resolvePath, data)
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := fx.srv.URL + resolvePath
+	quarter := len(data) / 4
+
+	// Client 1 reads a quarter and disconnects.
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	req1, _ := http.NewRequestWithContext(ctx1, http.MethodGet, resolveURL, nil)
+	resp1, err := http.DefaultClient.Do(req1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(resp1.Body, make([]byte, quarter)); err != nil {
+		t.Fatalf("client1 read: %v", err)
+	}
+	cancel1()
+	resp1.Body.Close()
+
+	<-upstream.gateHit // ingest stalled at half
+
+	// Client 2 resumes from its quarter with a Range request; the region up to
+	// the spooled half must arrive promptly.
+	req2, _ := http.NewRequest(http.MethodGet, resolveURL, nil)
+	req2.Header.Set("Range", fmt.Sprintf("bytes=%d-", quarter))
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusPartialContent {
+		t.Fatalf("resume status = %d, want 206", resp2.StatusCode)
+	}
+
+	upToHalf := make([]byte, len(data)/2-quarter)
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := io.ReadFull(resp2.Body, upToHalf)
+		readDone <- err
+	}()
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("client2 read spooled region: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("client2 Range resume did not receive already-spooled bytes")
+	}
+	if !bytes.Equal(upToHalf, data[quarter:len(data)/2]) {
+		t.Fatal("client2 resumed region mismatch")
+	}
+
+	close(upstream.gate)
+	rest, err := io.ReadAll(resp2.Body)
+	if err != nil {
+		t.Fatalf("client2 read rest: %v", err)
+	}
+	if !bytes.Equal(rest, data[len(data)/2:]) {
+		t.Fatal("client2 tail mismatch")
+	}
+}
+
+// flakyUpstream serves one partial body (sendMax bytes, then a dropped
+// connection) and answers every following data request with 500 while
+// failLeft > 0, so the whole ingest task fails with partial progress. It
+// records the Range offsets of incoming data requests.
+type flakyUpstream struct {
+	mu          sync.Mutex
+	data        []byte
+	commit      string
+	etag        string
+	failLeft    int   // remaining forced failures
+	sendMax     int   // bytes to send on the first failing request
+	partialSent bool  // the one partial body has been served
+	offsets     []int // Range start of each data GET
+}
+
+func (u *flakyUpstream) heal() {
+	u.mu.Lock()
+	u.failLeft = 0
+	u.mu.Unlock()
+}
+
+func (u *flakyUpstream) rangeOffsets() []int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]int(nil), u.offsets...)
+}
+
+func (u *flakyUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/cdn") {
+		u.mu.Lock()
+		data := u.data
+		offset := 0
+		if rg := r.Header.Get("Range"); strings.HasPrefix(rg, "bytes=") {
+			fmt.Sscanf(rg, "bytes=%d-", &offset)
+		}
+		mode := "serve"
+		if r.Method == http.MethodGet {
+			u.offsets = append(u.offsets, offset)
+			if u.failLeft > 0 {
+				u.failLeft--
+				if u.partialSent {
+					mode = "error"
+				} else {
+					u.partialSent = true
+					mode = "partial"
+				}
+			}
+		}
+		sendMax := u.sendMax
+		u.mu.Unlock()
+
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+			return
+		}
+		if mode == "error" {
+			http.Error(w, "upstream flake", http.StatusInternalServerError)
+			return
+		}
+		if offset > 0 {
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", offset, len(data)-1, len(data)))
+			w.Header().Set("Content-Length", fmt.Sprint(len(data)-offset))
+			w.WriteHeader(http.StatusPartialContent)
+		} else {
+			w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+			w.WriteHeader(http.StatusOK)
+		}
+		body := data[offset:]
+		if mode == "partial" && len(body) > sendMax {
+			_, _ = w.Write(body[:sendMax])
+			w.(http.Flusher).Flush()
+			// Drop the connection mid-body.
+			if hj, ok := w.(http.Hijacker); ok {
+				if conn, _, err := hj.Hijack(); err == nil {
+					conn.Close()
+					return
+				}
+			}
+			panic(http.ErrAbortHandler)
+		}
+		_, _ = w.Write(body)
+		return
+	}
+
+	u.mu.Lock()
+	etag, commit, size := u.etag, u.commit, len(u.data)
+	u.mu.Unlock()
+	w.Header().Set("ETag", `"`+etag+`"`)
+	w.Header().Set("X-Linked-Etag", `"`+etag+`"`)
+	w.Header().Set("X-Linked-Size", fmt.Sprint(size))
+	w.Header().Set("X-Repo-Commit", commit)
+	http.Redirect(w, r, "/cdn"+r.URL.Path, http.StatusFound)
+}
+
+// clearBackoff lets the next request start a fresh task immediately.
+func clearBackoff(h *Handler, key string) {
+	h.mu.Lock()
+	if e := h.entries[key]; e != nil && e.State == stateFailed {
+		e.nextRetry = time.Time{}
+	}
+	h.mu.Unlock()
+}
+
+// A task that dies mid-download must leave its partial spool behind, and the
+// next task must resume from that offset instead of refetching from zero.
+func TestMirrorResumeAfterTaskFailure(t *testing.T) {
+	data := make([]byte, 96*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	up := &flakyUpstream{data: data, commit: "commit-1", etag: "etag-1", failLeft: 1000, sendMax: 32 * 1024}
+	upstreamSrv := httptest.NewServer(up)
+	defer upstreamSrv.Close()
+
+	const resolvePath = "/org/repo/resolve/main/flaky.bin"
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := fx.srv.URL + resolvePath
+
+	// First request: the upstream serves one partial body then fails hard, so
+	// the task fails with partial progress, and each retry must have resumed
+	// from the previous offset.
+	resp, err := http.Get(resolveURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	waitFailed(t, fx.handler, resolvePath)
+	offsets := up.rangeOffsets()
+	if len(offsets) < 2 {
+		t.Fatalf("expected multiple fetch attempts, got offsets %v", offsets)
+	}
+	for _, off := range offsets[1:] {
+		if off == 0 {
+			t.Fatalf("a retry restarted from 0 instead of resuming: offsets %v", offsets)
+		}
+	}
+
+	// Second request (upstream healed, backoff cleared): the new task must
+	// resume from the partial spool, not from zero.
+	up.heal()
+	clearBackoff(fx.handler, resolvePath)
+	before := len(offsets)
+	resp, err = http.Get(resolveURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(body, data) {
+		t.Fatalf("body mismatch after resume: got %d bytes, want %d", len(body), len(data))
+	}
+	offsets = up.rangeOffsets()
+	if len(offsets) <= before {
+		t.Fatal("second task issued no upstream fetch")
+	}
+	if first := offsets[before]; first == 0 {
+		t.Fatalf("second task restarted from 0 instead of resuming: offsets %v", offsets)
+	}
+	waitReady(t, resolveURL)
+}
+
+// A restart of the mirror process must also resume from the partial spool.
+func TestMirrorResumeAcrossRestart(t *testing.T) {
+	data := make([]byte, 96*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	up := &flakyUpstream{data: data, commit: "commit-1", etag: "etag-1", failLeft: 1000, sendMax: 24 * 1024}
+	upstreamSrv := httptest.NewServer(up)
+	defer upstreamSrv.Close()
+
+	const resolvePath = "/org/repo/resolve/main/restart.bin"
+	storageDir, cacheDir := t.TempDir(), t.TempDir()
+	fx := newMirrorFixture(t, upstreamSrv.URL, storageDir, cacheDir)
+
+	resp, err := http.Get(fx.srv.URL + resolvePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	waitFailed(t, fx.handler, resolvePath)
+	up.heal()
+	before := len(up.rangeOffsets())
+
+	// "Restart": a fresh handler over the same cache dir.
+	fx2 := newMirrorFixture(t, upstreamSrv.URL, storageDir, cacheDir)
+	resp, err = http.Get(fx2.srv.URL + resolvePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(body, data) {
+		t.Fatalf("body mismatch after restart: got %d bytes, want %d", len(body), len(data))
+	}
+	offsets := up.rangeOffsets()
+	if len(offsets) <= before {
+		t.Fatal("restarted mirror issued no upstream fetch")
+	}
+	if first := offsets[before]; first == 0 {
+		t.Fatalf("restarted mirror refetched from 0 instead of resuming: offsets %v", offsets)
+	}
+	waitReady(t, fx2.srv.URL+resolvePath)
+}
+
+// A changed upstream etag must invalidate the partial spool instead of
+// resuming into mismatched content.
+func TestMirrorStalePartialDiscarded(t *testing.T) {
+	data := make([]byte, 64*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	up := &flakyUpstream{data: data, commit: "commit-1", etag: "etag-1", failLeft: 1000, sendMax: 16 * 1024}
+	upstreamSrv := httptest.NewServer(up)
+	defer upstreamSrv.Close()
+
+	const resolvePath = "/org/repo/resolve/main/stale.bin"
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := fx.srv.URL + resolvePath
+
+	resp, err := http.Get(resolveURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	waitFailed(t, fx.handler, resolvePath)
+	before := len(up.rangeOffsets())
+
+	// Upstream content changed: new etag, new bytes.
+	data2 := make([]byte, 64*1024)
+	if _, err := rand.Read(data2); err != nil {
+		t.Fatal(err)
+	}
+	up.mu.Lock()
+	up.data = data2
+	up.etag = "etag-2"
+	up.commit = "commit-2"
+	up.failLeft = 0
+	up.mu.Unlock()
+
+	clearBackoff(fx.handler, resolvePath)
+	resp, err = http.Get(resolveURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(body, data2) {
+		t.Fatal("body mismatch after etag change")
+	}
+	offsets := up.rangeOffsets()
+	if len(offsets) <= before {
+		t.Fatal("no upstream fetch after etag change")
+	}
+	if first := offsets[before]; first != 0 {
+		t.Fatalf("stale partial was resumed (offset %d) instead of discarded", first)
+	}
+	waitReady(t, resolveURL)
+}
+
+// waitFailed polls until the entry for key is in the failed state.
+func waitFailed(t *testing.T, h *Handler, key string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mu.Lock()
+		e := h.entries[key]
+		_, running := h.tasks[key]
+		h.mu.Unlock()
+		if !running && e != nil && e.State == stateFailed {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("task never reached failed state")
+}

--- a/mirror/spool.go
+++ b/mirror/spool.go
@@ -1,0 +1,343 @@
+package mirror
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// spool is an append-only file that is written by exactly one ingest download
+// and concurrently tail-read by any number of HTTP responses. Readers block
+// at the current end until more bytes land or the writer finishes.
+//
+// The file name is <keyhash>-<etag>-<size>.spool, so the content identity is
+// part of the path itself: a later task that probes the same etag and size
+// computes the same name and resumes from the existing length, surviving task
+// failures and process restarts with no sidecar state. A changed etag or size
+// yields a different name, and stale siblings of the key are swept on open.
+// The file is only unlinked after a successful ingest, or via markRemove when
+// the bytes are known to be unusable.
+type spool struct {
+	f *os.File
+
+	mu        sync.Mutex
+	cond      *sync.Cond
+	written   int64
+	done      bool
+	err       error
+	refs      int
+	retired   bool // file handle closed, no new readers
+	removable bool // unlink the file when retiring
+}
+
+// hexTokenRe matches etags that are safe and meaningful to embed verbatim,
+// notably the sha256 etags hubs advertise for LFS files.
+var hexTokenRe = regexp.MustCompile(`^[0-9a-fA-F]{1,64}$`)
+
+func spoolKeyPrefix(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:16]) + "-"
+}
+
+func spoolETagToken(etag string) string {
+	if etag == "" {
+		return "noetag"
+	}
+	if hexTokenRe.MatchString(etag) {
+		return strings.ToLower(etag)
+	}
+	sum := sha256.Sum256([]byte(etag))
+	return hex.EncodeToString(sum[:16])
+}
+
+// spoolFileName builds the deterministic spool name for a resolve key and the
+// upstream validators known at probe time; size < 0 (unknown) becomes "u".
+func spoolFileName(key, etag string, size int64) string {
+	sizeTok := "u"
+	if size >= 0 {
+		sizeTok = strconv.FormatInt(size, 10)
+	}
+	return spoolKeyPrefix(key) + spoolETagToken(etag) + "-" + sizeTok + ".spool"
+}
+
+// sweepStaleSpools removes other spool files of the same key (older etag or
+// size), which can no longer be resumed.
+func sweepStaleSpools(dir, key, keep string) {
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	prefix := spoolKeyPrefix(key)
+	for _, ent := range ents {
+		n := ent.Name()
+		if n != keep && strings.HasPrefix(n, prefix) && strings.HasSuffix(n, ".spool") {
+			_ = os.Remove(filepath.Join(dir, n))
+		}
+	}
+}
+
+// openSpool opens (or creates) the spool for key and the probed validators,
+// resuming existing partial bytes: the name already proves the etag and size
+// match. Without an etag there is no trustworthy identity, so the file is
+// truncated and starts fresh.
+func openSpool(dir, key, etag string, expectedSize int64) (*spool, error) {
+	name := spoolFileName(key, etag, expectedSize)
+	sweepStaleSpools(dir, key, name)
+
+	f, err := os.OpenFile(filepath.Join(dir, name), os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open spool file: %w", err)
+	}
+	st, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("stat spool file: %w", err)
+	}
+	size := st.Size()
+
+	resume := etag != "" && (expectedSize < 0 || size <= expectedSize)
+	if !resume && size > 0 {
+		if err := f.Truncate(0); err != nil {
+			_ = f.Close()
+			return nil, fmt.Errorf("truncate stale spool: %w", err)
+		}
+		size = 0
+	}
+	if _, err := f.Seek(size, io.SeekStart); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("seek spool file: %w", err)
+	}
+
+	s := &spool{f: f, written: size}
+	s.cond = sync.NewCond(&s.mu)
+	return s, nil
+}
+
+// Write appends p and wakes waiting readers. Only the ingest goroutine calls it.
+func (s *spool) Write(p []byte) (int, error) {
+	n, err := s.f.Write(p)
+	if n > 0 {
+		s.mu.Lock()
+		s.written += int64(n)
+		s.cond.Broadcast()
+		s.mu.Unlock()
+	}
+	return n, err
+}
+
+// Seek supports the io.WriteSeeker contract needed by client.DownloadFile,
+// which seeks to the end for resume support before writing sequentially.
+func (s *spool) Seek(offset int64, whence int) (int64, error) {
+	pos, err := s.f.Seek(offset, whence)
+	if err != nil {
+		return pos, err
+	}
+	s.mu.Lock()
+	s.written = pos
+	s.mu.Unlock()
+	return pos, nil
+}
+
+// finish marks the spool complete (err == nil) or broken, and wakes readers.
+// The backing file is kept either way so a later task can resume partial
+// bytes or re-ingest completed ones; only markRemove schedules the unlink.
+func (s *spool) finish(err error) {
+	s.mu.Lock()
+	if !s.done {
+		s.done = true
+		s.err = err
+		s.cond.Broadcast()
+	}
+	retire := s.refs <= 0 && !s.retired
+	if retire {
+		s.retired = true
+	}
+	remove := retire && s.removable
+	s.mu.Unlock()
+	if retire {
+		s.close(remove)
+	}
+}
+
+// markRemove schedules the backing file for unlink once the spool retires
+// (after the ingest published the entry, or when the bytes are unusable).
+func (s *spool) markRemove() {
+	s.mu.Lock()
+	s.removable = true
+	retired := s.retired
+	s.mu.Unlock()
+	if retired {
+		s.unlink()
+	}
+}
+
+func (s *spool) close(remove bool) {
+	_ = s.f.Close()
+	if remove {
+		s.unlink()
+	}
+}
+
+func (s *spool) unlink() {
+	_ = os.Remove(s.f.Name())
+}
+
+// size returns the bytes written so far.
+func (s *spool) size() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.written
+}
+
+// waitFor blocks until at least one byte past offset is available, the writer
+// finished, or ctx is canceled. It returns the currently available length.
+func (s *spool) waitFor(ctx context.Context, offset int64) (int64, bool, error) {
+	stop := context.AfterFunc(ctx, func() {
+		s.mu.Lock()
+		s.cond.Broadcast()
+		s.mu.Unlock()
+	})
+	defer stop()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for s.written <= offset && !s.done {
+		if ctx.Err() != nil {
+			return s.written, s.done, ctx.Err()
+		}
+		s.cond.Wait()
+	}
+	if s.done && s.err != nil {
+		return s.written, true, s.err
+	}
+	return s.written, s.done, nil
+}
+
+// acquire registers a reader reference. It reports false when the spool has
+// already been retired.
+func (s *spool) acquire() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.retired {
+		return false
+	}
+	s.refs++
+	return true
+}
+
+// release drops a reader reference, retiring the spool when the ingest is
+// done and no readers remain.
+func (s *spool) release() {
+	s.mu.Lock()
+	s.refs--
+	retire := s.refs <= 0 && s.done && !s.retired
+	if retire {
+		s.retired = true
+	}
+	remove := retire && s.removable
+	s.mu.Unlock()
+	if retire {
+		s.close(remove)
+	}
+}
+
+// readAt reads from the backing file without waiting.
+func (s *spool) readAt(p []byte, off int64) (int, error) {
+	return s.f.ReadAt(p, off)
+}
+
+// newReader returns a tail-following reader from offset until the writer
+// completes, or nil when the spool has already been retired. The request ctx
+// only interrupts waits, never the ingest itself.
+func (s *spool) newReader(ctx context.Context, offset int64) io.ReadCloser {
+	if !s.acquire() {
+		return nil
+	}
+	return &spoolReader{ctx: ctx, s: s, pos: offset, size: -1}
+}
+
+// newSeekReader returns a blocking ReadSeekCloser over the final size of the
+// file, suitable for http.ServeContent range handling while bytes still land.
+// It returns nil when the spool has already been retired.
+func (s *spool) newSeekReader(ctx context.Context, size int64) io.ReadSeekCloser {
+	if !s.acquire() {
+		return nil
+	}
+	return &spoolReader{ctx: ctx, s: s, size: size}
+}
+
+// spoolReader tail-reads the spool. size bounds reads and SeekEnd when the
+// final length is known; -1 means unknown, and EOF then comes from the writer
+// finishing.
+type spoolReader struct {
+	ctx    context.Context
+	s      *spool
+	pos    int64
+	size   int64
+	closed bool
+}
+
+func (r *spoolReader) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		r.pos = offset
+	case io.SeekCurrent:
+		r.pos += offset
+	case io.SeekEnd:
+		r.pos = r.size + offset
+	default:
+		return 0, fmt.Errorf("invalid whence %d", whence)
+	}
+	if r.pos < 0 {
+		return 0, fmt.Errorf("negative position")
+	}
+	return r.pos, nil
+}
+
+func (r *spoolReader) Read(p []byte) (int, error) {
+	if r.size >= 0 && r.pos >= r.size {
+		return 0, io.EOF
+	}
+	avail, done, err := r.s.waitFor(r.ctx, r.pos)
+	if err != nil {
+		return 0, err
+	}
+	if avail <= r.pos {
+		if r.size < 0 && done {
+			return 0, io.EOF
+		}
+		return 0, io.ErrUnexpectedEOF
+	}
+	limit := int64(len(p))
+	if r.size >= 0 {
+		if rest := r.size - r.pos; rest < limit {
+			limit = rest
+		}
+	}
+	if rest := avail - r.pos; rest < limit {
+		limit = rest
+	}
+	n, err := r.s.readAt(p[:limit], r.pos)
+	r.pos += int64(n)
+	if err == io.EOF && n > 0 {
+		err = nil
+	}
+	return n, err
+}
+
+func (r *spoolReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	r.s.release()
+	return nil
+}

--- a/mirror/upstream.go
+++ b/mirror/upstream.go
@@ -1,0 +1,143 @@
+package mirror
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/wzshiming/xet/hf"
+)
+
+// authInjector adds the mirror's upstream credential to requests that target
+// the upstream hub host, and never anywhere else, so the token cannot leak to
+// CDN or CAS hosts reached through redirects.
+type authInjector struct {
+	inner http.RoundTripper
+	host  string
+	token string
+}
+
+func (t *authInjector) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.token != "" && req.URL.Host == t.host && req.Header.Get("Authorization") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	return t.inner.RoundTrip(req)
+}
+
+// probeResult captures upstream metadata for one resolve path. Everything is
+// taken from response headers only, so no platform-specific adapters exist.
+type probeResult struct {
+	status int
+	size   int64 // -1 when unknown
+	etag   string
+	sha256 string // set when the upstream etag looks like a SHA-256
+	commit string
+	xet    bool // upstream advertised xet link headers on the resolve response
+}
+
+var hexSHA256Re = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// probe issues HEAD requests for the resolve key, following redirects
+// manually so that metadata headers from the hub hop are retained while later
+// hops can still supply the content length. Upstreams whose HEAD responses
+// carry no size at all (e.g. modelscope.cn) leave size at -1; the ingest
+// download learns it from its first response headers and resolve replies wait
+// for that (task.sized).
+func (h *Handler) probe(ctx context.Context, key string) (*probeResult, error) {
+	res := &probeResult{size: -1}
+
+	cur := h.upstreamURL(key)
+	for hop := 0; hop < 8; hop++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodHead, cur, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create probe request: %w", err)
+		}
+		// Disable transparent gzip so sizes describe the raw bytes.
+		req.Header.Set("Accept-Encoding", "identity")
+
+		resp, err := h.probeClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("probe %s: %w", cur, err)
+		}
+		_ = resp.Body.Close()
+
+		res.collect(resp.Header)
+
+		if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+			loc := resp.Header.Get("Location")
+			if loc == "" {
+				res.status = resp.StatusCode
+				return res, nil
+			}
+			u, err := req.URL.Parse(loc)
+			if err != nil {
+				return nil, fmt.Errorf("parse redirect location %q: %w", loc, err)
+			}
+			cur = u.String()
+			continue
+		}
+
+		res.status = resp.StatusCode
+		if res.size < 0 && resp.ContentLength >= 0 {
+			res.size = resp.ContentLength
+		}
+		break
+	}
+
+	if hexSHA256Re.MatchString(res.etag) {
+		res.sha256 = res.etag
+	}
+	if res.commit == "" {
+		// Hub clients (huggingface_hub) refuse to download when the resolve
+		// response has no X-Repo-Commit; synthesize one for upstreams (e.g.
+		// modelscope.cn) that omit it: the revision itself when it already is
+		// a commit hash, otherwise a stable hash of repo identity + revision.
+		if m := resolveRe.FindStringSubmatch(key); m != nil {
+			if commitRevRe.MatchString(m[2]) {
+				res.commit = m[2]
+			} else {
+				sum := sha256.Sum256([]byte("xet-mirror-pseudo-commit\x00" + m[1] + "\x00" + m[2]))
+				res.commit = hex.EncodeToString(sum[:20])
+			}
+		}
+	}
+	return res, nil
+}
+
+// collect fills empty fields from a response hop; earlier hops win.
+func (p *probeResult) collect(header http.Header) {
+	if p.etag == "" {
+		e := header.Get("X-Linked-Etag")
+		if e == "" {
+			e = header.Get("ETag")
+		}
+		p.etag = trimETag(e)
+	}
+	if p.size < 0 {
+		if v := header.Get("X-Linked-Size"); v != "" {
+			if n, err := strconv.ParseInt(v, 10, 64); err == nil && n >= 0 {
+				p.size = n
+			}
+		}
+	}
+	if p.commit == "" {
+		p.commit = header.Get("X-Repo-Commit")
+	}
+	if !p.xet {
+		links := hf.ParseLinkHeaders(header.Values("Link"))
+		if links["xet-reconstruction-info"] != "" && links["xet-auth"] != "" {
+			p.xet = true
+		}
+	}
+}
+
+func trimETag(etag string) string {
+	etag = strings.TrimPrefix(strings.TrimSpace(etag), "W/")
+	return strings.Trim(etag, `"`)
+}

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -19,3 +19,16 @@ go test ./...
 
 Set `XET_CORE_REFERENCE_BIN` to an already-built reference executable to skip
 the automatic Cargo build.
+
+## Mirror compatibility tests
+
+`mirror/` tests the mirror against real public hubs with the official `hf`
+CLI as the downstream client: huggingface.co (xet upstream, openai/gpt-oss-20b)
+and modelscope.cn (plain HTTP upstream, openai-mirror/gpt-oss-20b). They skip
+unless the `hf` CLI is on PATH and the upstream is reachable; huggingface.co
+may need an HTTPS proxy:
+
+```sh
+https_proxy=http://127.0.0.1:1087 go test ./mirror/
+```
+

--- a/test/conformance/go.mod
+++ b/test/conformance/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/wzshiming/httpseek v0.6.1 // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/test/conformance/go.sum
+++ b/test/conformance/go.sum
@@ -1,5 +1,9 @@
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
+github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
+github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
@@ -14,5 +18,7 @@ github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
 github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
 github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
 github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/test/conformance/mirror/mirror_compat_test.go
+++ b/test/conformance/mirror/mirror_compat_test.go
@@ -1,0 +1,315 @@
+// Package mirror_test exercises the mirror as a middle layer between real
+// public hubs and the official `hf` CLI acting as the downstream client:
+//
+//   - xet-capable upstream:  https://huggingface.co  (openai/gpt-oss-20b)
+//   - plain HTTP upstream:   https://modelscope.cn   (openai-mirror/gpt-oss-20b)
+//
+// Prerequisites, each skipping the tests when missing:
+//   - the `hf` CLI on PATH (pip install -U "huggingface_hub[cli,hf_xet]")
+//   - network reachability of the upstream; huggingface.co may need an HTTPS
+//     proxy, e.g.: https_proxy=http://127.0.0.1:1087 go test ./mirror/...
+package mirror_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wzshiming/xet/mirror"
+	"github.com/wzshiming/xet/server"
+	"github.com/wzshiming/xet/storage"
+	"github.com/wzshiming/xet/token"
+)
+
+// testFile is an LFS-backed file (~27 MiB) present in both test repos.
+const testFile = "tokenizer.json"
+
+func TestHuggingFaceXetUpstream(t *testing.T) {
+	runMirrorCompat(t, "https://huggingface.co", "openai/gpt-oss-20b")
+}
+
+func TestModelScopePlainUpstream(t *testing.T) {
+	runMirrorCompat(t, "https://modelscope.cn", "openai-mirror/gpt-oss-20b")
+}
+
+// runMirrorCompat starts a mirror in front of upstream and downloads testFile
+// through it with the hf CLI in three states: cold (streamed while the mirror
+// ingests), warm via the xet protocol, and warm via the plain sha256 bridge.
+// It then restarts the mirror on the persisted cache with an unreachable
+// upstream and revalidation due on every request: a hub outage must not
+// break a warm mirror.
+func runMirrorCompat(t *testing.T, upstream, repo string) {
+	if testing.Short() {
+		t.Skip("network test; skipped in -short mode")
+	}
+	hfBin, err := exec.LookPath("hf")
+	if err != nil {
+		t.Skip(`hf CLI not found on PATH; install with: pip install -U "huggingface_hub[cli,hf_xet]"`)
+	}
+
+	resolvePath := "/" + repo + "/resolve/main/" + testFile
+	wantSHA256 := probeUpstreamSHA256(t, upstream+resolvePath)
+
+	storageDir, cacheDir := t.TempDir(), t.TempDir()
+	mirrorURL := startMirror(t, upstream, storageDir, cacheDir)
+	resolveURL := mirrorURL + resolvePath
+
+	t.Run("hf cli cold", func(t *testing.T) {
+		verifyDownload(t, hfBin, mirrorURL, repo, wantSHA256, false)
+	})
+
+	resp := waitReady(t, resolveURL)
+	if resp.Header.Get("X-Xet-Hash") == "" {
+		t.Error("ready resolve response is missing X-Xet-Hash")
+	}
+	if loc := resp.Header.Get("Location"); !strings.HasSuffix(loc, "/xet-bridge/"+wantSHA256) {
+		t.Errorf("ready resolve redirect = %q, want suffix %q", loc, "/xet-bridge/"+wantSHA256)
+	}
+	// Metadata hub clients refuse to download without, mirrored from the
+	// upstream or synthesized (modelscope omits size on HEAD and may omit
+	// the commit; the mirror must fill both).
+	if got := trimETag(resp.Header.Get("ETag")); got != wantSHA256 {
+		t.Errorf("ready ETag = %q, want upstream sha256 %q", got, wantSHA256)
+	}
+	if size, err := strconv.ParseInt(resp.Header.Get("X-Linked-Size"), 10, 64); err != nil || size <= 0 {
+		t.Errorf("ready X-Linked-Size = %q, want a positive size", resp.Header.Get("X-Linked-Size"))
+	}
+	if commit := resp.Header.Get("X-Repo-Commit"); !commitRe.MatchString(commit) {
+		t.Errorf("ready X-Repo-Commit = %q, want a 40-hex commit", commit)
+	}
+
+	t.Run("hf cli xet warm", func(t *testing.T) {
+		if !hasHFXet(hfBin) {
+			t.Skip("hf CLI has no hf_xet; xet downstream path unavailable")
+		}
+		verifyDownload(t, hfBin, mirrorURL, repo, wantSHA256, false)
+	})
+
+	t.Run("hf cli plain warm", func(t *testing.T) {
+		verifyDownload(t, hfBin, mirrorURL, repo, wantSHA256, true)
+	})
+
+	restartedURL := startMirror(t, unreachableUpstream(t), storageDir, cacheDir,
+		mirror.WithRevalidateInterval(0))
+	waitReady(t, restartedURL+resolvePath)
+
+	t.Run("hf cli xet warm after restart, upstream down", func(t *testing.T) {
+		if !hasHFXet(hfBin) {
+			t.Skip("hf CLI has no hf_xet; xet downstream path unavailable")
+		}
+		verifyDownload(t, hfBin, restartedURL, repo, wantSHA256, false)
+	})
+
+	t.Run("hf cli plain warm after restart, upstream down", func(t *testing.T) {
+		verifyDownload(t, hfBin, restartedURL, repo, wantSHA256, true)
+	})
+}
+
+// unreachableUpstream returns a loopback URL that refuses connections.
+func unreachableUpstream(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.NotFoundHandler())
+	srv.Close()
+	return srv.URL
+}
+
+// startMirror wires the same composition as cmd/xetd: a CAS server that
+// matches its routes first and falls through to the mirror handler, with a
+// shared issuer tying token minting to validation. storageDir and cacheDir
+// are taken by the caller so a restarted mirror can reuse them.
+func startMirror(t *testing.T, upstream, storageDir, cacheDir string, opts ...mirror.Option) string {
+	t.Helper()
+	var inner atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inner.Load().(http.Handler).ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	stor, err := storage.NewFileStorage(
+		storage.WithBasePath(storageDir),
+		storage.WithBaseURL(srv.URL),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issuer, err := token.NewIssuer(nil, 15*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := mirror.NewHandler(
+		append([]mirror.Option{
+			mirror.WithStorage(stor),
+			mirror.WithUpstream(upstream),
+			mirror.WithExternalURL(srv.URL),
+			mirror.WithCacheDir(cacheDir),
+			mirror.WithMintToken(issuer.Mint),
+		}, opts...)...,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inner.Store(http.Handler(server.NewHandler(
+		server.WithStorage(stor),
+		server.WithAuthFunc(func(tok string) bool { return issuer.Validate(tok, time.Now()) }),
+		server.WithNext(h),
+	)))
+	return srv.URL
+}
+
+// verifyDownload runs `hf download` against the mirror into a fresh local dir
+// with a fresh HF_HOME, then checks the bytes against the upstream sha256.
+func verifyDownload(t *testing.T, hfBin, endpoint, repo, wantSHA256 string, disableXet bool) {
+	t.Helper()
+	localDir := t.TempDir()
+	cmd := exec.CommandContext(t.Context(), hfBin, "download", repo, testFile, "--local-dir", localDir)
+	cmd.Env = hfEnv(t, endpoint, disableXet)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("hf download failed: %v\n%s", err, out)
+	}
+	if got := sha256File(t, filepath.Join(localDir, testFile)); got != wantSHA256 {
+		t.Fatalf("downloaded sha256 = %s, want %s", got, wantSHA256)
+	}
+}
+
+// hfEnv builds the CLI environment: hub traffic pinned to the mirror, caches
+// and credentials isolated per invocation, and proxy variables stripped so
+// loopback traffic to the mirror never routes through a proxy.
+func hfEnv(t *testing.T, endpoint string, disableXet bool) []string {
+	t.Helper()
+	var env []string
+	for _, kv := range os.Environ() {
+		name, _, _ := strings.Cut(kv, "=")
+		switch strings.ToUpper(name) {
+		case "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY":
+			continue
+		}
+		if strings.HasPrefix(name, "HF_") || strings.HasPrefix(name, "HUGGING") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env,
+		"HF_ENDPOINT="+endpoint,
+		"HF_HOME="+t.TempDir(),
+		"HF_HUB_DISABLE_TELEMETRY=1",
+		"HF_HUB_DISABLE_PROGRESS_BARS=1",
+		"HF_HUB_ETAG_TIMEOUT=60",
+		"NO_PROXY=127.0.0.1,localhost",
+		"no_proxy=127.0.0.1,localhost",
+	)
+	if disableXet {
+		env = append(env, "HF_HUB_DISABLE_XET=1")
+	}
+	return env
+}
+
+var (
+	sha256Re = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	commitRe = regexp.MustCompile(`^[0-9a-f]{40}$`)
+)
+
+// probeUpstreamSHA256 checks the upstream is reachable and returns the sha256
+// the hub hop advertises for the file, skipping the test when unreachable.
+func probeUpstreamSHA256(t *testing.T, resolveURL string) string {
+	t.Helper()
+	c := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, err := http.NewRequest(http.MethodHead, resolveURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept-Encoding", "identity")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Skipf("upstream unreachable (huggingface.co may need https_proxy, e.g. https_proxy=http://127.0.0.1:1087): %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		t.Skipf("upstream %s returned status %d", resolveURL, resp.StatusCode)
+	}
+	etag := trimETag(resp.Header.Get("X-Linked-Etag"))
+	if etag == "" {
+		etag = trimETag(resp.Header.Get("ETag"))
+	}
+	if !sha256Re.MatchString(etag) {
+		t.Fatalf("upstream etag %q is not a sha256; pick an LFS-backed test file", etag)
+	}
+	return etag
+}
+
+func trimETag(etag string) string {
+	return strings.Trim(strings.TrimPrefix(strings.TrimSpace(etag), "W/"), `"`)
+}
+
+// waitReady polls the resolve URL with HEAD until the mirror answers with the
+// ready-state redirect, meaning ingestion completed into local storage.
+func waitReady(t *testing.T, resolveURL string) *http.Response {
+	t.Helper()
+	c := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	deadline := time.Now().Add(5 * time.Minute)
+	last := "no request made"
+	for time.Now().Before(deadline) {
+		resp, err := c.Head(resolveURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusFound {
+			return resp
+		}
+		last = resp.Status
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("mirror never reached ready state; last status: %s", last)
+	return nil
+}
+
+func sha256File(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// hasHFXet reports whether the CLI's Python environment ships hf_xet.
+func hasHFXet(hfBin string) bool {
+	out, err := exec.Command(hfBin, "env").Output()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if k, v, ok := strings.Cut(line, ":"); ok &&
+			strings.Contains(k, "hf_xet") && !strings.Contains(v, "not installed") {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/mirror_test.go
+++ b/test/e2e/mirror_test.go
@@ -1,0 +1,721 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wzshiming/xet/mirror"
+	"github.com/wzshiming/xet/server"
+	"github.com/wzshiming/xet/storage"
+	"github.com/wzshiming/xet/token"
+)
+
+// fakeHub is a configurable plain hub: resolve requests answer metadata
+// headers and redirect to a /cdn path that serves the bytes.
+type fakeHub struct {
+	mu    sync.Mutex
+	files map[string][]byte
+
+	commit        string // "" omits X-Repo-Commit
+	etagOverride  string // "" uses the real sha256 of the data
+	sizeOverride  string // "" uses the real length
+	omitSize      bool   // no X-Linked-Size on resolve, no Content-Length on cdn HEAD
+	resolveStatus int    // when > 0, every resolve request answers this status
+
+	gate         chan struct{} // when set, non-Range cdn GETs stall halfway until closed
+	gateHit      chan struct{}
+	gateOnce     sync.Once
+	dropNextData atomic.Bool // abort the next cdn GET halfway through the body
+
+	probes   atomic.Int64 // HEAD requests on resolve paths
+	dataGETs atomic.Int64 // GET requests on cdn paths
+}
+
+func newFakeHub() *fakeHub {
+	return &fakeHub{files: map[string][]byte{}, commit: "commit-e2e"}
+}
+
+func (u *fakeHub) set(path string, data []byte) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.files[path] = data
+}
+
+func (u *fakeHub) get(path string) ([]byte, bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	data, ok := u.files[path]
+	return data, ok
+}
+
+func (u *fakeHub) etagFor(data []byte) string {
+	if u.etagOverride != "" {
+		return u.etagOverride
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func (u *fakeHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/cdn/") {
+		u.serveData(w, r, strings.TrimPrefix(r.URL.Path, "/cdn"))
+		return
+	}
+	u.serveResolve(w, r)
+}
+
+func (u *fakeHub) serveResolve(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodHead {
+		u.probes.Add(1)
+	}
+	if u.resolveStatus > 0 {
+		w.WriteHeader(u.resolveStatus)
+		return
+	}
+	data, ok := u.get(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	etag := u.etagFor(data)
+	w.Header().Set("ETag", `"`+etag+`"`)
+	w.Header().Set("X-Linked-Etag", `"`+etag+`"`)
+	if !u.omitSize {
+		size := u.sizeOverride
+		if size == "" {
+			size = fmt.Sprint(len(data))
+		}
+		w.Header().Set("X-Linked-Size", size)
+	}
+	if u.commit != "" {
+		w.Header().Set("X-Repo-Commit", u.commit)
+	}
+	http.Redirect(w, r, "/cdn"+r.URL.Path, http.StatusFound)
+}
+
+func (u *fakeHub) serveData(w http.ResponseWriter, r *http.Request, path string) {
+	data, ok := u.get(path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method == http.MethodHead {
+		if !u.omitSize {
+			w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+		}
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	u.dataGETs.Add(1)
+	if u.dropNextData.CompareAndSwap(true, false) {
+		w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data[:len(data)/2])
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler) // simulate a mid-body connection drop
+	}
+	if u.gate != nil && r.Header.Get("Range") == "" {
+		w.Header().Set("Content-Length", fmt.Sprint(len(data)))
+		w.WriteHeader(http.StatusOK)
+		half := len(data) / 2
+		_, _ = w.Write(data[:half])
+		w.(http.Flusher).Flush()
+		u.gateOnce.Do(func() { close(u.gateHit) })
+		<-u.gate
+		_, _ = w.Write(data[half:])
+		return
+	}
+	http.ServeContent(w, r, "", time.Time{}, bytes.NewReader(data))
+}
+
+// newMirrorServer wires the same composition as cmd/xetd: the CAS server
+// matches its routes first and falls through to the mirror handler.
+func newMirrorServer(t *testing.T, upstreamURL, storageDir, cacheDir string, opts ...mirror.Option) *httptest.Server {
+	t.Helper()
+	var inner atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inner.Load().(http.Handler).ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	stor, err := storage.NewFileStorage(
+		storage.WithBasePath(storageDir),
+		storage.WithBaseURL(srv.URL),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issuer, err := token.NewIssuer(nil, 15*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := mirror.NewHandler(
+		append([]mirror.Option{
+			mirror.WithStorage(stor),
+			mirror.WithUpstream(upstreamURL),
+			mirror.WithExternalURL(srv.URL),
+			mirror.WithCacheDir(cacheDir),
+			mirror.WithMintToken(issuer.Mint),
+		}, opts...)...,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inner.Store(http.Handler(server.NewHandler(
+		server.WithStorage(stor),
+		server.WithAuthFunc(func(tok string) bool { return issuer.Validate(tok, time.Now()) }),
+		server.WithNext(h),
+	)))
+	return srv
+}
+
+func noRedirectClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// waitMirrorReady polls until the mirror answers with the ready-state
+// redirect and returns that response (body already consumed).
+func waitMirrorReady(t *testing.T, resolveURL string) *http.Response {
+	t.Helper()
+	c := noRedirectClient()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := c.Get(resolveURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusFound {
+			return resp
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("mirror never reached ready state")
+	return nil
+}
+
+// pollResolveStatus polls until the resolve URL answers with the wanted
+// status and returns the response body.
+func pollResolveStatus(t *testing.T, resolveURL string, want int) string {
+	t.Helper()
+	c := noRedirectClient()
+	deadline := time.Now().Add(15 * time.Second)
+	lastStatus := -1
+	lastBody := ""
+	for time.Now().Before(deadline) {
+		resp, err := c.Get(resolveURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, _ := io.ReadAll(resp.Body) // mid-ingest bodies may abort; only the status matters
+		resp.Body.Close()
+		lastStatus, lastBody = resp.StatusCode, string(b)
+		if lastStatus == want {
+			return lastBody
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("resolve never returned %d, last status %d body %q", want, lastStatus, lastBody)
+	return ""
+}
+
+// waitIndexPersisted waits for the on-disk index entry, the mirror's
+// persistence contract for ready files.
+func waitIndexPersisted(t *testing.T, cacheDir string) {
+	t.Helper()
+	dir := filepath.Join(cacheDir, "index")
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		entries, _ := os.ReadDir(dir)
+		for _, de := range entries {
+			if strings.HasSuffix(de.Name(), ".json") {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("index entry never persisted")
+}
+
+func getBody(t *testing.T, url string) []byte {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body %q", resp.StatusCode, body)
+	}
+	return body
+}
+
+// TestMirrorEmptyFile: zero-byte files are cached and served as a direct 200
+// with no redirect and no xet Link headers, and survive a restart.
+func TestMirrorEmptyFile(t *testing.T) {
+	hub := newFakeHub()
+	hubSrv := httptest.NewServer(hub)
+	defer hubSrv.Close()
+
+	const resolvePath = "/org/repo/resolve/main/empty.bin"
+	hub.set(resolvePath, []byte{})
+
+	storageDir, cacheDir := t.TempDir(), t.TempDir()
+	srv := newMirrorServer(t, hubSrv.URL, storageDir, cacheDir)
+	resolveURL := srv.URL + resolvePath
+
+	if body := getBody(t, resolveURL); len(body) != 0 {
+		t.Fatalf("first request body = %d bytes, want 0", len(body))
+	}
+	waitIndexPersisted(t, cacheDir)
+
+	emptySum := sha256.Sum256(nil)
+	wantETag := `"` + hex.EncodeToString(emptySum[:]) + `"`
+
+	resp, err := noRedirectClient().Get(resolveURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ready status = %d, want 200 (not a redirect)", resp.StatusCode)
+	}
+	if resp.ContentLength != 0 {
+		t.Fatalf("Content-Length = %d, want 0", resp.ContentLength)
+	}
+	if got := resp.Header.Get("ETag"); got != wantETag {
+		t.Fatalf("ETag = %q, want %q", got, wantETag)
+	}
+	if got := resp.Header.Get("X-Linked-Size"); got != "0" {
+		t.Fatalf("X-Linked-Size = %q, want 0", got)
+	}
+	if links := resp.Header.Values("Link"); len(links) != 0 {
+		t.Fatalf("empty file must carry no xet Link headers, got %q", links)
+	}
+
+	// Restart with the same storage and cache: still served, no re-probe.
+	probesBefore := hub.probes.Load()
+	srv2 := newMirrorServer(t, hubSrv.URL, storageDir, cacheDir)
+	if body := getBody(t, srv2.URL+resolvePath); len(body) != 0 {
+		t.Fatalf("post-restart body = %d bytes, want 0", len(body))
+	}
+	if got := hub.probes.Load(); got != probesBefore {
+		t.Fatalf("restart re-probed upstream: %d -> %d", probesBefore, got)
+	}
+}
+
+// TestMirrorUpstreamFailureCached: probe failures are answered immediately and
+// cached with backoff, so repeated requests do not hammer the upstream.
+func TestMirrorUpstreamFailureCached(t *testing.T) {
+	t.Run("server error maps to 502", func(t *testing.T) {
+		hub := newFakeHub()
+		hub.resolveStatus = http.StatusInternalServerError
+		hubSrv := httptest.NewServer(hub)
+		defer hubSrv.Close()
+
+		srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+		resolveURL := srv.URL + "/org/repo/resolve/main/broken.bin"
+
+		for i := range 2 {
+			resp, err := http.Get(resolveURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusBadGateway {
+				t.Fatalf("request %d: status = %d, want 502", i, resp.StatusCode)
+			}
+		}
+		if got := hub.probes.Load(); got != 1 {
+			t.Fatalf("upstream probes = %d, want 1 (failure not cached)", got)
+		}
+	})
+
+	t.Run("not found maps to 404", func(t *testing.T) {
+		hub := newFakeHub()
+		hubSrv := httptest.NewServer(hub)
+		defer hubSrv.Close()
+
+		srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+		resolveURL := srv.URL + "/org/repo/resolve/main/missing.bin"
+
+		for i := range 2 {
+			resp, err := http.Get(resolveURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusNotFound {
+				t.Fatalf("request %d: status = %d, want 404", i, resp.StatusCode)
+			}
+		}
+		if got := hub.probes.Load(); got != 1 {
+			t.Fatalf("upstream probes = %d, want 1 (404 not cached)", got)
+		}
+	})
+}
+
+// TestMirrorSHA256Mismatch: when the upstream-advertised sha256 etag does not
+// match the bytes, in-flight readers still get the bytes but the ingest fails
+// and the file ends in a failed state instead of being cached corrupt.
+func TestMirrorSHA256Mismatch(t *testing.T) {
+	hub := newFakeHub()
+	hub.etagOverride = strings.Repeat("ab", 32) // valid hex shape, wrong digest
+
+	hubSrv := httptest.NewServer(hub)
+	defer hubSrv.Close()
+
+	data := deterministicData(64 * 1024)
+	const resolvePath = "/org/repo/resolve/main/lying-etag.bin"
+	hub.set(resolvePath, data)
+
+	srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := srv.URL + resolvePath
+
+	// Serve-while-caching still delivers the actual bytes.
+	if body := getBody(t, resolveURL); !bytes.Equal(body, data) {
+		t.Fatalf("in-flight body mismatch: %d bytes, want %d", len(body), len(data))
+	}
+
+	body := pollResolveStatus(t, resolveURL, http.StatusBadGateway)
+	if !strings.Contains(body, "sha256 mismatch") {
+		t.Fatalf("error body = %q, want it to mention the sha256 mismatch", body)
+	}
+}
+
+// TestMirrorSizeMismatch: an upstream that advertises the wrong size must not
+// be cached as ready.
+func TestMirrorSizeMismatch(t *testing.T) {
+	hub := newFakeHub()
+	data := deterministicData(32 * 1024)
+	hub.sizeOverride = fmt.Sprint(len(data) + 16)
+
+	hubSrv := httptest.NewServer(hub)
+	defer hubSrv.Close()
+
+	const resolvePath = "/org/repo/resolve/main/lying-size.bin"
+	hub.set(resolvePath, data)
+
+	srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := srv.URL + resolvePath
+
+	// Trigger ingestion; the in-flight response is truncated mid-body, so
+	// tolerate the read error and only care about the final state.
+	if resp, err := http.Get(resolveURL); err == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+
+	body := pollResolveStatus(t, resolveURL, http.StatusBadGateway)
+	if !strings.Contains(body, "size mismatch") {
+		t.Fatalf("error body = %q, want it to mention the size mismatch", body)
+	}
+}
+
+// TestMirrorClientDisconnectKeepsIngest: dropping the only downstream client
+// mid-transfer must not cancel the background ingestion.
+func TestMirrorClientDisconnectKeepsIngest(t *testing.T) {
+	hub := newFakeHub()
+	hub.gate = make(chan struct{})
+	hub.gateHit = make(chan struct{})
+	hubSrv := httptest.NewServer(hub)
+	defer hubSrv.Close()
+
+	data := deterministicData(128 * 1024)
+	const resolvePath = "/org/repo/resolve/main/abandoned.bin"
+	hub.set(resolvePath, data)
+
+	srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := srv.URL + resolvePath
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resolveURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-hub.gateHit // upstream has streamed half into the spool
+	cancel()      // the only client goes away
+	_ = resp.Body.Close()
+	close(hub.gate)
+
+	waitMirrorReady(t, resolveURL)
+	if got := hub.dataGETs.Load(); got != 1 {
+		t.Fatalf("upstream data GETs = %d, want 1 (disconnect restarted the ingest)", got)
+	}
+	if body := getBody(t, resolveURL); !bytes.Equal(body, data) {
+		t.Fatal("cached body mismatch after client disconnect")
+	}
+	if got := hub.dataGETs.Load(); got != 1 {
+		t.Fatalf("upstream data GETs after ready = %d, want 1", got)
+	}
+}
+
+// TestMirrorCommitRevisionPinned: a 40-hex commit revision is immutable and
+// must never be revalidated, even when the revalidate interval is zero.
+func TestMirrorCommitRevisionPinned(t *testing.T) {
+	hub := newFakeHub()
+	hubSrv := httptest.NewServer(hub)
+	defer hubSrv.Close()
+
+	rev := strings.Repeat("c0ffee", 6) + "abcd" // 40 hex chars
+	resolvePath := "/org/repo/resolve/" + rev + "/pinned.bin"
+	v1 := deterministicData(48 * 1024)
+	hub.set(resolvePath, v1)
+
+	srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir(), mirror.WithRevalidateInterval(0))
+	resolveURL := srv.URL + resolvePath
+
+	if body := getBody(t, resolveURL); !bytes.Equal(body, v1) {
+		t.Fatal("initial body mismatch")
+	}
+	waitMirrorReady(t, resolveURL)
+	probesAfterIngest := hub.probes.Load()
+
+	// Upstream content changes (which real hubs never do for a commit).
+	hub.set(resolvePath, deterministicData(10*1024))
+
+	if body := getBody(t, resolveURL); !bytes.Equal(body, v1) {
+		t.Fatal("commit-pinned content changed; it must keep serving the cached bytes")
+	}
+	if got := hub.probes.Load(); got != probesAfterIngest {
+		t.Fatalf("commit revision was revalidated: probes %d -> %d", probesAfterIngest, got)
+	}
+}
+
+// TestMirrorServesCacheDuringUpstreamOutage: once a file is ready, an upstream
+// outage must not break downloads even when revalidation is due.
+func TestMirrorServesCacheDuringUpstreamOutage(t *testing.T) {
+	hub := newFakeHub()
+	hubSrv := httptest.NewServer(hub)
+	defer hubSrv.Close()
+
+	data := deterministicData(48 * 1024)
+	const resolvePath = "/org/repo/resolve/main/outage.bin"
+	hub.set(resolvePath, data)
+
+	srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir(), mirror.WithRevalidateInterval(0))
+	resolveURL := srv.URL + resolvePath
+
+	if body := getBody(t, resolveURL); !bytes.Equal(body, data) {
+		t.Fatal("initial body mismatch")
+	}
+	waitMirrorReady(t, resolveURL)
+
+	// Upstream starts failing; revalidation is attempted on every request.
+	hub.resolveStatus = http.StatusInternalServerError
+
+	if body := getBody(t, resolveURL); !bytes.Equal(body, data) {
+		t.Fatal("cached body not served during upstream outage")
+	}
+	resp := waitMirrorReady(t, resolveURL)
+	if got := resp.Header.Get("X-Linked-Size"); got != fmt.Sprint(len(data)) {
+		t.Fatalf("X-Linked-Size = %q, want %d", got, len(data))
+	}
+}
+
+// TestMirrorSizeOnlyKnownFromFetch: upstreams like modelscope.cn answer HEAD
+// without any size; the mirror must learn it from the ingest download's
+// response headers and only then answer metadata requests.
+func TestMirrorSizeOnlyKnownFromFetch(t *testing.T) {
+	hub := newFakeHub()
+	hub.omitSize = true
+	hub.gate = make(chan struct{})
+	hub.gateHit = make(chan struct{})
+	hubSrv := httptest.NewServer(hub)
+	defer hubSrv.Close()
+
+	data := deterministicData(96 * 1024)
+	const resolvePath = "/org/repo/resolve/main/nosize.bin"
+	hub.set(resolvePath, data)
+
+	srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := srv.URL + resolvePath
+
+	type result struct {
+		body []byte
+		err  error
+	}
+	got := make(chan result, 1)
+	go func() {
+		resp, err := http.Get(resolveURL)
+		if err != nil {
+			got <- result{nil, err}
+			return
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		got <- result{b, err}
+	}()
+
+	<-hub.gateHit // ingest is mid-flight: size learned from GET headers only
+
+	resp, err := noRedirectClient().Head(resolveURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mid-ingest HEAD status = %d, want 200", resp.StatusCode)
+	}
+	if resp.ContentLength != int64(len(data)) {
+		t.Fatalf("mid-ingest HEAD Content-Length = %d, want %d", resp.ContentLength, len(data))
+	}
+	if got := resp.Header.Get("X-Linked-Size"); got != fmt.Sprint(len(data)) {
+		t.Fatalf("mid-ingest X-Linked-Size = %q, want %d", got, len(data))
+	}
+	if got := resp.Header.Get("X-Repo-Commit"); got == "" {
+		t.Fatal("mid-ingest HEAD missing X-Repo-Commit")
+	}
+
+	close(hub.gate)
+	r := <-got
+	if r.err != nil {
+		t.Fatalf("streaming GET: %v", r.err)
+	}
+	if !bytes.Equal(r.body, data) {
+		t.Fatalf("streaming GET body mismatch: %d bytes, want %d", len(r.body), len(data))
+	}
+
+	ready := waitMirrorReady(t, resolveURL)
+	if got := ready.Header.Get("X-Linked-Size"); got != fmt.Sprint(len(data)) {
+		t.Fatalf("ready X-Linked-Size = %q, want %d", got, len(data))
+	}
+}
+
+// TestMirrorResumeAfterUpstreamDrop: a connection drop halfway through the
+// upstream download must be resumed, and the cached file must still be intact.
+func TestMirrorResumeAfterUpstreamDrop(t *testing.T) {
+	hub := newFakeHub()
+	hub.dropNextData.Store(true)
+	hubSrv := httptest.NewServer(hub)
+	defer hubSrv.Close()
+
+	data := deterministicData(256 * 1024)
+	const resolvePath = "/org/repo/resolve/main/flaky.bin"
+	hub.set(resolvePath, data)
+
+	srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+	resolveURL := srv.URL + resolvePath
+
+	if body := getBody(t, resolveURL); !bytes.Equal(body, data) {
+		t.Fatalf("body after upstream drop mismatch: %d bytes, want %d", len(body), len(data))
+	}
+	waitMirrorReady(t, resolveURL)
+
+	if got := hub.dataGETs.Load(); got < 2 {
+		t.Fatalf("upstream data GETs = %d, want >= 2 (drop should force a resume)", got)
+	}
+	if body := getBody(t, resolveURL); !bytes.Equal(body, data) {
+		t.Fatal("cached body mismatch after resumed ingest")
+	}
+}
+
+// TestMirrorPseudoCommit: upstreams that send no X-Repo-Commit still yield a
+// commit header downstream: synthesized and stable for branches, the revision
+// itself for commit revisions.
+func TestMirrorPseudoCommit(t *testing.T) {
+	commitRe := regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+	t.Run("branch revision synthesizes a stable commit", func(t *testing.T) {
+		hub := newFakeHub()
+		hub.commit = "" // upstream omits X-Repo-Commit
+		hubSrv := httptest.NewServer(hub)
+		defer hubSrv.Close()
+
+		const resolvePath = "/org/repo/resolve/main/nocommit.bin"
+		hub.set(resolvePath, deterministicData(8*1024))
+
+		srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+		resolveURL := srv.URL + resolvePath
+
+		getBody(t, resolveURL)
+		first := waitMirrorReady(t, resolveURL).Header.Get("X-Repo-Commit")
+		if !commitRe.MatchString(first) {
+			t.Fatalf("X-Repo-Commit = %q, want a synthesized 40-hex commit", first)
+		}
+		if second := waitMirrorReady(t, resolveURL).Header.Get("X-Repo-Commit"); second != first {
+			t.Fatalf("pseudo commit not stable: %q then %q", first, second)
+		}
+	})
+
+	t.Run("commit revision is used verbatim", func(t *testing.T) {
+		hub := newFakeHub()
+		hub.commit = ""
+		hubSrv := httptest.NewServer(hub)
+		defer hubSrv.Close()
+
+		rev := strings.Repeat("ab", 20)
+		resolvePath := "/org/repo/resolve/" + rev + "/nocommit.bin"
+		hub.set(resolvePath, deterministicData(8*1024))
+
+		srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+		resolveURL := srv.URL + resolvePath
+
+		getBody(t, resolveURL)
+		if got := waitMirrorReady(t, resolveURL).Header.Get("X-Repo-Commit"); got != rev {
+			t.Fatalf("X-Repo-Commit = %q, want the pinned revision %q", got, rev)
+		}
+	})
+}
+
+// TestMirrorDistinctRevisions: the same path under different revisions must be
+// cached as independent entries.
+func TestMirrorDistinctRevisions(t *testing.T) {
+	hub := newFakeHub()
+	hubSrv := httptest.NewServer(hub)
+	defer hubSrv.Close()
+
+	v1 := deterministicData(16 * 1024)
+	v2 := deterministicData(24 * 1024)
+	const pathMain = "/org/repo/resolve/main/model.bin"
+	const pathDev = "/org/repo/resolve/dev/model.bin"
+	hub.set(pathMain, v1)
+	hub.set(pathDev, v2)
+
+	srv := newMirrorServer(t, hubSrv.URL, t.TempDir(), t.TempDir())
+
+	if body := getBody(t, srv.URL+pathMain); !bytes.Equal(body, v1) {
+		t.Fatal("main revision body mismatch")
+	}
+	if body := getBody(t, srv.URL+pathDev); !bytes.Equal(body, v2) {
+		t.Fatal("dev revision body mismatch")
+	}
+
+	locMain := waitMirrorReady(t, srv.URL+pathMain).Header.Get("Location")
+	locDev := waitMirrorReady(t, srv.URL+pathDev).Header.Get("Location")
+	if locMain == locDev {
+		t.Fatalf("revisions share a bridge location: %q", locMain)
+	}
+	if got := hub.dataGETs.Load(); got != 2 {
+		t.Fatalf("upstream data GETs = %d, want 2", got)
+	}
+}

--- a/token/token.go
+++ b/token/token.go
@@ -1,0 +1,65 @@
+// Package token implements short-lived HMAC-signed bearer tokens that can be
+// minted and validated statelessly, e.g. as the AuthFunc of a CAS server.
+package token
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const prefix = "xtk1"
+
+// Issuer mints and validates short-lived bearer tokens signed with an HMAC
+// secret.
+type Issuer struct {
+	secret []byte
+	ttl    time.Duration
+}
+
+// NewIssuer creates an Issuer. An empty secret is replaced by a random one,
+// scoping the tokens to the lifetime of the process. A non-positive ttl
+// defaults to 15 minutes.
+func NewIssuer(secret []byte, ttl time.Duration) (*Issuer, error) {
+	if len(secret) == 0 {
+		secret = make([]byte, 32)
+		if _, err := rand.Read(secret); err != nil {
+			return nil, fmt.Errorf("generate token secret: %w", err)
+		}
+	}
+	if ttl <= 0 {
+		ttl = 15 * time.Minute
+	}
+	return &Issuer{secret: secret, ttl: ttl}, nil
+}
+
+func (t *Issuer) sign(expStr string) string {
+	mac := hmac.New(sha256.New, t.secret)
+	mac.Write([]byte(prefix + "." + expStr))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Mint returns a bearer token and its expiry as a Unix timestamp.
+func (t *Issuer) Mint(now time.Time) (string, int64) {
+	exp := now.Add(t.ttl).Unix()
+	expStr := strconv.FormatInt(exp, 10)
+	return prefix + "." + expStr + "." + t.sign(expStr), exp
+}
+
+// Validate reports whether token was minted by this issuer and is not expired.
+func (t *Issuer) Validate(token string, now time.Time) bool {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[0] != prefix {
+		return false
+	}
+	exp, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil || now.Unix() >= exp {
+		return false
+	}
+	return hmac.Equal([]byte(t.sign(parts[1])), []byte(parts[2]))
+}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,0 +1,53 @@
+package token
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIssuer(t *testing.T) {
+	issuer, err := NewIssuer(nil, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	token, exp := issuer.Mint(now)
+	if exp <= now.Unix() {
+		t.Fatalf("exp = %d, want after %d", exp, now.Unix())
+	}
+	if !issuer.Validate(token, now) {
+		t.Fatal("freshly minted token rejected")
+	}
+	if issuer.Validate(token, now.Add(2*time.Minute)) {
+		t.Fatal("expired token accepted")
+	}
+	if issuer.Validate(token+"x", now) {
+		t.Fatal("tampered token accepted")
+	}
+	if issuer.Validate("garbage", now) {
+		t.Fatal("garbage token accepted")
+	}
+	other, err := NewIssuer(nil, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other.Validate(token, now) {
+		t.Fatal("token minted by another issuer accepted")
+	}
+
+	t.Run("fixed secret shared across issuers", func(t *testing.T) {
+		secret := []byte("0123456789abcdef0123456789abcdef")
+		a, err := NewIssuer(secret, time.Minute)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := NewIssuer(secret, time.Minute)
+		if err != nil {
+			t.Fatal(err)
+		}
+		token, _ := a.Mint(now)
+		if !b.Validate(token, now) {
+			t.Fatal("token minted with shared secret rejected")
+		}
+	})
+}


### PR DESCRIPTION
Adds a full-cache mirror mode to `xetd` that bridges xet and plain hubs in either direction.

## What changed

- Added `mirror.Handler` for hub-style resolve routes. A cache miss starts one background ingestion per `(repo, revision, path)`; concurrent cold requests read from the same growing spool, and Range reads wait for the requested bytes.
- Detects xet upstreams from resolve `Link` headers. Xet sources use the existing client download path; plain sources use resumable HTTP. Completed spools are SHA-256 verified and ingested into local xorbs and shards through the standard upload pipeline.
- Persists ready entries, revalidates mutable revisions, and applies exponential backoff after failures. Ready responses expose both mirror-local xet links and the existing `/xet-bridge/{sha256}` redirect.
- Added mirror-scoped CAS token minting and validation. Upstream credentials are injected only for the configured hub host and downstream authorization is never forwarded.
- Added `xetd -upstream` and `-upstream-token` wiring. Non-file routes continue through the upstream control-plane proxy.

## Guarantees

- File bytes are always cached locally; there is no downstream file passthrough.
- One ingestion owns the upstream fetch and continues if a downstream client disconnects.
- Cold clients receive plain HTTP while ingestion is in progress; warm clients can use either xet or plain HTTP.

## Validation

- Mirror tests cover plain and xet upstreams, concurrent cold downloads, blocking ranges, retries and 404 backoff, stale revalidation, restart persistence, credential isolation, token handling, and ready-state xet/plain downloads.
- Conformance tests exercise the official `hf` CLI through the mirror against Hugging Face (xet upstream) and ModelScope (plain upstream), including cold, warm xet, and warm plain downloads.
- PR CI: Go Tests and Conformance Tests pass.

Storage garbage collection remains a follow-up because the repository does not currently GC xorbs.

Fixes #132