### PR TITLE
feat: verify chunk cache entries with a crc32 checksum

### DIFF
--- a/download/cache_manager.go
+++ b/download/cache_manager.go
@@ -50,6 +50,11 @@ type CacheManager struct {
 	// evaluateLocked drains it for eviction candidates and reconcileLocked
 	// uses it to rebuild the LRU.
 	evicted []evictedEntry
+
+	// verified remembers published entries whose checksum already passed,
+	// keyed by final path, so each entry is verified at most once per
+	// manager.
+	verified sync.Map
 }
 
 // NewCacheManager creates a manager for the chunk cache at cacheDir (empty
@@ -101,6 +106,17 @@ func (m *CacheManager) release(path string) {
 	}
 }
 
+// wasVerified reports whether path already passed checksum verification.
+func (m *CacheManager) wasVerified(path string) bool {
+	_, ok := m.verified.Load(path)
+	return ok
+}
+
+// markVerified remembers that path passed checksum verification.
+func (m *CacheManager) markVerified(path string) {
+	m.verified.Store(path, struct{}{})
+}
+
 // evaluate reconciles tracked state with the cache directory, then evicts
 // least-recently-used entries until the total fits the capacity. Reconciling
 // first keeps the bound directory-level even when other managers or
@@ -134,6 +150,8 @@ func (m *CacheManager) evaluateLocked() {
 				skipped = append(skipped, ev)
 				continue
 			}
+			// A future file reusing this name must be verified afresh.
+			m.verified.Delete(ev.key)
 			m.total -= ev.entry.size
 		}
 	}
@@ -235,6 +253,7 @@ func (m *CacheManager) reconcileLocked() {
 		if !ok {
 			// The name vanished (evicted by another process); open handles
 			// keep the data alive but it no longer occupies the directory.
+			m.verified.Delete(ev.key)
 			continue
 		}
 		ev.entry.size = size

--- a/download/cache_manager_test.go
+++ b/download/cache_manager_test.go
@@ -36,9 +36,9 @@ func setCapacity(m *CacheManager, capacity int64) {
 }
 
 // cacheEntryFileSize is the on-disk size of a single-chunk entry: header
-// (numOffsets + 2 offsets) plus the payload.
+// (crc32 + numOffsets + 2 offsets) plus the payload.
 func cacheEntryFileSize(payload string) int64 {
-	return int64(4 + 4*2 + len(payload))
+	return int64(4 + 4 + 4*2 + len(payload))
 }
 
 func findFinalFile(t *testing.T, dir, hash string) string {

--- a/download/chunk_cache.go
+++ b/download/chunk_cache.go
@@ -3,6 +3,7 @@ package download
 import (
 	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"os"
 	"path/filepath"
@@ -65,12 +66,19 @@ func (r cacheRange) partialPath() string { return r.basePath() + ".partial" }
 //
 // File format (all integers little-endian):
 //
+//	[crc32       uint32]           // checksum of everything after this field
 //	[numOffsets  uint32]           // = numChunks + 1
 //	[offset[0]   uint32]           // always 0
 //	[offset[1]   uint32]           // end of chunk 0
 //	...
 //	[offset[N]   uint32]           // = total data length
 //	[data bytes ...]               // decoded chunks concatenated
+//
+// The crc32 (IEEE) input is the data region followed by the header minus the
+// checksum field, so the streaming writer hashes chunks as they arrive and
+// folds in the offset table when it is patched at publish time. It is checked
+// lazily, on the first open per manager. Files written before the checksum
+// existed (starting directly with numOffsets) are adopted unverified.
 //
 // The .partial file is also the stable flock target. Once complete, the final
 // size-bearing name is hard-linked to the same inode, so data is written once
@@ -88,6 +96,7 @@ type chunkCache struct {
 	partialPath    string
 	finalBasePath  string
 	expectedChunks uint32
+	crc            uint32 // incremental crc32 of the data region while writing
 	published      bool
 	manager        *CacheManager
 	refPaths       []string // cache files acquired from manager, released in Done
@@ -221,12 +230,13 @@ func newLockedChunkCache(dec io.Reader, m *CacheManager, hash string, chunkStart
 	}
 
 	// Write a placeholder header. The actual numOffsets is known from the
-	// chunk range, so we can write the correct header size upfront.
+	// chunk range, so we can write the correct header size upfront. The
+	// leading crc32 stays zero until finalize seals the file.
 	numChunks := chunkEnd - chunkStart
 	numOffsets := numChunks + 1
-	headerSize := 4 + 4*int(numOffsets)
+	headerSize := 8 + 4*int(numOffsets)
 	header := make([]byte, headerSize)
-	binary.LittleEndian.PutUint32(header[0:], numOffsets)
+	binary.LittleEndian.PutUint32(header[4:], numOffsets)
 	// offsets[0] = 0, the rest will be filled in during LoadAll.
 	if _, err := f.WriteAt(header, 0); err != nil {
 		return nil, fmt.Errorf("write header: %w", err)
@@ -352,7 +362,29 @@ func openCachedRange(m *CacheManager, hash string, chunkStart, chunkEnd uint32) 
 			return nil, nil
 		}
 
-		metas, err := readCacheFileMetas(f, c.start, c.end, needStart, needEnd, c.size)
+		layout, err := readCacheFileLayout(f, c.start, c.end)
+		if err != nil {
+			f.Close()
+			closeSegments()
+			// Remove corrupted cache file so it doesn't cause repeated errors.
+			os.Remove(c.path) //nolint:errcheck
+			return nil, nil
+		}
+
+		// Legacy files without a checksum are adopted unverified; new files
+		// are verified once per manager, on their first open.
+		if layout.hasCRC && !m.wasVerified(c.path) {
+			if err := verifyCacheFileCRC(f, layout, c.size); err != nil {
+				f.Close()
+				closeSegments()
+				// Remove the corrupted entry under its flock, like eviction.
+				removeCacheEntryFiles(c.path)
+				return nil, nil
+			}
+			m.markVerified(c.path)
+		}
+
+		metas, err := readCacheFileMetas(f, layout, c.start, needStart, needEnd, c.size)
 		if err != nil {
 			f.Close()
 			closeSegments()
@@ -396,35 +428,99 @@ func openCachedRange(m *CacheManager, hash string, chunkStart, chunkEnd uint32) 
 	}, nil
 }
 
+// cacheFileLayout describes where the offset table and data live in a cache
+// file, and the checksum carried by files written after the crc32 field was
+// added.
+type cacheFileLayout struct {
+	numOffsets  uint32
+	tableOff    int64 // file offset of the offset table
+	headerBytes int64 // total header size; the data region starts here
+	crc         uint32
+	hasCRC      bool
+}
+
+// readCacheFileLayout reads the fixed head of a cache file and decides which
+// layout it uses. New files start with [crc32][numOffsets]; legacy files
+// written before the checksum field start directly with [numOffsets]. The two
+// cannot be confused: the offset count implied by the file name is never
+// zero, while the word after a legacy count is offset[0], which always is.
+func readCacheFileLayout(f *os.File, fileStart, fileEnd uint32) (cacheFileLayout, error) {
+	if fileEnd < fileStart {
+		return cacheFileLayout{}, fmt.Errorf("invalid chunk range")
+	}
+	expected := fileEnd - fileStart + 1
+	var head [8]byte
+	if _, err := f.ReadAt(head[:], 0); err != nil {
+		return cacheFileLayout{}, err
+	}
+	if binary.LittleEndian.Uint32(head[4:]) == expected {
+		return cacheFileLayout{
+			numOffsets:  expected,
+			tableOff:    8,
+			headerBytes: 8 + 4*int64(expected),
+			crc:         binary.LittleEndian.Uint32(head[:4]),
+			hasCRC:      true,
+		}, nil
+	}
+	if binary.LittleEndian.Uint32(head[:4]) == expected {
+		return cacheFileLayout{
+			numOffsets:  expected,
+			tableOff:    4,
+			headerBytes: 4 + 4*int64(expected),
+		}, nil
+	}
+	return cacheFileLayout{}, fmt.Errorf("invalid cache offset count")
+}
+
+// verifyCacheFileCRC re-reads the whole file and compares it against the
+// checksum stored in the header. The CRC input is the data region followed by
+// the header minus the checksum field, the same order finalize feeds the
+// hasher.
+func verifyCacheFileCRC(f *os.File, layout cacheFileLayout, fileSize int64) error {
+	if layout.headerBytes > fileSize {
+		return fmt.Errorf("cache file is smaller than its header")
+	}
+	sum := uint32(0)
+	buf := pool.GetChunkBuf()
+	defer pool.PutChunkBuf(buf)
+	for off := layout.headerBytes; off < fileSize; {
+		n := min(int64(len(buf)), fileSize-off)
+		if _, err := f.ReadAt(buf[:n], off); err != nil {
+			return err
+		}
+		sum = crc32.Update(sum, crc32.IEEETable, buf[:n])
+		off += n
+	}
+	hdr := make([]byte, layout.headerBytes-4)
+	if _, err := f.ReadAt(hdr, 4); err != nil {
+		return err
+	}
+	sum = crc32.Update(sum, crc32.IEEETable, hdr)
+	if sum != layout.crc {
+		return fmt.Errorf("cache file checksum mismatch")
+	}
+	return nil
+}
+
 // readCacheFileMetas reads metas for [chunkStart, chunkEnd) from an already-open
 // cache file. The caller is responsible for closing f in all cases.
-func readCacheFileMetas(f *os.File, fileStart, fileEnd, chunkStart, chunkEnd uint32, fileSize int64) ([]chunkRef, error) {
-	var countBuf [4]byte
-	if _, err := f.ReadAt(countBuf[:], 0); err != nil {
-		return nil, err
-	}
-	numOffsets := binary.LittleEndian.Uint32(countBuf[:])
-	if fileEnd < fileStart || numOffsets != fileEnd-fileStart+1 {
-		return nil, fmt.Errorf("invalid cache offset count")
-	}
-
+func readCacheFileMetas(f *os.File, layout cacheFileLayout, fileStart, chunkStart, chunkEnd uint32, fileSize int64) ([]chunkRef, error) {
 	if chunkStart < fileStart || chunkEnd < chunkStart {
 		return nil, fmt.Errorf("invalid chunk range")
 	}
 	idxStart := int(chunkStart - fileStart)
 	idxEnd := int(chunkEnd - fileStart)
-	if idxEnd >= int(numOffsets) || idxStart > idxEnd {
+	if idxEnd >= int(layout.numOffsets) || idxStart > idxEnd {
 		return nil, fmt.Errorf("invalid chunk range")
 	}
 
 	numChunks := int(chunkEnd - chunkStart)
 	rawBuf := make([]byte, (numChunks+1)*4)
-	if _, err := f.ReadAt(rawBuf, int64(4+idxStart*4)); err != nil {
+	if _, err := f.ReadAt(rawBuf, layout.tableOff+int64(idxStart)*4); err != nil {
 		return nil, err
 	}
 
-	headerBytes := int64(4 + 4*int(numOffsets))
-	dataBytes := fileSize - headerBytes
+	dataBytes := fileSize - layout.headerBytes
 	if dataBytes < 0 {
 		return nil, fmt.Errorf("cache file is smaller than its header")
 	}
@@ -436,7 +532,7 @@ func readCacheFileMetas(f *os.File, fileStart, fileEnd, chunkStart, chunkEnd uin
 			return nil, fmt.Errorf("invalid cache offsets")
 		}
 		metas[i] = chunkRef{
-			offset: headerBytes + int64(start),
+			offset: layout.headerBytes + int64(start),
 			size:   int32(end - start),
 		}
 	}
@@ -499,6 +595,7 @@ func (c *chunkCache) load() (int, error) {
 	if _, werr := c.file.WriteAt(tmp[:n], c.writePos); werr != nil {
 		return 0, fmt.Errorf("write chunk to file: %w", werr)
 	}
+	c.crc = crc32.Update(c.crc, crc32.IEEETable, tmp[:n])
 	c.metas = append(c.metas, chunkRef{offset: c.writePos, size: int32(n)})
 	c.writePos += int64(n)
 	return len(c.metas), nil
@@ -572,11 +669,14 @@ func (c *chunkCache) finalize() error {
 		offsets[i+1] = offsets[i] + uint32(m.size)
 	}
 
-	header := make([]byte, 4+4*int(numOffsets))
-	binary.LittleEndian.PutUint32(header[0:], numOffsets)
+	header := make([]byte, 8+4*int(numOffsets))
+	binary.LittleEndian.PutUint32(header[4:], numOffsets)
 	for i, o := range offsets {
-		binary.LittleEndian.PutUint32(header[4+4*i:], o)
+		binary.LittleEndian.PutUint32(header[8+4*i:], o)
 	}
+	// The data region was hashed chunk by chunk in load; fold in the header
+	// minus the checksum field to seal the file.
+	binary.LittleEndian.PutUint32(header[0:], crc32.Update(c.crc, crc32.IEEETable, header[4:]))
 	if _, err := file.WriteAt(header, 0); err != nil {
 		return fmt.Errorf("write cache header: %w", err)
 	}
@@ -600,8 +700,10 @@ func (c *chunkCache) finalize() error {
 	}
 	if c.manager != nil {
 		// Track the published entry (still referenced by this open cache) and
-		// evict any overage now that the cache grew.
+		// evict any overage now that the cache grew. The freshly synced file
+		// matches the checksum it was sealed with, so remember it as verified.
 		c.manager.acquire(finalPath, info.Size())
+		c.manager.markVerified(finalPath)
 		c.refPaths = append(c.refPaths, finalPath)
 		c.manager.evaluate()
 	}

--- a/download/chunk_cache_test.go
+++ b/download/chunk_cache_test.go
@@ -3,6 +3,8 @@ package download
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -118,6 +120,108 @@ func TestChunkCacheRejectsEarlyEOF(t *testing.T) {
 	cache.Done()
 	if _, err := os.Stat(cache.partialPath); !os.IsNotExist(err) {
 		t.Fatalf("partial cache was not removed: %v", err)
+	}
+}
+
+// corruptLastByte flips the final byte of the file at path.
+func corruptLastByte(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b [1]byte
+	if _, err := f.ReadAt(b[:], info.Size()-1); err != nil {
+		t.Fatal(err)
+	}
+	b[0] ^= 0xff
+	if _, err := f.WriteAt(b[:], info.Size()-1); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestChunkCacheRemovesEntryOnChecksumMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeCacheEntry(t, NewCacheManager(dir, 0), testCacheHash, "chunk")
+	corruptLastByte(t, findFinalFile(t, dir, testCacheHash))
+
+	// A fresh manager has no verification memory, so the first open must
+	// detect the corruption, drop the entry, and report a miss.
+	cached, err := openCachedRange(NewCacheManager(dir, 0), testCacheHash, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached != nil {
+		cached.Done()
+		t.Fatal("corrupted cache entry was served")
+	}
+	if entryExists(t, dir, testCacheHash) {
+		t.Fatal("corrupted cache entry was not removed")
+	}
+}
+
+func TestChunkCacheVerifiesChecksumOncePerManager(t *testing.T) {
+	dir := t.TempDir()
+	writeCacheEntry(t, NewCacheManager(dir, 0), testCacheHash, "chunk")
+
+	m := NewCacheManager(dir, 0)
+	cached, err := openCachedRange(m, testCacheHash, 0, 1)
+	if err != nil || cached == nil {
+		t.Fatalf("open cached range: %v", err)
+	}
+	cached.Done()
+
+	// Corruption after the first verified open goes unnoticed by the same
+	// manager: verification is lazy and runs at most once per entry.
+	corruptLastByte(t, findFinalFile(t, dir, testCacheHash))
+	cached, err = openCachedRange(m, testCacheHash, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached == nil {
+		t.Fatal("verified entry was re-verified and dropped")
+	}
+	cached.Done()
+}
+
+func TestChunkCacheAdoptsLegacyEntryWithoutChecksum(t *testing.T) {
+	dir := t.TempDir()
+	payload := "legacy-chunk"
+	// Legacy layout: [numOffsets][offset0][offset1][data], no crc32 field.
+	header := make([]byte, 12)
+	binary.LittleEndian.PutUint32(header[0:], 2)
+	binary.LittleEndian.PutUint32(header[8:], uint32(len(payload)))
+	content := append(header, payload...)
+
+	base := cacheFileBasePath(dir, testCacheHash, 0, 1, 0, int64(len(payload)))
+	if err := os.MkdirAll(filepath.Dir(base), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := fmt.Sprintf("%s_%d", base, len(content))
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cached, err := openCachedRange(NewCacheManager(dir, 0), testCacheHash, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached == nil {
+		t.Fatal("legacy cache entry was not adopted")
+	}
+	defer cached.Done()
+	buf := make([]byte, 32)
+	n, err := cached.Chunk(0, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf[:n]); got != payload {
+		t.Fatalf("got %q, want %q", got, payload)
 	}
 }
 


### PR DESCRIPTION
Add a crc32 to published chunk cache entries and verify it lazily, following up on #134 which left cache contents unchecked, so on-disk corruption (bit rot, truncated-then-extended writes) no longer flows back to readers as valid chunk data.

- Prepend a crc32 field to the cache file header (`[crc32][numOffsets][offsets...][data]`); the published name keeps its `<chunkStart>-<chunkEnd>_<bytesStart>-<bytesEnd>_<fileSize>` shape. This deliberately diverges from xet-core, which embeds the checksum in the file name.
- Hash the data region chunk by chunk as it streams through `load` and fold in the patched offset table at publish time, so sealing needs no extra read pass.
- Verify on the first open per manager and remember the result in memory; repeated hits stay cheap and the per-chunk read path is untouched.
- On mismatch, remove the entry under its `.partial` flock (the same path eviction uses) and treat the lookup as a miss so the range is re-downloaded.
- Adopt entries written before the checksum existed unverified: the legacy layout is detected from the offset count implied by the file name (its first offset entry is always zero), so an upgrade keeps the existing cache.

Fixes #136
