### PR TITLE
feat: bound the chunk cache and evict with LRU

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/wzshiming/httpseek"
+	"github.com/wzshiming/xet/download"
 	"github.com/wzshiming/xet/progress"
 )
 
@@ -29,6 +30,8 @@ type Client struct {
 	retries       int
 	progressFunc  progress.ProgressFunc
 	cacheDir      string
+	cacheSize     int64
+	cacheManager  *download.CacheManager
 }
 
 type Options func(*Client)
@@ -94,6 +97,16 @@ func WithCacheDir(cacheDir string) Options {
 	}
 }
 
+// WithCacheSize bounds the total size in bytes of the persistent disk chunk
+// cache; least recently used entries are evicted once the limit is exceeded.
+// Zero or negative keeps the cache unbounded. Defaults to
+// download.DefaultCacheSize (10 GB), matching xet-core.
+func WithCacheSize(sizeBytes int64) Options {
+	return func(c *Client) {
+		c.cacheSize = sizeBytes
+	}
+}
+
 // NewClient creates a new API client
 func NewClient(opts ...Options) (*Client, error) {
 	c := &Client{
@@ -101,10 +114,13 @@ func NewClient(opts ...Options) (*Client, error) {
 		namespace:   "default",
 		concurrency: 4,
 		retries:     5,
+		cacheSize:   download.DefaultCacheSize,
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
+
+	c.cacheManager = download.NewCacheManager(c.cacheDir, c.cacheSize)
 
 	if c.httpClient.Transport == nil {
 		c.httpClient.Transport = http.DefaultTransport.(*http.Transport).Clone()

--- a/client/download.go
+++ b/client/download.go
@@ -82,6 +82,9 @@ func (c *Client) downloadFileWithAuthProvider(ctx context.Context, provider Auth
 	if err != nil {
 		return err
 	}
+	// Close releases cache references even when the copy stops early on a
+	// write error.
+	defer reader.Close()
 
 	n, err := io.Copy(w, reader)
 	if err != nil {
@@ -97,14 +100,14 @@ func (c *Client) downloadFileWithAuthProvider(ctx context.Context, provider Auth
 // and returns a reader plus the expected reconstructed length. When a resume
 // (Range) query is rejected, it retries once from the start without a Range
 // header.
-func (c *Client) newDownloadReader(ctx context.Context, provider AuthProvider, fileHash xet.FileHash, header http.Header, resumeOffset int64, w io.WriteSeeker, apiVersion reconstructionAPIVersion) (io.Reader, int64, error) {
+func (c *Client) newDownloadReader(ctx context.Context, provider AuthProvider, fileHash xet.FileHash, header http.Header, resumeOffset int64, w io.WriteSeeker, apiVersion reconstructionAPIVersion) (io.ReadCloser, int64, error) {
 	if apiVersion == reconstructionAPIVersionV1 {
 		return c.newDownloadReaderV1(ctx, provider, fileHash, header, resumeOffset, w)
 	}
 	return c.newDownloadReaderV2(ctx, provider, fileHash, header, resumeOffset, w)
 }
 
-func (c *Client) newDownloadReaderV1(ctx context.Context, provider AuthProvider, fileHash xet.FileHash, header http.Header, resumeOffset int64, w io.WriteSeeker) (io.Reader, int64, error) {
+func (c *Client) newDownloadReaderV1(ctx context.Context, provider AuthProvider, fileHash xet.FileHash, header http.Header, resumeOffset int64, w io.WriteSeeker) (io.ReadCloser, int64, error) {
 	reconstructionResp, err := c.GetReconstructionV1WithAuthProvider(ctx, provider, fileHash, header)
 	if err != nil {
 		if resumeOffset > 0 {
@@ -118,14 +121,14 @@ func (c *Client) newDownloadReaderV1(ctx context.Context, provider AuthProvider,
 		}
 	}
 
-	reader, err := download.NewReaderV1(ctx, c, reconstructionResp, c.cacheDir, c.downloadOptions()...)
+	reader, err := download.NewReaderV1(ctx, c, reconstructionResp, c.downloadOptions()...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("initialize reader v1: %w", err)
 	}
 	return reader, download.ExpectedLengthV1(reconstructionResp), nil
 }
 
-func (c *Client) newDownloadReaderV2(ctx context.Context, provider AuthProvider, fileHash xet.FileHash, header http.Header, resumeOffset int64, w io.WriteSeeker) (io.Reader, int64, error) {
+func (c *Client) newDownloadReaderV2(ctx context.Context, provider AuthProvider, fileHash xet.FileHash, header http.Header, resumeOffset int64, w io.WriteSeeker) (io.ReadCloser, int64, error) {
 	reconstructionResp, err := c.GetReconstructionV2WithAuthProvider(ctx, provider, fileHash, header)
 	if err != nil {
 		if resumeOffset > 0 {
@@ -139,7 +142,7 @@ func (c *Client) newDownloadReaderV2(ctx context.Context, provider AuthProvider,
 		}
 	}
 
-	reader, err := download.NewReaderV2(ctx, c, reconstructionResp, c.cacheDir, c.downloadOptions()...)
+	reader, err := download.NewReaderV2(ctx, c, reconstructionResp, c.downloadOptions()...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("initialize reader v2: %w", err)
 	}
@@ -151,6 +154,7 @@ func (c *Client) newDownloadReaderV2(ctx context.Context, provider AuthProvider,
 func (c *Client) downloadOptions() []download.Option {
 	opts := []download.Option{
 		download.WithConcurrency(c.concurrency),
+		download.WithCacheManager(c.cacheManager),
 	}
 	if c.progressFunc != nil {
 		opts = append(opts, download.WithProgressFunc(c.progressFunc))
@@ -162,13 +166,15 @@ func (c *Client) downloadOptions() []download.Option {
 // All files share one fetch_info map, so each xorb is fetched only once across the batch.
 // It returns a reader and size per file in the same order as fileHashes.
 // Individual errors are embedded per-entry; a nil reader means that file was not found.
-func (c *Client) DownloadFiles(ctx context.Context, fileHashes []xet.FileHash) ([]io.Reader, []int64, error) {
+// Readers release their cache references when read to EOF; close any reader
+// that is not fully consumed.
+func (c *Client) DownloadFiles(ctx context.Context, fileHashes []xet.FileHash) ([]io.ReadCloser, []int64, error) {
 	return c.DownloadFilesWithAuthProvider(ctx, nil, fileHashes)
 }
 
 // DownloadFilesWithAuthProvider downloads multiple files using a single batch
 // reconstruction request and a per-call auth provider.
-func (c *Client) DownloadFilesWithAuthProvider(ctx context.Context, provider AuthProvider, fileHashes []xet.FileHash) ([]io.Reader, []int64, error) {
+func (c *Client) DownloadFilesWithAuthProvider(ctx context.Context, provider AuthProvider, fileHashes []xet.FileHash) ([]io.ReadCloser, []int64, error) {
 	if len(fileHashes) == 0 {
 		return nil, nil, nil
 	}
@@ -178,7 +184,7 @@ func (c *Client) DownloadFilesWithAuthProvider(ctx context.Context, provider Aut
 		return nil, nil, fmt.Errorf("get batch reconstruction: %w", err)
 	}
 
-	readers := make([]io.Reader, len(fileHashes))
+	readers := make([]io.ReadCloser, len(fileHashes))
 	sizes := make([]int64, len(fileHashes))
 	for i, fileHash := range fileHashes {
 		terms, ok := batchResp.Files[fileHash.String()]
@@ -195,13 +201,7 @@ func (c *Client) DownloadFilesWithAuthProvider(ctx context.Context, provider Aut
 		}
 
 		sizes[i] = download.ExpectedLengthV1(singleResp)
-		opts := []download.Option{
-			download.WithConcurrency(c.concurrency),
-		}
-		if c.progressFunc != nil {
-			opts = append(opts, download.WithProgressFunc(c.progressFunc))
-		}
-		reader, err := download.NewReaderV1(ctx, c, singleResp, c.cacheDir, opts...)
+		reader, err := download.NewReaderV1(ctx, c, singleResp, c.downloadOptions()...)
 		if err != nil {
 			readers[i] = errReader{err: fmt.Errorf("initialize reader for file %s: %w", fileHash.String(), err)}
 		} else {
@@ -218,4 +218,8 @@ type errReader struct {
 
 func (e errReader) Read(p []byte) (n int, err error) {
 	return 0, e.err
+}
+
+func (e errReader) Close() error {
+	return nil
 }

--- a/download/cache_manager.go
+++ b/download/cache_manager.go
@@ -1,0 +1,341 @@
+package download
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/groupcache/lru"
+	"github.com/wzshiming/xet/internal/flock"
+)
+
+// DefaultCacheSize is the default chunk cache capacity in bytes, matching
+// xet-core's default chunk cache size (HF_XET_CHUNK_CACHE_SIZE_BYTES).
+const DefaultCacheSize int64 = 10_000_000_000
+
+// cacheEntry is the LRU bookkeeping for one published cache file.
+type cacheEntry struct {
+	size int64
+	refs int // active in-process users; entries with refs > 0 are never evicted
+}
+
+// evictedEntry is one (key, entry) pair reported by the LRU's OnEvicted.
+type evictedEntry struct {
+	key   string
+	entry *cacheEntry
+}
+
+// CacheManager bounds the total size of one chunk cache directory.
+//
+// Entries are tracked in an in-memory LRU that is touched once when a cache
+// file is acquired and once more when its user is done. Eviction is
+// evaluated when an entry is published or released, never on the read path,
+// and every evaluation first reconciles the tracked state with the directory
+// so the bound holds even when several managers or processes share it.
+// Cross-process (and cross-manager) safety relies on the per-entry .partial
+// flock: names are only unlinked while holding that lock, so active writers
+// are never disturbed, and already-open readers keep their data through the
+// open handles even after the names are removed.
+type CacheManager struct {
+	mu       sync.Mutex
+	dir      string
+	capacity int64 // bytes; <= 0 disables eviction
+	lru      *lru.Cache
+	total    int64
+
+	// evicted accumulates entries popped from the LRU via RemoveOldest;
+	// evaluateLocked drains it for eviction candidates and reconcileLocked
+	// uses it to rebuild the LRU.
+	evicted []evictedEntry
+}
+
+// NewCacheManager creates a manager for the chunk cache at cacheDir (empty
+// means the default directory). capacity bounds the cache size in bytes;
+// zero or negative disables eviction. Callers should create one manager per
+// cache directory and pass it to every reader sharing that directory.
+func NewCacheManager(cacheDir string, capacity int64) *CacheManager {
+	m := &CacheManager{
+		dir:      defaultCacheDir(cacheDir),
+		capacity: capacity,
+		lru:      lru.New(0),
+	}
+	m.lru.OnEvicted = func(key lru.Key, value any) {
+		k, _ := key.(string)
+		e, _ := value.(*cacheEntry)
+		m.evicted = append(m.evicted, evictedEntry{key: k, entry: e})
+	}
+	return m
+}
+
+// prepare reconciles tracked state with the cache directory (adopting
+// pre-existing entries and removing orphaned .partial files) and evicts any
+// overage before a download starts.
+func (m *CacheManager) prepare() {
+	m.evaluate()
+}
+
+// acquire records one use of the cache file at path and refreshes its LRU
+// position, adding it if not yet tracked.
+func (m *CacheManager) acquire(path string, size int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if v, ok := m.lru.Get(path); ok {
+		v.(*cacheEntry).refs++
+		return
+	}
+	m.lru.Add(path, &cacheEntry{size: size, refs: 1})
+	m.total += size
+}
+
+// release drops one use of path and refreshes its LRU position.
+func (m *CacheManager) release(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if v, ok := m.lru.Get(path); ok {
+		if e := v.(*cacheEntry); e.refs > 0 {
+			e.refs--
+		}
+	}
+}
+
+// evaluate reconciles tracked state with the cache directory, then evicts
+// least-recently-used entries until the total fits the capacity. Reconciling
+// first keeps the bound directory-level even when other managers or
+// processes write to the same directory.
+func (m *CacheManager) evaluate() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reconcileLocked()
+	m.evaluateLocked()
+}
+
+func (m *CacheManager) evaluateLocked() {
+	if m.capacity <= 0 {
+		return
+	}
+	var skipped []evictedEntry
+	for m.total > m.capacity && m.lru.Len() > 0 {
+		m.lru.RemoveOldest()
+		if len(m.evicted) == 0 {
+			break
+		}
+		batch := m.evicted
+		m.evicted = nil
+		for _, ev := range batch {
+			if ev.entry == nil {
+				continue
+			}
+			// Entries in use here or locked by another process are kept and
+			// become most recently used.
+			if ev.entry.refs > 0 || !removeCacheEntryFiles(ev.key) {
+				skipped = append(skipped, ev)
+				continue
+			}
+			m.total -= ev.entry.size
+		}
+	}
+	for _, s := range skipped {
+		m.lru.Add(s.key, s.entry)
+	}
+}
+
+// reconcileLocked re-reads the cache directory so the tracked state matches
+// disk: entries created by other managers or processes are adopted, entries
+// removed elsewhere are dropped, sizes are refreshed, and orphaned .partial
+// files left behind by crashed downloads are cleaned up. The recency order
+// and refs of already-tracked entries are preserved.
+func (m *CacheManager) reconcileLocked() {
+	type diskEntry struct {
+		path    string
+		size    int64
+		modTime time.Time
+	}
+	var found []diskEntry
+
+	prefixes, err := os.ReadDir(m.dir)
+	if err != nil && !os.IsNotExist(err) {
+		return
+	}
+	for _, prefix := range prefixes {
+		if !prefix.IsDir() {
+			continue
+		}
+		hashDirs, err := os.ReadDir(filepath.Join(m.dir, prefix.Name()))
+		if err != nil {
+			continue
+		}
+		for _, hd := range hashDirs {
+			if !hd.IsDir() {
+				continue
+			}
+			dir := filepath.Join(m.dir, prefix.Name(), hd.Name())
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				continue
+			}
+			published := make(map[string]bool)
+			var partials []string
+			for _, de := range entries {
+				name := de.Name()
+				if de.IsDir() {
+					continue
+				}
+				if strings.HasSuffix(name, ".partial") {
+					partials = append(partials, name)
+					continue
+				}
+				if _, _, _, _, _, ok := parseCacheFileName(name); !ok {
+					continue
+				}
+				info, err := de.Info()
+				if err != nil {
+					continue
+				}
+				published[name[:strings.LastIndex(name, "_")]] = true
+				// Account the real on-disk size; a corrupt entry whose size
+				// does not match its name must not inflate the total.
+				found = append(found, diskEntry{
+					path:    filepath.Join(dir, name),
+					size:    info.Size(),
+					modTime: info.ModTime(),
+				})
+			}
+			for _, name := range partials {
+				if published[strings.TrimSuffix(name, ".partial")] {
+					continue
+				}
+				removeOrphanPartial(filepath.Join(dir, name))
+			}
+		}
+	}
+
+	onDisk := make(map[string]int64, len(found))
+	for _, de := range found {
+		onDisk[de.path] = de.size
+	}
+
+	// Rebuild the LRU by popping everything oldest-first and re-adding the
+	// entries whose names are still on disk, preserving their recency order.
+	m.evicted = nil
+	for m.lru.Len() > 0 {
+		m.lru.RemoveOldest()
+	}
+	tracked := m.evicted
+	m.evicted = nil
+	m.total = 0
+	kept := make(map[string]bool, len(tracked))
+	for _, ev := range tracked {
+		if ev.entry == nil {
+			continue
+		}
+		size, ok := onDisk[ev.key]
+		if !ok {
+			// The name vanished (evicted by another process); open handles
+			// keep the data alive but it no longer occupies the directory.
+			continue
+		}
+		ev.entry.size = size
+		m.lru.Add(ev.key, ev.entry)
+		m.total += size
+		kept[ev.key] = true
+	}
+
+	// Adopt entries this manager has not seen yet, oldest first so they are
+	// evicted in modification-time order.
+	sort.Slice(found, func(i, j int) bool { return found[i].modTime.Before(found[j].modTime) })
+	for _, de := range found {
+		if kept[de.path] {
+			continue
+		}
+		m.lru.Add(de.path, &cacheEntry{size: de.size})
+		m.total += de.size
+	}
+}
+
+// cachePartialPathFor returns the .partial flock target for a published cache
+// file path by stripping the trailing _<fileSize> component.
+func cachePartialPathFor(finalPath string) (string, bool) {
+	name := filepath.Base(finalPath)
+	idx := strings.LastIndex(name, "_")
+	if idx <= 0 {
+		return "", false
+	}
+	return filepath.Join(filepath.Dir(finalPath), name[:idx]+".partial"), true
+}
+
+// removeCacheEntryFiles unlinks a published cache file together with its
+// .partial flock target (both names share one inode). Names are only removed
+// while holding the entry's flock, so a writer that is mid-publish is never
+// disturbed. Returns false when the entry is in use elsewhere and must be
+// kept.
+func removeCacheEntryFiles(finalPath string) bool {
+	partialPath, ok := cachePartialPathFor(finalPath)
+	if !ok {
+		return false
+	}
+	lockFile, err := os.OpenFile(partialPath, os.O_RDWR, 0)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false
+		}
+		// No flock target left, so no writer can be active on this entry.
+		if err := os.Remove(finalPath); err != nil && !os.IsNotExist(err) {
+			return false
+		}
+		removeEmptyCacheDirs(finalPath)
+		return true
+	}
+	defer lockFile.Close()
+	if err := flock.TryLock(lockFile); err != nil {
+		return false
+	}
+	defer flock.Unlock(lockFile) //nolint:errcheck
+	// Only remove names while the locked handle still backs partialPath;
+	// otherwise another process already recycled this entry.
+	pathInfo, statErr := os.Stat(partialPath)
+	fileInfo, fstatErr := lockFile.Stat()
+	if statErr != nil || fstatErr != nil || !os.SameFile(pathInfo, fileInfo) {
+		return false
+	}
+	if err := os.Remove(finalPath); err != nil && !os.IsNotExist(err) {
+		return false
+	}
+	os.Remove(partialPath) //nolint:errcheck
+	removeEmptyCacheDirs(finalPath)
+	return true
+}
+
+// removeOrphanPartial removes a .partial file that has no published sibling,
+// but only if no writer holds its flock.
+func removeOrphanPartial(path string) {
+	lockFile, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return
+	}
+	defer lockFile.Close()
+	if err := flock.TryLock(lockFile); err != nil {
+		return
+	}
+	defer flock.Unlock(lockFile) //nolint:errcheck
+	pathInfo, statErr := os.Stat(path)
+	fileInfo, fstatErr := lockFile.Stat()
+	if statErr != nil || fstatErr != nil || !os.SameFile(pathInfo, fileInfo) {
+		return
+	}
+	os.Remove(path) //nolint:errcheck
+	removeEmptyCacheDirs(path)
+}
+
+// removeEmptyCacheDirs opportunistically removes the hash directory and its
+// two-character parent once they become empty. Removal fails harmlessly while
+// they still contain entries.
+func removeEmptyCacheDirs(path string) {
+	hashDir := filepath.Dir(path)
+	if os.Remove(hashDir) != nil {
+		return
+	}
+	os.Remove(filepath.Dir(hashDir)) //nolint:errcheck
+}

--- a/download/cache_manager_test.go
+++ b/download/cache_manager_test.go
@@ -1,0 +1,371 @@
+package download
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wzshiming/xet/internal/flock"
+)
+
+// writeCacheEntry publishes one single-chunk cache entry and returns its
+// final file path.
+func writeCacheEntry(t *testing.T, m *CacheManager, hash string, payload string) string {
+	t.Helper()
+	cache, err := newChunkCache(bytes.NewReader([]byte(payload)), m, hash, 0, 1, 0, int64(len(payload)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.LoadAll(); err != nil {
+		t.Fatal(err)
+	}
+	cache.Done()
+	return findFinalFile(t, m.dir, hash)
+}
+
+// setCapacity changes the eviction bound of an existing manager.
+func setCapacity(m *CacheManager, capacity int64) {
+	m.mu.Lock()
+	m.capacity = capacity
+	m.mu.Unlock()
+}
+
+// cacheEntryFileSize is the on-disk size of a single-chunk entry: header
+// (numOffsets + 2 offsets) plus the payload.
+func cacheEntryFileSize(payload string) int64 {
+	return int64(4 + 4*2 + len(payload))
+}
+
+func findFinalFile(t *testing.T, dir, hash string) string {
+	t.Helper()
+	hashDir := filepath.Join(dir, hash[:2], hash[2:])
+	entries, err := os.ReadDir(hashDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatal(err)
+	}
+	for _, de := range entries {
+		if _, _, _, _, _, ok := parseCacheFileName(de.Name()); ok {
+			return filepath.Join(hashDir, de.Name())
+		}
+	}
+	return ""
+}
+
+func entryExists(t *testing.T, dir, hash string) bool {
+	t.Helper()
+	return findFinalFile(t, dir, hash) != ""
+}
+
+const (
+	testHashA = "aa11111111111111"
+	testHashB = "bb22222222222222"
+	testHashC = "cc33333333333333"
+)
+
+func TestCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	entrySize := cacheEntryFileSize(payload)
+	// Room for exactly two entries.
+	m := NewCacheManager(dir, entrySize*2)
+
+	writeCacheEntry(t, m, testHashA, payload)
+	writeCacheEntry(t, m, testHashB, payload)
+	writeCacheEntry(t, m, testHashC, payload)
+
+	if entryExists(t, dir, testHashA) {
+		t.Fatal("oldest entry was not evicted")
+	}
+	for _, h := range []string{testHashB, testHashC} {
+		if !entryExists(t, dir, h) {
+			t.Fatalf("entry %s was evicted unexpectedly", h)
+		}
+	}
+
+	// Touch B so C becomes the least recently used.
+	cc, err := openCachedRange(m, testHashB, 0, 1)
+	if err != nil || cc == nil {
+		t.Fatalf("open cached range: %v", err)
+	}
+	cc.Done()
+
+	writeCacheEntry(t, m, testHashA, payload)
+	if entryExists(t, dir, testHashC) {
+		t.Fatal("least recently used entry C was not evicted")
+	}
+	if !entryExists(t, dir, testHashB) {
+		t.Fatal("recently used entry B was evicted")
+	}
+	if !entryExists(t, dir, testHashA) {
+		t.Fatal("just written entry A was evicted")
+	}
+}
+
+func TestCacheDoesNotEvictInUseEntry(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	m := NewCacheManager(dir, 1) // everything is over capacity
+
+	// While publishing, the writer itself still references the entry, so it
+	// must survive the eviction that runs at publish time.
+	cache, err := newChunkCache(bytes.NewReader([]byte(payload)), m, testHashA, 0, 1, 0, int64(len(payload)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.LoadAll(); err != nil {
+		t.Fatal(err)
+	}
+	if !entryExists(t, dir, testHashA) {
+		t.Fatal("entry was evicted while its writer was still using it")
+	}
+	// Done drops the writer's reference and must re-evaluate on its own.
+	cache.Done()
+	if entryExists(t, dir, testHashA) {
+		t.Fatal("released entry was not evicted after Done")
+	}
+
+	// Hold a reader on a fresh entry while eviction runs.
+	setCapacity(m, 0) // disable eviction while publishing B
+	writeCacheEntry(t, m, testHashB, payload)
+	reader, err := openCachedRange(m, testHashB, 0, 1)
+	if err != nil || reader == nil {
+		t.Fatalf("open cached range: %v", err)
+	}
+
+	setCapacity(m, 1)
+	m.evaluate()
+	if !entryExists(t, dir, testHashB) {
+		t.Fatal("in-use entry was evicted")
+	}
+
+	buf := make([]byte, 32)
+	n, err := reader.Chunk(0, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf[:n]); got != payload {
+		t.Fatalf("got %q, want %q", got, payload)
+	}
+	// Done drops the reader's reference and must re-evaluate on its own.
+	reader.Done()
+	if entryExists(t, dir, testHashB) {
+		t.Fatal("released entry was not evicted")
+	}
+}
+
+func TestCacheBoundsDirectoryAcrossManagers(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	entrySize := cacheEntryFileSize(payload)
+	// Two managers over the same directory, each with room for two entries.
+	m1 := NewCacheManager(dir, entrySize*2)
+	m2 := NewCacheManager(dir, entrySize*2)
+
+	writeCacheEntry(t, m1, testHashA, payload)
+	writeCacheEntry(t, m2, testHashB, payload)
+	// m1 only ever wrote A, but must still count B when evicting.
+	writeCacheEntry(t, m1, testHashC, payload)
+
+	if entryExists(t, dir, testHashA) {
+		t.Fatal("directory-level bound was not enforced across managers")
+	}
+	for _, h := range []string{testHashB, testHashC} {
+		if !entryExists(t, dir, h) {
+			t.Fatalf("entry %s was evicted unexpectedly", h)
+		}
+	}
+}
+
+func TestCacheEvictionSkipsFlockedEntry(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	m := NewCacheManager(dir, 0)
+
+	finalPath := writeCacheEntry(t, m, testHashA, payload)
+	partialPath, ok := cachePartialPathFor(finalPath)
+	if !ok {
+		t.Fatal("no partial path for final file")
+	}
+
+	// Simulate another process holding the entry's flock.
+	lockFile, err := os.OpenFile(partialPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lockFile.Close()
+	if err := flock.TryLock(lockFile); err != nil {
+		t.Fatal(err)
+	}
+
+	setCapacity(m, 1)
+	m.evaluate()
+	if !entryExists(t, dir, testHashA) {
+		t.Fatal("flocked entry was evicted")
+	}
+
+	if err := flock.Unlock(lockFile); err != nil {
+		t.Fatal(err)
+	}
+	m.evaluate()
+	if entryExists(t, dir, testHashA) {
+		t.Fatal("unlocked entry was not evicted")
+	}
+	if _, err := os.Stat(partialPath); !os.IsNotExist(err) {
+		t.Fatalf("partial file was not removed with the entry: %v", err)
+	}
+}
+
+func TestCacheUnboundedWhenCapacityNotPositive(t *testing.T) {
+	dir := t.TempDir()
+	payload := strings.Repeat("x", 64)
+	m := NewCacheManager(dir, 0)
+
+	for _, h := range []string{testHashA, testHashB, testHashC} {
+		writeCacheEntry(t, m, h, payload)
+	}
+	for _, h := range []string{testHashA, testHashB, testHashC} {
+		if !entryExists(t, dir, h) {
+			t.Fatalf("entry %s was evicted despite unbounded cache", h)
+		}
+	}
+}
+
+func TestCacheScanAdoptsExistingEntriesAndCleansOrphans(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	// Write entries via a throwaway manager so a fresh manager has to
+	// discover them from disk.
+	writer := NewCacheManager(dir, 0)
+	pathA := writeCacheEntry(t, writer, testHashA, payload)
+	pathB := writeCacheEntry(t, writer, testHashB, payload)
+
+	// Make A clearly older than B.
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(pathA, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	// A crashed download leaves an orphaned partial with no published file.
+	orphanDir := filepath.Join(dir, testHashC[:2], testHashC[2:])
+	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orphan := filepath.Join(orphanDir, cacheFileBaseName(0, 1, 0, 10)+".partial")
+	if err := os.WriteFile(orphan, []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fresh := NewCacheManager(dir, cacheEntryFileSize(payload)) // room for one entry
+	fresh.prepare()
+
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphaned partial was not cleaned up: %v", err)
+	}
+	if entryExists(t, dir, testHashA) {
+		t.Fatal("older adopted entry was not evicted")
+	}
+	if !entryExists(t, dir, testHashB) {
+		t.Fatal("newer adopted entry was evicted")
+	}
+	if got := findFinalFile(t, dir, testHashB); got != pathB {
+		t.Fatalf("got %q, want %q", got, pathB)
+	}
+}
+
+func TestCacheScanKeepsPartialOfPublishedEntry(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	finalPath := writeCacheEntry(t, NewCacheManager(dir, 0), testHashA, payload)
+	partialPath, _ := cachePartialPathFor(finalPath)
+
+	fresh := NewCacheManager(dir, 0)
+	fresh.prepare()
+
+	if _, err := os.Stat(partialPath); err != nil {
+		t.Fatalf("partial flock target of published entry was removed: %v", err)
+	}
+	if !entryExists(t, dir, testHashA) {
+		t.Fatal("published entry disappeared")
+	}
+}
+
+func TestCachePartialPathFor(t *testing.T) {
+	final := filepath.Join("cache", "ab", "cdef", "0-4_10-20_1234")
+	got, ok := cachePartialPathFor(final)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	want := filepath.Join("cache", "ab", "cdef", "0-4_10-20.partial")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestCacheEvictionRemovesEmptyDirs(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	m := NewCacheManager(dir, 0)
+	writeCacheEntry(t, m, testHashA, payload)
+
+	setCapacity(m, 1)
+	m.evaluate()
+	if _, err := os.Stat(filepath.Join(dir, testHashA[:2])); !os.IsNotExist(err) {
+		t.Fatalf("empty hash prefix dir was not removed: %v", err)
+	}
+}
+
+func TestCacheEvictionOrderStress(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	entrySize := cacheEntryFileSize(payload)
+	m := NewCacheManager(dir, entrySize*3)
+
+	hashes := make([]string, 6)
+	for i := range hashes {
+		hashes[i] = fmt.Sprintf("%02d11111111111111", i)
+		writeCacheEntry(t, m, hashes[i], payload)
+	}
+	// Only the three most recent entries survive.
+	for _, h := range hashes[:3] {
+		if entryExists(t, dir, h) {
+			t.Fatalf("entry %s should have been evicted", h)
+		}
+	}
+	for _, h := range hashes[3:] {
+		if !entryExists(t, dir, h) {
+			t.Fatalf("entry %s should have survived", h)
+		}
+	}
+}
+
+func TestOpenCachedRangeTreatsUnreadableEntryAsMiss(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod does not restrict reads on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses permission checks")
+	}
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	path := writeCacheEntry(t, m, testHashA, "0123456789")
+	if err := os.Chmod(path, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	cached, err := openCachedRange(m, testHashA, 0, 1)
+	if err != nil {
+		t.Fatalf("unreadable entry should be a cache miss, got error: %v", err)
+	}
+	if cached != nil {
+		cached.Done()
+		t.Fatal("unreadable entry should be a cache miss, got a cache hit")
+	}
+}

--- a/download/chunk_cache.go
+++ b/download/chunk_cache.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/wzshiming/xet/internal/flock"
 	"github.com/wzshiming/xet/internal/pool"
@@ -34,9 +35,12 @@ func newCacheRange(cacheDir, hash string, chunkStart, chunkEnd uint32, bytesStar
 		return cacheRange{}, fmt.Errorf("invalid cache range for hash %q", hash)
 	}
 	return cacheRange{
-		cacheDir: defaultCacheDir(cacheDir),
-		hash:     hash, chunkStart: chunkStart, chunkEnd: chunkEnd,
-		bytesStart: bytesStart, bytesEnd: bytesEnd,
+		cacheDir:   cacheDir,
+		hash:       hash,
+		chunkStart: chunkStart,
+		chunkEnd:   chunkEnd,
+		bytesStart: bytesStart,
+		bytesEnd:   bytesEnd,
 	}, nil
 }
 
@@ -85,6 +89,8 @@ type chunkCache struct {
 	finalBasePath  string
 	expectedChunks uint32
 	published      bool
+	manager        *CacheManager
+	refPaths       []string // cache files acquired from manager, released in Done
 }
 
 // cacheFileBaseName returns the stable portion of a cache entry name.
@@ -140,18 +146,18 @@ func parseCacheFileName(name string) (chunkStart, chunkEnd uint32, bytesStart, b
 // completed file published by the first caller.
 //
 // The caller must call Done() to release the file lock.
-func newChunkCache(dec io.Reader, cacheDir, hash string, chunkStart, chunkEnd uint32, bytesStart, bytesEnd int64) (*chunkCache, error) {
-	lockFile, err := lockChunkCache(cacheDir, hash, chunkStart, chunkEnd, bytesStart, bytesEnd)
+func newChunkCache(dec io.Reader, m *CacheManager, hash string, chunkStart, chunkEnd uint32, bytesStart, bytesEnd int64) (*chunkCache, error) {
+	lockFile, err := lockChunkCache(m.dir, hash, chunkStart, chunkEnd, bytesStart, bytesEnd)
 	if err != nil {
 		return nil, err
 	}
-	cache, err := openCachedRange(cacheDir, hash, chunkStart, chunkEnd)
+	cache, err := openCachedRange(m, hash, chunkStart, chunkEnd)
 	if err != nil || cache != nil {
 		flock.Unlock(lockFile) //nolint:errcheck
 		lockFile.Close()
 		return cache, err
 	}
-	cache, err = newLockedChunkCache(dec, cacheDir, hash, chunkStart, chunkEnd, bytesStart, bytesEnd, lockFile)
+	cache, err = newLockedChunkCache(dec, m, hash, chunkStart, chunkEnd, bytesStart, bytesEnd, lockFile)
 	if err != nil {
 		flock.Unlock(lockFile) //nolint:errcheck
 		lockFile.Close()
@@ -164,23 +170,45 @@ func lockChunkCache(cacheDir, hash string, chunkStart, chunkEnd uint32, bytesSta
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(r.dir(), 0o755); err != nil {
-		return nil, fmt.Errorf("create cache dir: %w", err)
-	}
 
-	lockFile, err := os.OpenFile(r.partialPath(), os.O_RDWR|os.O_CREATE, 0o644)
-	if err != nil {
-		return nil, fmt.Errorf("create partial cache file: %w", err)
-	}
-	if err := flock.Lock(lockFile); err != nil {
+	// Cache eviction may unlink the partial file (or its directory) while a
+	// contender waits on the lock, so verify after locking that the handle
+	// still backs the path and retry on a fresh file otherwise.
+	const maxAttempts = 10
+	for attempt := 0; ; attempt++ {
+		if err := os.MkdirAll(r.dir(), 0o755); err != nil {
+			return nil, fmt.Errorf("create cache dir: %w", err)
+		}
+		lockFile, err := os.OpenFile(r.partialPath(), os.O_RDWR|os.O_CREATE, 0o644)
+		if err != nil {
+			// Retry only races with eviction: the directory vanishing, or a
+			// delete-pending name on Windows (a permission error). Anything
+			// else is a persistent failure.
+			if (os.IsNotExist(err) || os.IsPermission(err)) && attempt < maxAttempts {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			return nil, fmt.Errorf("create partial cache file: %w", err)
+		}
+		if err := flock.Lock(lockFile); err != nil {
+			lockFile.Close()
+			return nil, fmt.Errorf("lock cache file: %w", err)
+		}
+		pathInfo, statErr := os.Stat(r.partialPath())
+		fileInfo, fstatErr := lockFile.Stat()
+		if statErr == nil && fstatErr == nil && os.SameFile(pathInfo, fileInfo) {
+			return lockFile, nil
+		}
+		flock.Unlock(lockFile) //nolint:errcheck
 		lockFile.Close()
-		return nil, fmt.Errorf("lock cache file: %w", err)
+		if attempt >= maxAttempts {
+			return nil, fmt.Errorf("lock cache file: partial file keeps being replaced")
+		}
 	}
-	return lockFile, nil
 }
 
-func newLockedChunkCache(dec io.Reader, cacheDir, hash string, chunkStart, chunkEnd uint32, bytesStart, bytesEnd int64, lockFile *os.File) (*chunkCache, error) {
-	r, err := newCacheRange(cacheDir, hash, chunkStart, chunkEnd, bytesStart, bytesEnd)
+func newLockedChunkCache(dec io.Reader, m *CacheManager, hash string, chunkStart, chunkEnd uint32, bytesStart, bytesEnd int64, lockFile *os.File) (*chunkCache, error) {
+	r, err := newCacheRange(m.dir, hash, chunkStart, chunkEnd, bytesStart, bytesEnd)
 	if err != nil {
 		return nil, err
 	}
@@ -212,6 +240,7 @@ func newLockedChunkCache(dec io.Reader, cacheDir, hash string, chunkStart, chunk
 		partialPath:    r.partialPath(),
 		finalBasePath:  r.basePath(),
 		expectedChunks: numChunks,
+		manager:        m,
 	}, nil
 }
 
@@ -225,15 +254,14 @@ func defaultCacheDir(cacheDir string) string {
 // openCachedRange opens one or more cache files that together cover
 // [chunkStart, chunkEnd). It scans the hash directory and assembles metas
 // from cached files. Returns nil if the range cannot be fully covered.
-func openCachedRange(cacheDir, hash string, chunkStart, chunkEnd uint32) (*chunkCache, error) {
+func openCachedRange(m *CacheManager, hash string, chunkStart, chunkEnd uint32) (*chunkCache, error) {
 	if len(hash) < 2 {
 		return nil, nil
 	}
-	cacheDir = defaultCacheDir(cacheDir)
-	hashDir := filepath.Join(cacheDir, hash[:2], hash[2:])
+	hashDir := filepath.Join(m.dir, hash[:2], hash[2:])
 	files, err := os.ReadDir(hashDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) || os.IsPermission(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -276,10 +304,14 @@ func openCachedRange(cacheDir, hash string, chunkStart, chunkEnd uint32) (*chunk
 		metas []chunkRef
 		file  *os.File
 	}
+	var acquired []string
 	var segments []fileSegment
 	closeSegments := func() {
 		for _, seg := range segments {
 			seg.file.Close()
+		}
+		for _, p := range acquired {
+			m.release(p)
 		}
 	}
 	covered := chunkStart
@@ -301,6 +333,13 @@ func openCachedRange(cacheDir, hash string, chunkStart, chunkEnd uint32) (*chunk
 		f, err := os.Open(c.path)
 		if err != nil {
 			closeSegments()
+			// The entry may have been evicted between listing and opening;
+			// treat it as a cache miss. On Windows an evicted name that is
+			// still open elsewhere stays delete-pending and surfaces as a
+			// permission error.
+			if os.IsNotExist(err) || os.IsPermission(err) {
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -321,6 +360,8 @@ func openCachedRange(cacheDir, hash string, chunkStart, chunkEnd uint32) (*chunk
 			os.Remove(c.path) //nolint:errcheck
 			return nil, nil
 		}
+		m.acquire(c.path, c.size)
+		acquired = append(acquired, c.path)
 		segments = append(segments, fileSegment{metas: metas, file: f})
 		covered = needEnd
 	}
@@ -332,10 +373,10 @@ func openCachedRange(cacheDir, hash string, chunkStart, chunkEnd uint32) (*chunk
 
 	var allMetas []chunkRef
 	for i, seg := range segments {
-		for _, m := range seg.metas {
+		for _, ref := range seg.metas {
 			allMetas = append(allMetas, chunkRef{
-				offset:  m.offset,
-				size:    m.size,
+				offset:  ref.offset,
+				size:    ref.size,
 				fileIdx: i,
 			})
 		}
@@ -350,6 +391,8 @@ func openCachedRange(cacheDir, hash string, chunkStart, chunkEnd uint32) (*chunk
 		readonly: true,
 		file:     segments[0].file,
 		files:    extraFiles,
+		manager:  m,
+		refPaths: acquired,
 	}, nil
 }
 
@@ -555,6 +598,13 @@ func (c *chunkCache) finalize() error {
 		}
 		c.lockFile = nil
 	}
+	if c.manager != nil {
+		// Track the published entry (still referenced by this open cache) and
+		// evict any overage now that the cache grew.
+		c.manager.acquire(finalPath, info.Size())
+		c.refPaths = append(c.refPaths, finalPath)
+		c.manager.evaluate()
+	}
 	return nil
 }
 
@@ -578,5 +628,21 @@ func (c *chunkCache) Done() {
 		f.Close()
 	}
 	c.files = nil
+	var mgr *CacheManager
+	if c.manager != nil {
+		for _, p := range c.refPaths {
+			c.manager.release(p)
+		}
+		if len(c.refPaths) > 0 {
+			mgr = c.manager
+		}
+		c.refPaths = nil
+		c.manager = nil
+	}
 	c.mut.Unlock()
+	if mgr != nil {
+		// References just dropped, so entries kept alive during the download
+		// become evictable now rather than at the next publish.
+		mgr.evaluate()
+	}
 }

--- a/download/chunk_cache_test.go
+++ b/download/chunk_cache_test.go
@@ -20,7 +20,8 @@ const testCacheHash = "0123456789abcdef"
 
 func TestChunkCachePublishesFinalSizeInName(t *testing.T) {
 	dir := t.TempDir()
-	cache, err := newChunkCache(bytes.NewReader([]byte("chunk")), dir, testCacheHash, 0, 1, 10, 20)
+	m := NewCacheManager(dir, 0)
+	cache, err := newChunkCache(bytes.NewReader([]byte("chunk")), m, testCacheHash, 0, 1, 10, 20)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +65,7 @@ func TestChunkCachePublishesFinalSizeInName(t *testing.T) {
 		t.Fatal("partial lock path and final cache path do not reference the same inode")
 	}
 
-	cached, err := openCachedRange(dir, testCacheHash, 0, 1)
+	cached, err := openCachedRange(m, testCacheHash, 0, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +96,7 @@ func TestChunkCacheIgnoresPartialAndWrongSizedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cached, err := openCachedRange(dir, testCacheHash, 0, 1)
+	cached, err := openCachedRange(NewCacheManager(dir, 0), testCacheHash, 0, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +108,7 @@ func TestChunkCacheIgnoresPartialAndWrongSizedFiles(t *testing.T) {
 
 func TestChunkCacheRejectsEarlyEOF(t *testing.T) {
 	dir := t.TempDir()
-	cache, err := newChunkCache(bytes.NewReader([]byte("only-one-chunk")), dir, testCacheHash, 0, 2, 10, 20)
+	cache, err := newChunkCache(bytes.NewReader([]byte("only-one-chunk")), NewCacheManager(dir, 0), testCacheHash, 0, 2, 10, 20)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +123,8 @@ func TestChunkCacheRejectsEarlyEOF(t *testing.T) {
 
 func TestChunkCacheConcurrentWriterReusesPublishedFile(t *testing.T) {
 	dir := t.TempDir()
-	first, err := newChunkCache(bytes.NewReader([]byte("first")), dir, testCacheHash, 0, 1, 10, 20)
+	m := NewCacheManager(dir, 0)
+	first, err := newChunkCache(bytes.NewReader([]byte("first")), m, testCacheHash, 0, 1, 10, 20)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +132,7 @@ func TestChunkCacheConcurrentWriterReusesPublishedFile(t *testing.T) {
 	result := make(chan *chunkCache, 1)
 	errs := make(chan error, 1)
 	go func() {
-		cache, err := newChunkCache(bytes.NewReader([]byte("second")), dir, testCacheHash, 0, 1, 10, 20)
+		cache, err := newChunkCache(bytes.NewReader([]byte("second")), m, testCacheHash, 0, 1, 10, 20)
 		result <- cache
 		errs <- err
 	}()
@@ -211,8 +213,10 @@ func TestPrefetcherLocksBeforeNetworkRequest(t *testing.T) {
 	}
 	entry1 := &prefetchEntry{task: task, ready: make(chan struct{})}
 	entry2 := &prefetchEntry{task: task, ready: make(chan struct{})}
-	p1 := &prefetcher{ctx: context.Background(), client: client, cacheDir: t.TempDir()}
-	p2 := &prefetcher{ctx: context.Background(), client: client, cacheDir: p1.cacheDir}
+	// Separate managers over the same directory simulate two processes.
+	dir := t.TempDir()
+	p1 := &prefetcher{ctx: context.Background(), client: client, cache: NewCacheManager(dir, 0)}
+	p2 := &prefetcher{ctx: context.Background(), client: client, cache: NewCacheManager(dir, 0)}
 
 	done1 := make(chan struct{})
 	done2 := make(chan struct{})

--- a/download/decode_v1.go
+++ b/download/decode_v1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 
 	"github.com/wzshiming/xet/internal/pool"
@@ -29,19 +30,27 @@ type ReaderV1 struct {
 	err          error
 }
 
-// NewReaderV1 creates a new V1 reconstruction reader
-func NewReaderV1(ctx context.Context, client ClientAdapter, reconstruction *ReconstructionResponseV1, cacheDir string, opts ...Option) (io.Reader, error) {
+// NewReaderV1 creates a new V1 reconstruction reader.
+func NewReaderV1(ctx context.Context, client ClientAdapter, reconstruction *ReconstructionResponseV1, opts ...Option) (io.ReadCloser, error) {
 	options := &options{}
 	for _, opt := range opts {
 		opt(options)
 	}
+
+	cache := options.cache
+	if cache == nil {
+		return nil, fmt.Errorf("no cache manager provided")
+	}
+	// Adopt pre-existing entries and clean up orphaned partial files before
+	// the download starts.
+	cache.prepare()
 
 	termFetches, tasks, err := planReaderV1(reconstruction)
 	if err != nil {
 		return nil, fmt.Errorf("plan reader: %w", err)
 	}
 
-	prefetcher, err := newPrefetcher(ctx, client, termFetches, tasks, cacheDir, options)
+	prefetcher, err := newPrefetcher(ctx, client, termFetches, tasks, cache, options)
 	if err != nil {
 		return nil, fmt.Errorf("initialize prefetcher: %w", err)
 	}
@@ -141,6 +150,16 @@ func (r *ReaderV1) cleanup() {
 	r.prefetcher = nil
 	r.currentCache = nil
 	r.currentTerm = nil
+}
+
+// Close releases the prefetcher and all cache references held by the reader.
+// It is safe to call multiple times and after Read has returned io.EOF.
+func (r *ReaderV1) Close() error {
+	r.cleanup()
+	if r.err == nil {
+		r.err = fs.ErrClosed
+	}
+	return nil
 }
 
 // finishCurrentTerm advances to the next reconstruction term.

--- a/download/decode_v2.go
+++ b/download/decode_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 
 	"github.com/wzshiming/xet/internal/pool"
@@ -29,22 +30,31 @@ type ReaderV2 struct {
 	err          error
 }
 
-// NewReaderV2 creates a new V2 reconstruction reader
-func NewReaderV2(ctx context.Context, client ClientAdapter, reconstruction *ReconstructionResponseV2, cacheDir string, opts ...Option) (io.Reader, error) {
+// NewReaderV2 creates a new V2 reconstruction reader.
+func NewReaderV2(ctx context.Context, client ClientAdapter, reconstruction *ReconstructionResponseV2, opts ...Option) (io.ReadCloser, error) {
 	options := &options{}
 	for _, opt := range opts {
 		opt(options)
 	}
+
+	cache := options.cache
+	if cache == nil {
+		return nil, fmt.Errorf("no cache manager provided")
+	}
+	// Adopt pre-existing entries and clean up orphaned partial files before
+	// the download starts.
+	cache.prepare()
 
 	termFetches, tasks, err := planReaderV2(reconstruction)
 	if err != nil {
 		return nil, fmt.Errorf("plan reader: %w", err)
 	}
 
-	prefetcher, err := newPrefetcher(ctx, client, termFetches, tasks, cacheDir, options)
+	prefetcher, err := newPrefetcher(ctx, client, termFetches, tasks, cache, options)
 	if err != nil {
 		return nil, fmt.Errorf("initialize prefetcher: %w", err)
 	}
+
 	return &ReaderV2{
 		client:         client,
 		ctx:            ctx,
@@ -140,6 +150,16 @@ func (r *ReaderV2) cleanup() {
 	r.prefetcher = nil
 	r.currentCache = nil
 	r.currentTerm = nil
+}
+
+// Close releases the prefetcher and all cache references held by the reader.
+// It is safe to call multiple times and after Read has returned io.EOF.
+func (r *ReaderV2) Close() error {
+	r.cleanup()
+	if r.err == nil {
+		r.err = fs.ErrClosed
+	}
+	return nil
 }
 
 // finishCurrentTerm advances to the next reconstruction term.

--- a/download/download.go
+++ b/download/download.go
@@ -10,6 +10,16 @@ type Option func(*options)
 type options struct {
 	concurrency  int
 	progressFunc progress.ProgressFunc
+	cache        *CacheManager
+}
+
+// WithCacheManager shares one CacheManager across readers so the capacity
+// bound applies to the whole cache directory. When unset, each reader uses a
+// private manager for the cacheDir passed to its constructor.
+func WithCacheManager(cache *CacheManager) Option {
+	return func(o *options) {
+		o.cache = cache
+	}
 }
 
 // WithConcurrency configures how many xorb ranges are prefetched concurrently.

--- a/download/prefetcher.go
+++ b/download/prefetcher.go
@@ -53,7 +53,7 @@ type prefetcher struct {
 	client       ClientAdapter
 	entries      map[fetchKey]*prefetchEntry
 	progressFunc progress.ProgressFunc
-	cacheDir     string
+	cache        *CacheManager
 }
 
 type progressReader struct {
@@ -73,7 +73,7 @@ func (r *progressReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func newPrefetcher(ctx context.Context, client ClientAdapter, termFetches []selectedFetch, tasks []fetchTask, cacheDir string, opts *options) (*prefetcher, error) {
+func newPrefetcher(ctx context.Context, client ClientAdapter, termFetches []selectedFetch, tasks []fetchTask, cache *CacheManager, opts *options) (*prefetcher, error) {
 	entries := make(map[fetchKey]*prefetchEntry, len(tasks))
 	items := make([]*prefetchEntry, 0, len(entries))
 	termOrder := make(map[fetchKey]int, len(termFetches))
@@ -110,7 +110,7 @@ func newPrefetcher(ctx context.Context, client ClientAdapter, termFetches []sele
 		client:       client,
 		entries:      entries,
 		progressFunc: opts.progressFunc,
-		cacheDir:     cacheDir,
+		cache:        cache,
 	}
 
 	if err := p.start(items, opts.concurrency); err != nil {
@@ -123,7 +123,7 @@ func newPrefetcher(ctx context.Context, client ClientAdapter, termFetches []sele
 func (p *prefetcher) start(items []*prefetchEntry, desiredWorkers int) error {
 	newItems := make([]*prefetchEntry, 0, len(items))
 	for _, item := range items {
-		cc, err := openCachedRange(p.cacheDir, item.task.key.Hash, item.task.chunkStart, item.task.chunkEnd)
+		cc, err := openCachedRange(p.cache, item.task.key.Hash, item.task.chunkStart, item.task.chunkEnd)
 		if err != nil {
 			return fmt.Errorf("check cache for %s: %w", item.task.key.String(), err)
 		}
@@ -194,7 +194,7 @@ func (p *prefetcher) runJob(entry *prefetchEntry) {
 	var err error
 	key := entry.task.key
 
-	lockFile, err := lockChunkCache(p.cacheDir, key.Hash, entry.task.chunkStart, entry.task.chunkEnd, key.Start, key.End)
+	lockFile, err := lockChunkCache(p.cache.dir, key.Hash, entry.task.chunkStart, entry.task.chunkEnd, key.Start, key.End)
 	if err != nil {
 		p.failEntry(entry, err)
 		return
@@ -208,7 +208,7 @@ func (p *prefetcher) runJob(entry *prefetchEntry) {
 	}()
 
 	// Another process may have populated the cache while this worker waited.
-	cache, err = openCachedRange(p.cacheDir, key.Hash, entry.task.chunkStart, entry.task.chunkEnd)
+	cache, err = openCachedRange(p.cache, key.Hash, entry.task.chunkStart, entry.task.chunkEnd)
 	if err != nil {
 		p.failEntry(entry, err)
 		return
@@ -240,7 +240,7 @@ func (p *prefetcher) runJob(entry *prefetchEntry) {
 	}
 
 	dec := xorb.NewDecoder(reader, false)
-	cache, err = newLockedChunkCache(dec, p.cacheDir, key.Hash, entry.task.chunkStart, entry.task.chunkEnd, key.Start, key.End, lockFile)
+	cache, err = newLockedChunkCache(dec, p.cache, key.Hash, entry.task.chunkStart, entry.task.chunkEnd, key.Start, key.End, lockFile)
 	if err != nil {
 		p.failEntry(entry, err)
 		return


### PR DESCRIPTION
Bound the persistent chunk cache and evict least-recently-used entries once it exceeds the limit, following up on #117 which left the cache growing without bound.

- Track published cache files in an in-memory LRU (`groupcache/lru`), touched once on acquire and once on release; entries still in use are never removed.
- Evaluate eviction only when an entry is published or a download starts, keeping the read path free of extra work.
- Remove entry names only while holding the per-entry `.partial` flock, so concurrent writers in other processes are never disturbed; already-open readers keep their data through the open handles.
- Clean up orphaned `.partial` files left behind by crashed downloads during the once-per-manager directory scan.
- Add `client.WithCacheSize`; defaults to 10 GB matching xet-core's `HF_XET_CHUNK_CACHE_SIZE_BYTES`, zero or negative keeps the cache unbounded.

Fixes #134
