### PR TITLE
feat: drop the .partial file from the chunk cache

### DIFF
--- a/download/cache_manager.go
+++ b/download/cache_manager.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -35,10 +34,10 @@ type evictedEntry struct {
 // evaluated when an entry is published or released, never on the read path,
 // and every evaluation first reconciles the tracked state with the directory
 // so the bound holds even when several managers or processes share it.
-// Cross-process (and cross-manager) safety relies on the per-entry .partial
-// flock: names are only unlinked while holding that lock, so active writers
-// are never disturbed, and already-open readers keep their data through the
-// open handles even after the names are removed.
+// Cross-process (and cross-manager) safety relies on the flock on the entry
+// file itself: names are only unlinked while holding that lock, so active
+// writers are never disturbed, and already-open readers keep their data
+// through the open handles even after the names are removed.
 type CacheManager struct {
 	mu       sync.Mutex
 	dir      string
@@ -76,8 +75,8 @@ func NewCacheManager(cacheDir string, capacity int64) *CacheManager {
 }
 
 // prepare reconciles tracked state with the cache directory (adopting
-// pre-existing entries and removing orphaned .partial files) and evicts any
-// overage before a download starts.
+// pre-existing entries and removing crashed incomplete entries) and evicts
+// any overage before a download starts.
 func (m *CacheManager) prepare() {
 	m.evaluate()
 }
@@ -88,7 +87,11 @@ func (m *CacheManager) acquire(path string, size int64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if v, ok := m.lru.Get(path); ok {
-		v.(*cacheEntry).refs++
+		e := v.(*cacheEntry)
+		e.refs++
+		// The name may back a recreated file; refresh the tracked size.
+		m.total += size - e.size
+		e.size = size
 		return
 	}
 	m.lru.Add(path, &cacheEntry{size: size, refs: 1})
@@ -146,7 +149,7 @@ func (m *CacheManager) evaluateLocked() {
 			}
 			// Entries in use here or locked by another process are kept and
 			// become most recently used.
-			if ev.entry.refs > 0 || !removeCacheEntryFiles(ev.key) {
+			if ev.entry.refs > 0 || !removeCacheEntry(ev.key) {
 				skipped = append(skipped, ev)
 				continue
 			}
@@ -162,8 +165,8 @@ func (m *CacheManager) evaluateLocked() {
 
 // reconcileLocked re-reads the cache directory so the tracked state matches
 // disk: entries created by other managers or processes are adopted, entries
-// removed elsewhere are dropped, sizes are refreshed, and orphaned .partial
-// files left behind by crashed downloads are cleaned up. The recency order
+// removed elsewhere are dropped, sizes are refreshed, and incomplete entries
+// left behind by crashed downloads are cleaned up. The recency order
 // and refs of already-tracked entries are preserved.
 func (m *CacheManager) reconcileLocked() {
 	type diskEntry struct {
@@ -194,38 +197,31 @@ func (m *CacheManager) reconcileLocked() {
 			if err != nil {
 				continue
 			}
-			published := make(map[string]bool)
-			var partials []string
 			for _, de := range entries {
 				name := de.Name()
 				if de.IsDir() {
 					continue
 				}
-				if strings.HasSuffix(name, ".partial") {
-					partials = append(partials, name)
-					continue
-				}
-				if _, _, _, _, _, ok := parseCacheFileName(name); !ok {
+				cs, ce, _, _, ok := parseCacheFileName(name)
+				if !ok {
 					continue
 				}
 				info, err := de.Info()
 				if err != nil {
 					continue
 				}
-				published[name[:strings.LastIndex(name, "_")]] = true
-				// Account the real on-disk size; a corrupt entry whose size
-				// does not match its name must not inflate the total.
+				path := filepath.Join(dir, name)
+				if !isCompleteCacheFile(path, cs, ce, info.Size()) {
+					// Either an active download (protected by its flock) or a
+					// crashed leftover; only the latter can be removed.
+					removeIncompleteCacheEntry(path, cs, ce)
+					continue
+				}
 				found = append(found, diskEntry{
-					path:    filepath.Join(dir, name),
+					path:    path,
 					size:    info.Size(),
 					modTime: info.ModTime(),
 				})
-			}
-			for _, name := range partials {
-				if published[strings.TrimSuffix(name, ".partial")] {
-					continue
-				}
-				removeOrphanPartial(filepath.Join(dir, name))
 			}
 		}
 	}
@@ -274,37 +270,29 @@ func (m *CacheManager) reconcileLocked() {
 	}
 }
 
-// cachePartialPathFor returns the .partial flock target for a published cache
-// file path by stripping the trailing _<fileSize> component.
-func cachePartialPathFor(finalPath string) (string, bool) {
-	name := filepath.Base(finalPath)
-	idx := strings.LastIndex(name, "_")
-	if idx <= 0 {
-		return "", false
-	}
-	return filepath.Join(filepath.Dir(finalPath), name[:idx]+".partial"), true
-}
-
-// removeCacheEntryFiles unlinks a published cache file together with its
-// .partial flock target (both names share one inode). Names are only removed
-// while holding the entry's flock, so a writer that is mid-publish is never
-// disturbed. Returns false when the entry is in use elsewhere and must be
-// kept.
-func removeCacheEntryFiles(finalPath string) bool {
-	partialPath, ok := cachePartialPathFor(finalPath)
-	if !ok {
+// isCompleteCacheFile reports whether the file at path is a sealed cache
+// entry for the chunk range in its name.
+func isCompleteCacheFile(path string, chunkStart, chunkEnd uint32, size int64) bool {
+	f, err := os.Open(path)
+	if err != nil {
 		return false
 	}
-	lockFile, err := os.OpenFile(partialPath, os.O_RDWR, 0)
+	defer f.Close()
+	_, err = readCacheFileLayout(f, chunkStart, chunkEnd, size)
+	return err == nil
+}
+
+// removeCacheEntry unlinks a cache entry file. The name is only removed
+// while holding the entry's flock, so an active writer is never disturbed.
+// Returns false when the entry is in use elsewhere and must be kept.
+func removeCacheEntry(path string) bool {
+	lockFile, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return false
 		}
-		// No flock target left, so no writer can be active on this entry.
-		if err := os.Remove(finalPath); err != nil && !os.IsNotExist(err) {
-			return false
-		}
-		removeEmptyCacheDirs(finalPath)
+		// The name is already gone (removed by another process).
+		removeEmptyCacheDirs(path)
 		return true
 	}
 	defer lockFile.Close()
@@ -312,24 +300,23 @@ func removeCacheEntryFiles(finalPath string) bool {
 		return false
 	}
 	defer flock.Unlock(lockFile) //nolint:errcheck
-	// Only remove names while the locked handle still backs partialPath;
-	// otherwise another process already recycled this entry.
-	pathInfo, statErr := os.Stat(partialPath)
+	// Only remove the name while the locked handle still backs it; otherwise
+	// another process already recycled this entry.
+	pathInfo, statErr := os.Stat(path)
 	fileInfo, fstatErr := lockFile.Stat()
 	if statErr != nil || fstatErr != nil || !os.SameFile(pathInfo, fileInfo) {
 		return false
 	}
-	if err := os.Remove(finalPath); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return false
 	}
-	os.Remove(partialPath) //nolint:errcheck
-	removeEmptyCacheDirs(finalPath)
+	removeEmptyCacheDirs(path)
 	return true
 }
 
-// removeOrphanPartial removes a .partial file that has no published sibling,
-// but only if no writer holds its flock.
-func removeOrphanPartial(path string) {
+// removeIncompleteCacheEntry removes a crashed leftover, but only if no
+// writer holds its flock and it is still incomplete once the lock is held.
+func removeIncompleteCacheEntry(path string, chunkStart, chunkEnd uint32) {
 	lockFile, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return
@@ -342,6 +329,10 @@ func removeOrphanPartial(path string) {
 	pathInfo, statErr := os.Stat(path)
 	fileInfo, fstatErr := lockFile.Stat()
 	if statErr != nil || fstatErr != nil || !os.SameFile(pathInfo, fileInfo) {
+		return
+	}
+	// The writer may have sealed the file between the check and the lock.
+	if _, err := readCacheFileLayout(lockFile, chunkStart, chunkEnd, fileInfo.Size()); err == nil {
 		return
 	}
 	os.Remove(path) //nolint:errcheck

--- a/download/cache_manager_test.go
+++ b/download/cache_manager_test.go
@@ -52,7 +52,7 @@ func findFinalFile(t *testing.T, dir, hash string) string {
 		t.Fatal(err)
 	}
 	for _, de := range entries {
-		if _, _, _, _, _, ok := parseCacheFileName(de.Name()); ok {
+		if _, _, _, _, ok := parseCacheFileName(de.Name()); ok {
 			return filepath.Join(hashDir, de.Name())
 		}
 	}
@@ -190,13 +190,9 @@ func TestCacheEvictionSkipsFlockedEntry(t *testing.T) {
 	m := NewCacheManager(dir, 0)
 
 	finalPath := writeCacheEntry(t, m, testHashA, payload)
-	partialPath, ok := cachePartialPathFor(finalPath)
-	if !ok {
-		t.Fatal("no partial path for final file")
-	}
 
 	// Simulate another process holding the entry's flock.
-	lockFile, err := os.OpenFile(partialPath, os.O_RDWR, 0)
+	lockFile, err := os.OpenFile(finalPath, os.O_RDWR, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,9 +213,6 @@ func TestCacheEvictionSkipsFlockedEntry(t *testing.T) {
 	m.evaluate()
 	if entryExists(t, dir, testHashA) {
 		t.Fatal("unlocked entry was not evicted")
-	}
-	if _, err := os.Stat(partialPath); !os.IsNotExist(err) {
-		t.Fatalf("partial file was not removed with the entry: %v", err)
 	}
 }
 
@@ -253,12 +246,12 @@ func TestCacheScanAdoptsExistingEntriesAndCleansOrphans(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// A crashed download leaves an orphaned partial with no published file.
+	// A crashed download leaves an incomplete entry with no lock holder.
 	orphanDir := filepath.Join(dir, testHashC[:2], testHashC[2:])
 	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	orphan := filepath.Join(orphanDir, cacheFileBaseName(0, 1, 0, 10)+".partial")
+	orphan := filepath.Join(orphanDir, cacheFileName(0, 1, 0, 10))
 	if err := os.WriteFile(orphan, []byte("junk"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +260,7 @@ func TestCacheScanAdoptsExistingEntriesAndCleansOrphans(t *testing.T) {
 	fresh.prepare()
 
 	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
-		t.Fatalf("orphaned partial was not cleaned up: %v", err)
+		t.Fatalf("crashed leftover was not cleaned up: %v", err)
 	}
 	if entryExists(t, dir, testHashA) {
 		t.Fatal("older adopted entry was not evicted")
@@ -280,32 +273,31 @@ func TestCacheScanAdoptsExistingEntriesAndCleansOrphans(t *testing.T) {
 	}
 }
 
-func TestCacheScanKeepsPartialOfPublishedEntry(t *testing.T) {
+func TestCacheScanKeepsLockedIncompleteEntry(t *testing.T) {
 	dir := t.TempDir()
-	payload := "0123456789"
-	finalPath := writeCacheEntry(t, NewCacheManager(dir, 0), testHashA, payload)
-	partialPath, _ := cachePartialPathFor(finalPath)
+	path := cacheFilePath(dir, testHashA, 0, 1, 0, 10)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("in-progress"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate an active writer holding the entry's flock.
+	lockFile, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lockFile.Close()
+	if err := flock.TryLock(lockFile); err != nil {
+		t.Fatal(err)
+	}
+	defer flock.Unlock(lockFile) //nolint:errcheck
 
 	fresh := NewCacheManager(dir, 0)
 	fresh.prepare()
 
-	if _, err := os.Stat(partialPath); err != nil {
-		t.Fatalf("partial flock target of published entry was removed: %v", err)
-	}
-	if !entryExists(t, dir, testHashA) {
-		t.Fatal("published entry disappeared")
-	}
-}
-
-func TestCachePartialPathFor(t *testing.T) {
-	final := filepath.Join("cache", "ab", "cdef", "0-4_10-20_1234")
-	got, ok := cachePartialPathFor(final)
-	if !ok {
-		t.Fatal("expected ok")
-	}
-	want := filepath.Join("cache", "ab", "cdef", "0-4_10-20.partial")
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("locked in-progress entry was removed: %v", err)
 	}
 }
 

--- a/download/chunk_cache.go
+++ b/download/chunk_cache.go
@@ -49,20 +49,17 @@ func (r cacheRange) dir() string {
 	return filepath.Join(r.cacheDir, r.hash[:2], r.hash[2:])
 }
 
-func (r cacheRange) basePath() string {
-	return filepath.Join(r.dir(), cacheFileBaseName(r.chunkStart, r.chunkEnd, r.bytesStart, r.bytesEnd))
+func (r cacheRange) path() string {
+	return filepath.Join(r.dir(), cacheFileName(r.chunkStart, r.chunkEnd, r.bytesStart, r.bytesEnd))
 }
-
-func (r cacheRange) partialPath() string { return r.basePath() + ".partial" }
 
 // chunkCache is the single cache for decoded xorb chunk ranges.
 //
 // Each entry is stored as a single file at:
 //
-//	cacheDir/<hash[:2]>/<hash[2:]>/<chunkStart>-<chunkEnd>_<bytesStart>-<bytesEnd>_<fileSize>
+//	cacheDir/<hash[:2]>/<hash[2:]>/<chunkStart>-<chunkEnd>_<bytesStart>-<bytesEnd>
 //
-// where bytesStart and bytesEnd identify the source xorb byte range and
-// fileSize is the exact size of the completed cache file.
+// where bytesStart and bytesEnd identify the source xorb byte range.
 //
 // File format (all integers little-endian):
 //
@@ -76,13 +73,16 @@ func (r cacheRange) partialPath() string { return r.basePath() + ".partial" }
 //
 // The crc32 (IEEE) input is the data region followed by the header, so the
 // streaming writer hashes chunks as they arrive and folds in the offset table
-// when it is patched at publish time. It is checked lazily, on the first open
-// per manager. Files written before the trailer existed (ending right after
-// the data region) are adopted unverified.
+// when it is patched at seal time. It is checked lazily, on the first open
+// per manager.
 //
-// The .partial file is also the stable flock target. Once complete, the final
-// size-bearing name is hard-linked to the same inode, so data is written once
-// and readers only consider published final names.
+// The entry file itself is the flock target, held by its writer from creation
+// until the file is sealed. Completeness is arithmetic: the name fixes the
+// header size, so a file is complete exactly when its size equals the header
+// plus offset[N] plus the trailer. A file only grows from incomplete to
+// complete and complete files are never rewritten, only unlinked, so readers
+// adopt them without locking. Writers truncate leftovers of crashed downloads
+// in place; that is safe because readers never adopt incomplete files.
 type chunkCache struct {
 	dec            io.Reader
 	metas          []chunkRef
@@ -93,8 +93,7 @@ type chunkCache struct {
 	file           *os.File   // backing file
 	files          []*os.File // additional files for multi-file read path (fileIdx > 0)
 	lockFile       *os.File   // same handle as file while the write lock is held
-	partialPath    string
-	finalBasePath  string
+	path           string     // entry file path
 	expectedChunks uint32
 	crc            uint32 // incremental crc32 of the data region while writing
 	published      bool
@@ -102,21 +101,21 @@ type chunkCache struct {
 	refPaths       []string // cache files acquired from manager, released in Done
 }
 
-// cacheFileBaseName returns the stable portion of a cache entry name.
-func cacheFileBaseName(start, end uint32, bytesStart, bytesEnd int64) string {
+// cacheFileName returns the entry file name for a chunk range.
+func cacheFileName(start, end uint32, bytesStart, bytesEnd int64) string {
 	return fmt.Sprintf("%d-%d_%d-%d", start, end, bytesStart, bytesEnd)
 }
 
-func cacheFileBasePath(cacheDir, hash string, start, end uint32, bytesStart, bytesEnd int64) string {
-	return filepath.Join(cacheDir, hash[:2], hash[2:], cacheFileBaseName(start, end, bytesStart, bytesEnd))
+func cacheFilePath(cacheDir, hash string, start, end uint32, bytesStart, bytesEnd int64) string {
+	return filepath.Join(cacheDir, hash[:2], hash[2:], cacheFileName(start, end, bytesStart, bytesEnd))
 }
 
 // parseCacheFileName parses a filename of the form
-// "<chunkStart>-<chunkEnd>_<bytesStart>-<bytesEnd>_<fileSize>" and returns the components.
+// "<chunkStart>-<chunkEnd>_<bytesStart>-<bytesEnd>" and returns the components.
 // Returns ok=false if parsing fails.
-func parseCacheFileName(name string) (chunkStart, chunkEnd uint32, bytesStart, bytesEnd, fileSize int64, ok bool) {
+func parseCacheFileName(name string) (chunkStart, chunkEnd uint32, bytesStart, bytesEnd int64, ok bool) {
 	parts := strings.Split(name, "_")
-	if len(parts) != 3 {
+	if len(parts) != 2 {
 		return
 	}
 	chunkParts := strings.SplitN(parts[0], "-", 2)
@@ -143,11 +142,10 @@ func parseCacheFileName(name string) (chunkStart, chunkEnd uint32, bytesStart, b
 	if err != nil || be < 0 {
 		return
 	}
-	size, err := strconv.ParseInt(parts[2], 10, 64)
-	if err != nil || size <= 0 || ce < cs || be < bs {
+	if ce < cs || be < bs {
 		return
 	}
-	return uint32(cs), uint32(ce), bs, be, size, true
+	return uint32(cs), uint32(ce), bs, be, true
 }
 
 // newChunkCache creates a chunkCache that decodes chunks from dec and writes
@@ -180,7 +178,7 @@ func lockChunkCache(cacheDir, hash string, chunkStart, chunkEnd uint32, bytesSta
 		return nil, err
 	}
 
-	// Cache eviction may unlink the partial file (or its directory) while a
+	// Cache eviction may unlink the entry file (or its directory) while a
 	// contender waits on the lock, so verify after locking that the handle
 	// still backs the path and retry on a fresh file otherwise.
 	const maxAttempts = 10
@@ -188,7 +186,7 @@ func lockChunkCache(cacheDir, hash string, chunkStart, chunkEnd uint32, bytesSta
 		if err := os.MkdirAll(r.dir(), 0o755); err != nil {
 			return nil, fmt.Errorf("create cache dir: %w", err)
 		}
-		lockFile, err := os.OpenFile(r.partialPath(), os.O_RDWR|os.O_CREATE, 0o644)
+		lockFile, err := os.OpenFile(r.path(), os.O_RDWR|os.O_CREATE, 0o644)
 		if err != nil {
 			// Retry only races with eviction: the directory vanishing, or a
 			// delete-pending name on Windows (a permission error). Anything
@@ -197,13 +195,13 @@ func lockChunkCache(cacheDir, hash string, chunkStart, chunkEnd uint32, bytesSta
 				time.Sleep(10 * time.Millisecond)
 				continue
 			}
-			return nil, fmt.Errorf("create partial cache file: %w", err)
+			return nil, fmt.Errorf("create cache file: %w", err)
 		}
 		if err := flock.Lock(lockFile); err != nil {
 			lockFile.Close()
 			return nil, fmt.Errorf("lock cache file: %w", err)
 		}
-		pathInfo, statErr := os.Stat(r.partialPath())
+		pathInfo, statErr := os.Stat(r.path())
 		fileInfo, fstatErr := lockFile.Stat()
 		if statErr == nil && fstatErr == nil && os.SameFile(pathInfo, fileInfo) {
 			return lockFile, nil
@@ -211,7 +209,7 @@ func lockChunkCache(cacheDir, hash string, chunkStart, chunkEnd uint32, bytesSta
 		flock.Unlock(lockFile) //nolint:errcheck
 		lockFile.Close()
 		if attempt >= maxAttempts {
-			return nil, fmt.Errorf("lock cache file: partial file keeps being replaced")
+			return nil, fmt.Errorf("lock cache file: entry file keeps being replaced")
 		}
 	}
 }
@@ -222,11 +220,11 @@ func newLockedChunkCache(dec io.Reader, m *CacheManager, hash string, chunkStart
 		return nil, err
 	}
 
-	// The locked partial file is the backing data file. Reuse its inode so all
-	// current and future contenders synchronize on the same flock target.
+	// The locked entry file is the backing data file; truncation discards any
+	// leftover from a crashed download, which readers never adopt.
 	f := lockFile
 	if err := f.Truncate(0); err != nil {
-		return nil, fmt.Errorf("truncate partial cache file: %w", err)
+		return nil, fmt.Errorf("truncate cache file: %w", err)
 	}
 
 	// Write a placeholder header. The actual numOffsets is known from the
@@ -246,8 +244,7 @@ func newLockedChunkCache(dec io.Reader, m *CacheManager, hash string, chunkStart
 		file:           f,
 		writePos:       int64(headerSize), // data starts after the header
 		lockFile:       lockFile,
-		partialPath:    r.partialPath(),
-		finalBasePath:  r.basePath(),
+		path:           r.path(),
 		expectedChunks: numChunks,
 		manager:        m,
 	}, nil
@@ -279,14 +276,13 @@ func openCachedRange(m *CacheManager, hash string, chunkStart, chunkEnd uint32) 
 	type candidate struct {
 		path       string
 		start, end uint32
-		size       int64
 	}
 	var candidates []candidate
 	for _, de := range files {
 		if de.IsDir() || strings.HasPrefix(de.Name(), ".") {
 			continue
 		}
-		cs, ce, _, _, size, ok := parseCacheFileName(de.Name())
+		cs, ce, _, _, ok := parseCacheFileName(de.Name())
 		if !ok {
 			continue
 		}
@@ -297,7 +293,6 @@ func openCachedRange(m *CacheManager, hash string, chunkStart, chunkEnd uint32) 
 			path:  filepath.Join(hashDir, de.Name()),
 			start: cs,
 			end:   ce,
-			size:  size,
 		})
 	}
 
@@ -341,43 +336,37 @@ func openCachedRange(m *CacheManager, hash string, chunkStart, chunkEnd uint32) 
 
 		f, err := os.Open(c.path)
 		if err != nil {
-			closeSegments()
 			// The entry may have been evicted between listing and opening;
-			// treat it as a cache miss. On Windows an evicted name that is
-			// still open elsewhere stays delete-pending and surfaces as a
-			// permission error.
+			// skip it. On Windows an evicted name that is still open elsewhere
+			// stays delete-pending and surfaces as a permission error.
 			if os.IsNotExist(err) || os.IsPermission(err) {
-				return nil, nil
+				continue
 			}
+			closeSegments()
 			return nil, err
 		}
 
-		// The final size is part of the published filename. A mismatch means
-		// the entry is incomplete or corrupted.
-		if fi, statErr := f.Stat(); statErr != nil || fi.Size() != c.size {
+		fi, statErr := f.Stat()
+		if statErr != nil {
 			f.Close()
-			closeSegments()
-			os.Remove(c.path) //nolint:errcheck
-			return nil, nil
+			continue
 		}
 
-		layout, err := readCacheFileLayout(f, c.start, c.end, c.size)
+		layout, err := readCacheFileLayout(f, c.start, c.end, fi.Size())
 		if err != nil {
+			// Still being written, or a crashed leftover; both are invisible
+			// to readers. Cleanup happens under the entry flock in reconcile.
 			f.Close()
-			closeSegments()
-			// Remove corrupted cache file so it doesn't cause repeated errors.
-			os.Remove(c.path) //nolint:errcheck
-			return nil, nil
+			continue
 		}
 
-		// Legacy files without a checksum are adopted unverified; new files
-		// are verified once per manager, on their first open.
-		if layout.hasCRC && !m.wasVerified(c.path) {
+		// Entries are verified once per manager, on their first open.
+		if !m.wasVerified(c.path) {
 			if err := verifyCacheFileCRC(f, layout); err != nil {
 				f.Close()
 				closeSegments()
 				// Remove the corrupted entry under its flock, like eviction.
-				removeCacheEntryFiles(c.path)
+				removeCacheEntry(c.path)
 				return nil, nil
 			}
 			m.markVerified(c.path)
@@ -387,11 +376,11 @@ func openCachedRange(m *CacheManager, hash string, chunkStart, chunkEnd uint32) 
 		if err != nil {
 			f.Close()
 			closeSegments()
-			// Remove corrupted cache file so it doesn't cause repeated errors.
-			os.Remove(c.path) //nolint:errcheck
+			// Remove the corrupted entry under its flock, like eviction.
+			removeCacheEntry(c.path)
 			return nil, nil
 		}
-		m.acquire(c.path, c.size)
+		m.acquire(c.path, fi.Size())
 		acquired = append(acquired, c.path)
 		segments = append(segments, fileSegment{metas: metas, file: f})
 		covered = needEnd
@@ -427,25 +416,27 @@ func openCachedRange(m *CacheManager, hash string, chunkStart, chunkEnd uint32) 
 	}, nil
 }
 
-// cacheFileLayout describes where the offset table and data live in a cache
-// file, and the checksum trailer carried by files written after it was added.
+// cacheFileLayout describes where the offset table, data, and checksum
+// trailer live in a sealed cache file.
 type cacheFileLayout struct {
 	numOffsets  uint32
 	headerBytes int64 // offset table ends here; the data region starts here
-	dataBytes   int64 // decoded data length; the trailer (if any) follows
+	dataBytes   int64 // decoded data length; the trailer follows
 	crc         uint32
-	hasCRC      bool
 }
 
-// readCacheFileLayout reads the offset count and decides which layout the
-// file uses via exact size arithmetic: files written before the checksum
-// existed end right after the data region, while current files carry a
-// trailing crc32. Anything else is structurally invalid.
+// readCacheFileLayout validates the exact size arithmetic that defines a
+// sealed entry: header, data, then a trailing crc32. Any other size means
+// the file is still being written or is a crashed leftover.
 func readCacheFileLayout(f *os.File, fileStart, fileEnd uint32, fileSize int64) (cacheFileLayout, error) {
 	if fileEnd < fileStart {
 		return cacheFileLayout{}, fmt.Errorf("invalid chunk range")
 	}
 	expected := fileEnd - fileStart + 1
+	headerBytes := 4 + 4*int64(expected)
+	if fileSize < headerBytes+4 {
+		return cacheFileLayout{}, fmt.Errorf("cache file incomplete")
+	}
 	var head [4]byte
 	if _, err := f.ReadAt(head[:], 0); err != nil {
 		return cacheFileLayout{}, err
@@ -453,7 +444,6 @@ func readCacheFileLayout(f *os.File, fileStart, fileEnd uint32, fileSize int64) 
 	if binary.LittleEndian.Uint32(head[:]) != expected {
 		return cacheFileLayout{}, fmt.Errorf("invalid cache offset count")
 	}
-	headerBytes := 4 + 4*int64(expected)
 	var lastBuf [4]byte
 	if _, err := f.ReadAt(lastBuf[:], headerBytes-4); err != nil {
 		return cacheFileLayout{}, err
@@ -463,20 +453,15 @@ func readCacheFileLayout(f *os.File, fileStart, fileEnd uint32, fileSize int64) 
 		headerBytes: headerBytes,
 		dataBytes:   int64(binary.LittleEndian.Uint32(lastBuf[:])),
 	}
-	switch fileSize {
-	case layout.headerBytes + layout.dataBytes:
-		// Legacy layout without a checksum trailer.
-		return layout, nil
-	case layout.headerBytes + layout.dataBytes + 4:
-		var crcBuf [4]byte
-		if _, err := f.ReadAt(crcBuf[:], fileSize-4); err != nil {
-			return cacheFileLayout{}, err
-		}
-		layout.crc = binary.LittleEndian.Uint32(crcBuf[:])
-		layout.hasCRC = true
-		return layout, nil
+	if fileSize != layout.headerBytes+layout.dataBytes+4 {
+		return cacheFileLayout{}, fmt.Errorf("cache file incomplete")
 	}
-	return cacheFileLayout{}, fmt.Errorf("cache file size mismatch")
+	var crcBuf [4]byte
+	if _, err := f.ReadAt(crcBuf[:], fileSize-4); err != nil {
+		return cacheFileLayout{}, err
+	}
+	layout.crc = binary.LittleEndian.Uint32(crcBuf[:])
+	return layout, nil
 }
 
 // verifyCacheFileCRC re-reads the whole file and compares it against the
@@ -643,8 +628,10 @@ func (c *chunkCache) LoadAll() error {
 	}
 }
 
-// finalize patches the offset table in the header with the actual chunk sizes,
-// then syncs the file to disk. No-op for read-only caches.
+// finalize patches the offset table in the header, seals the file with the
+// crc32 trailer, syncs it, and releases the write lock. The entry becomes
+// visible to readers once its size matches the sealed layout. No-op for
+// read-only caches.
 func (c *chunkCache) finalize() error {
 	c.mut.Lock()
 	defer c.mut.Unlock()
@@ -687,15 +674,16 @@ func (c *chunkCache) finalize() error {
 	if err := file.Sync(); err != nil {
 		return fmt.Errorf("sync cache file: %w", err)
 	}
-	info, err := file.Stat()
-	if err != nil {
-		return fmt.Errorf("stat cache file: %w", err)
-	}
-	finalPath := fmt.Sprintf("%s_%d", c.finalBasePath, info.Size())
-	if err := os.Link(c.partialPath, finalPath); err != nil {
-		return fmt.Errorf("publish cache file: %w", err)
-	}
 	c.published = true
+	if c.manager != nil {
+		// Track the sealed entry (still referenced by this open cache) before
+		// releasing the lock so eviction never catches it unreferenced. The
+		// freshly synced file matches the checksum it was sealed with, so
+		// remember it as verified.
+		c.manager.acquire(c.path, c.writePos+4)
+		c.manager.markVerified(c.path)
+		c.refPaths = append(c.refPaths, c.path)
+	}
 	if c.lockFile != nil {
 		if err := flock.Unlock(c.lockFile); err != nil {
 			return fmt.Errorf("unlock cache file: %w", err)
@@ -703,12 +691,7 @@ func (c *chunkCache) finalize() error {
 		c.lockFile = nil
 	}
 	if c.manager != nil {
-		// Track the published entry (still referenced by this open cache) and
-		// evict any overage now that the cache grew. The freshly synced file
-		// matches the checksum it was sealed with, so remember it as verified.
-		c.manager.acquire(finalPath, info.Size())
-		c.manager.markVerified(finalPath)
-		c.refPaths = append(c.refPaths, finalPath)
+		// Evict any overage now that the cache grew.
 		c.manager.evaluate()
 	}
 	return nil
@@ -719,6 +702,11 @@ func (c *chunkCache) finalize() error {
 func (c *chunkCache) Done() {
 	c.mut.Lock()
 	c.done = true
+	if c.file != nil && !c.readonly && !c.published {
+		// Discard the unfinished entry while still holding its lock so
+		// waiting contenders find an empty file and rewrite it.
+		c.file.Truncate(0) //nolint:errcheck
+	}
 	if c.lockFile != nil {
 		flock.Unlock(c.lockFile) //nolint:errcheck
 		c.lockFile = nil
@@ -726,9 +714,6 @@ func (c *chunkCache) Done() {
 	if c.file != nil {
 		c.file.Close()
 		c.file = nil
-	}
-	if !c.readonly && !c.published {
-		os.Remove(c.partialPath) //nolint:errcheck
 	}
 	for _, f := range c.files {
 		f.Close()

--- a/download/chunk_cache_test.go
+++ b/download/chunk_cache_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -20,7 +19,7 @@ import (
 
 const testCacheHash = "0123456789abcdef"
 
-func TestChunkCachePublishesFinalSizeInName(t *testing.T) {
+func TestChunkCacheSealsEntryInPlace(t *testing.T) {
 	dir := t.TempDir()
 	m := NewCacheManager(dir, 0)
 	cache, err := newChunkCache(bytes.NewReader([]byte("chunk")), m, testCacheHash, 0, 1, 10, 20)
@@ -36,35 +35,18 @@ func TestChunkCachePublishesFinalSizeInName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var found bool
-	var finalInfo os.FileInfo
-	for _, entry := range entries {
-		if strings.HasSuffix(entry.Name(), ".lock") {
-			t.Fatalf("unexpected separate lock file %q", entry.Name())
-		}
-		_, _, _, _, expectedSize, ok := parseCacheFileName(entry.Name())
-		if !ok {
-			continue
-		}
-		info, err := entry.Info()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if info.Size() != expectedSize {
-			t.Fatalf("filename size %d does not match file size %d", expectedSize, info.Size())
-		}
-		finalInfo = info
-		found = true
+	if len(entries) != 1 {
+		t.Fatalf("got %d files, want the single entry file", len(entries))
 	}
-	if !found {
-		t.Fatal("completed cache file was not published")
+	if got, want := entries[0].Name(), cacheFileName(0, 1, 10, 20); got != want {
+		t.Fatalf("got entry name %q, want %q", got, want)
 	}
-	partialInfo, err := os.Stat(cache.partialPath)
+	info, err := entries[0].Info()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !os.SameFile(partialInfo, finalInfo) {
-		t.Fatal("partial lock path and final cache path do not reference the same inode")
+	if got, want := info.Size(), cacheEntryFileSize("chunk"); got != want {
+		t.Fatalf("got entry size %d, want %d", got, want)
 	}
 
 	cached, err := openCachedRange(m, testCacheHash, 0, 1)
@@ -85,16 +67,14 @@ func TestChunkCachePublishesFinalSizeInName(t *testing.T) {
 	}
 }
 
-func TestChunkCacheIgnoresPartialAndWrongSizedFiles(t *testing.T) {
+func TestChunkCacheIgnoresIncompleteFiles(t *testing.T) {
 	dir := t.TempDir()
-	base := cacheFileBasePath(dir, testCacheHash, 0, 1, 10, 20)
-	if err := os.MkdirAll(filepath.Dir(base), 0o755); err != nil {
+	path := cacheFilePath(dir, testCacheHash, 0, 1, 10, 20)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(base+".partial", []byte("partial"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(base+"_999", []byte("short"), 0o644); err != nil {
+	// A crashed download: valid entry name, but not a sealed layout.
+	if err := os.WriteFile(path, []byte("garbage"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -108,6 +88,67 @@ func TestChunkCacheIgnoresPartialAndWrongSizedFiles(t *testing.T) {
 	}
 }
 
+func TestChunkCacheRewritesCrashedLeftoverInPlace(t *testing.T) {
+	dir := t.TempDir()
+	path := cacheFilePath(dir, testCacheHash, 0, 1, 10, 20)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("crashed-leftover"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewCacheManager(dir, 0)
+	cache, err := newChunkCache(bytes.NewReader([]byte("chunk")), m, testCacheHash, 0, 1, 10, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cache.readonly {
+		t.Fatal("crashed leftover was adopted instead of rewritten")
+	}
+	if err := cache.LoadAll(); err != nil {
+		t.Fatal(err)
+	}
+	cache.Done()
+
+	cached, err := openCachedRange(m, testCacheHash, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached == nil {
+		t.Fatal("rewritten entry was not adopted")
+	}
+	defer cached.Done()
+	buf := make([]byte, 16)
+	n, err := cached.Chunk(0, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf[:n]); got != "chunk" {
+		t.Fatalf("got %q, want %q", got, "chunk")
+	}
+}
+
+func TestChunkCacheInProgressEntryInvisibleToReaders(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	cache, err := newChunkCache(bytes.NewReader([]byte("chunk")), m, testCacheHash, 0, 1, 10, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cache.Done()
+
+	// The writer holds the lock and the entry is not sealed yet.
+	cached, err := openCachedRange(m, testCacheHash, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached != nil {
+		cached.Done()
+		t.Fatal("unsealed entry was visible to readers")
+	}
+}
+
 func TestChunkCacheRejectsEarlyEOF(t *testing.T) {
 	dir := t.TempDir()
 	cache, err := newChunkCache(bytes.NewReader([]byte("only-one-chunk")), NewCacheManager(dir, 0), testCacheHash, 0, 2, 10, 20)
@@ -118,8 +159,20 @@ func TestChunkCacheRejectsEarlyEOF(t *testing.T) {
 		t.Fatalf("got %v, want chunk count error", err)
 	}
 	cache.Done()
-	if _, err := os.Stat(cache.partialPath); !os.IsNotExist(err) {
-		t.Fatalf("partial cache was not removed: %v", err)
+	info, err := os.Stat(cache.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("failed entry was not discarded, size %d", info.Size())
+	}
+	cached, err := openCachedRange(NewCacheManager(dir, 0), testCacheHash, 0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached != nil {
+		cached.Done()
+		t.Fatal("discarded entry was visible")
 	}
 }
 
@@ -190,20 +243,19 @@ func TestChunkCacheVerifiesChecksumOncePerManager(t *testing.T) {
 	cached.Done()
 }
 
-func TestChunkCacheAdoptsLegacyEntryWithoutChecksum(t *testing.T) {
+func TestChunkCacheRejectsEntryWithoutChecksumTrailer(t *testing.T) {
 	dir := t.TempDir()
 	payload := "legacy-chunk"
-	// Legacy layout: [numOffsets][offset0][offset1][data], no crc32 trailer.
+	// Layout without the crc32 trailer: [numOffsets][offset0][offset1][data].
 	header := make([]byte, 12)
 	binary.LittleEndian.PutUint32(header[0:], 2)
 	binary.LittleEndian.PutUint32(header[8:], uint32(len(payload)))
 	content := append(header, payload...)
 
-	base := cacheFileBasePath(dir, testCacheHash, 0, 1, 0, int64(len(payload)))
-	if err := os.MkdirAll(filepath.Dir(base), 0o755); err != nil {
+	path := cacheFilePath(dir, testCacheHash, 0, 1, 0, int64(len(payload)))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	path := fmt.Sprintf("%s_%d", base, len(content))
 	if err := os.WriteFile(path, content, 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -212,17 +264,9 @@ func TestChunkCacheAdoptsLegacyEntryWithoutChecksum(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cached == nil {
-		t.Fatal("legacy cache entry was not adopted")
-	}
-	defer cached.Done()
-	buf := make([]byte, 32)
-	n, err := cached.Chunk(0, buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := string(buf[:n]); got != payload {
-		t.Fatalf("got %q, want %q", got, payload)
+	if cached != nil {
+		cached.Done()
+		t.Fatal("unsealed entry was adopted")
 	}
 }
 
@@ -267,6 +311,55 @@ func TestChunkCacheConcurrentWriterReusesPublishedFile(t *testing.T) {
 	}
 	if got := string(buf[:n]); got != "first" {
 		t.Fatalf("got %q, want first writer data", got)
+	}
+}
+
+func TestChunkCacheContenderRebuildsAfterWriterFailure(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	first, err := newChunkCache(bytes.NewReader([]byte("first")), m, testCacheHash, 0, 1, 10, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type result struct {
+		cache *chunkCache
+		err   error
+	}
+	results := make(chan result, 1)
+	go func() {
+		cache, err := newChunkCache(bytes.NewReader([]byte("second")), m, testCacheHash, 0, 1, 10, 20)
+		results <- result{cache, err}
+	}()
+
+	select {
+	case <-results:
+		t.Fatal("second writer did not wait for the lock")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// The first writer gives up without sealing the entry.
+	first.Done()
+
+	res := <-results
+	if res.err != nil {
+		t.Fatal(res.err)
+	}
+	second := res.cache
+	defer second.Done()
+	if second.readonly {
+		t.Fatal("second writer adopted a discarded entry")
+	}
+	if err := second.LoadAll(); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 16)
+	n, err := second.Chunk(0, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf[:n]); got != "second" {
+		t.Fatalf("got %q, want %q", got, "second")
 	}
 }
 


### PR DESCRIPTION
Replace the two-name `.partial` scheme with a single file per entry: the entry file itself is the flock target, the writer streams into it in place, and sealing it (patch offsets, append crc32 trailer, write numOffsets, sync, unlock) is what publishes it. The `_<fileSize>` name suffix is gone — completeness is exact size arithmetic against the name-derived header size (`headerBytes + offsets[N] + 4`), with numOffsets doubling as the commit mark: it stays zero until seal time and lands after everything it vouches for, so a mid-write file can never pass layout validation even when its size coincides.

- No `os.Link` at publish time, so the cache works on filesystems without hard-link support, and the orphan-partial pairing logic in reconcile goes away.
- A failed writer truncates the entry under its lock before unlocking; previously the `.partial` was removed after unlocking, which could yank the name from under a contender that had just passed its `SameFile` check.
- Readers stay lock-free: a file only grows from incomplete to complete, complete files are never rewritten, and unlocked incomplete files are removed as crashed leftovers during reconcile.
- The sealed entry is now tracked (`acquire`) before the lock is released, closing the window where a just-published entry was briefly unreferenced and evictable; `acquire` also refreshes the tracked size since names no longer carry it, and the verified map stores the file identity so a name recycled by another process is re-verified instead of inheriting the old file's checksum status.
- Old-format entries (`..._<size>` + `.partial`, including pre-#138 files without a trailer) are no longer recognized; they are ignored rather than migrated and can be cleared manually.
