### PR TITLE
perf: keep chunk cache eviction bookkeeping off the per-range path

### DIFF
--- a/download/cache_manager.go
+++ b/download/cache_manager.go
@@ -15,6 +15,12 @@ import (
 // xet-core's default chunk cache size (HF_XET_CHUNK_CACHE_SIZE_BYTES).
 const DefaultCacheSize int64 = 10_000_000_000
 
+// reconcileInterval is the minimum time between full directory walks on the
+// eviction slow path. The walk re-syncs tracked state with entries created
+// or removed by other managers and processes; throttling it keeps a cache
+// hovering at capacity from re-scanning the tree on every published range.
+const reconcileInterval = time.Minute
+
 // cacheEntry is the LRU bookkeeping for one published cache file.
 type cacheEntry struct {
 	size int64
@@ -30,10 +36,14 @@ type evictedEntry struct {
 // CacheManager bounds the total size of one chunk cache directory.
 //
 // Entries are tracked in an in-memory LRU that is touched once when a cache
-// file is acquired and once more when its user is done. Eviction is
-// evaluated when an entry is published or released, never on the read path,
-// and every evaluation first reconciles the tracked state with the directory
-// so the bound holds even when several managers or processes share it.
+// file is acquired and once more when its user is done. Publishing or
+// releasing a range is O(1) in-memory bookkeeping while the tracked total
+// stays under capacity; eviction only runs once it reaches capacity. The
+// full directory walk that keeps the bound directory-wide — adopting entries
+// created by other managers or processes and cleaning up crashed leftovers —
+// runs once when the manager is first prepared and afterwards only right
+// before evicting, at most once per reconcileInterval, never on the
+// per-range path.
 // Cross-process (and cross-manager) safety relies on the flock on the entry
 // file itself: names are only unlinked while holding that lock, so active
 // writers are never disturbed, and already-open readers keep their data
@@ -45,8 +55,12 @@ type CacheManager struct {
 	lru      *lru.Cache
 	total    int64
 
+	// lastReconcile is when reconcileLocked last walked the directory; the
+	// zero value means the initial scan has not happened yet.
+	lastReconcile time.Time
+
 	// evicted accumulates entries popped from the LRU via RemoveOldest;
-	// evaluateLocked drains it for eviction candidates and reconcileLocked
+	// evictLocked drains it for eviction candidates and reconcileLocked
 	// uses it to rebuild the LRU.
 	evicted []evictedEntry
 
@@ -74,11 +88,16 @@ func NewCacheManager(cacheDir string, capacity int64) *CacheManager {
 	return m
 }
 
-// prepare reconciles tracked state with the cache directory (adopting
-// pre-existing entries and removing crashed incomplete entries) and evicts
-// any overage before a download starts.
+// prepare runs the one-time directory scan that adopts pre-existing entries
+// and removes crashed incomplete entries, then evicts any overage before a
+// download starts. Calls after the first cost the same as evaluate.
 func (m *CacheManager) prepare() {
-	m.evaluate()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.lastReconcile.IsZero() {
+		m.reconcileLocked()
+	}
+	m.evaluateLocked()
 }
 
 // acquire records one use of the cache file at path and refreshes its LRU
@@ -120,18 +139,30 @@ func (m *CacheManager) markVerified(path string) {
 	m.verified.Store(path, struct{}{})
 }
 
-// evaluate reconciles tracked state with the cache directory, then evicts
-// least-recently-used entries until the total fits the capacity. Reconciling
-// first keeps the bound directory-level even when other managers or
-// processes write to the same directory.
+// evaluate evicts least-recently-used entries when the tracked total has
+// reached capacity; below capacity it is O(1) and touches no directory.
 func (m *CacheManager) evaluate() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.reconcileLocked()
 	m.evaluateLocked()
 }
 
+// evaluateLocked is the eviction slow path, entered only once the tracked
+// total reaches capacity. Before evicting it reconciles the tracked state
+// with the directory — throttled to reconcileInterval — so entries written
+// by other managers or processes are counted, stale names are dropped, and
+// the bound stays directory-wide.
 func (m *CacheManager) evaluateLocked() {
+	if m.capacity <= 0 || m.total < m.capacity {
+		return
+	}
+	if time.Since(m.lastReconcile) >= reconcileInterval {
+		m.reconcileLocked()
+	}
+	m.evictLocked()
+}
+
+func (m *CacheManager) evictLocked() {
 	if m.capacity <= 0 {
 		return
 	}
@@ -169,6 +200,8 @@ func (m *CacheManager) evaluateLocked() {
 // left behind by crashed downloads are cleaned up. The recency order
 // and refs of already-tracked entries are preserved.
 func (m *CacheManager) reconcileLocked() {
+	m.lastReconcile = time.Now()
+
 	type diskEntry struct {
 		path    string
 		size    int64

--- a/download/cache_manager_test.go
+++ b/download/cache_manager_test.go
@@ -68,7 +68,105 @@ const (
 	testHashA = "aa11111111111111"
 	testHashB = "bb22222222222222"
 	testHashC = "cc33333333333333"
+	testHashD = "dd44444444444444"
 )
+
+// trackedTotal reads the manager's in-memory byte total.
+func trackedTotal(m *CacheManager) int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.total
+}
+
+// writeOrphanEntry drops an incomplete cache entry with no lock holder, as a
+// crashed download would leave behind.
+func writeOrphanEntry(t *testing.T, dir, hash string) string {
+	t.Helper()
+	orphan := cacheFilePath(dir, hash, 0, 1, 0, 10)
+	if err := os.MkdirAll(filepath.Dir(orphan), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(orphan, []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return orphan
+}
+
+func TestCachePublishUnderCapacityIsInMemoryOnly(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	entrySize := cacheEntryFileSize(payload)
+
+	// An entry from another manager and a crashed leftover, both unknown to
+	// the manager under test.
+	writeCacheEntry(t, NewCacheManager(dir, 0), testHashB, payload)
+	orphan := writeOrphanEntry(t, dir, testHashC)
+
+	// Publishing and releasing while under capacity must stay in memory: the
+	// foreign entry is not adopted and the leftover is not cleaned up.
+	m := NewCacheManager(dir, entrySize*10)
+	writeCacheEntry(t, m, testHashA, payload)
+	if got := trackedTotal(m); got != entrySize {
+		t.Fatalf("under-capacity publish should only track its own entry: total %d, want %d", got, entrySize)
+	}
+	if _, err := os.Stat(orphan); err != nil {
+		t.Fatalf("crashed leftover should be untouched on the publish path: %v", err)
+	}
+
+	// The first prepare is the slow path: it adopts the foreign entry and
+	// cleans up the leftover.
+	m.prepare()
+	if got := trackedTotal(m); got != entrySize*2 {
+		t.Fatalf("prepare should adopt the foreign entry: total %d, want %d", got, entrySize*2)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("prepare should clean up crashed leftovers: %v", err)
+	}
+}
+
+func TestCacheEvictionThrottlesDirectoryWalk(t *testing.T) {
+	dir := t.TempDir()
+	payload := "0123456789"
+	entrySize := cacheEntryFileSize(payload)
+	m := NewCacheManager(dir, entrySize*2)
+
+	// Filling the cache to capacity runs the first full walk.
+	writeCacheEntry(t, m, testHashA, payload)
+	writeCacheEntry(t, m, testHashB, payload)
+
+	// A foreign entry written after that walk is not re-discovered while the
+	// throttle is active: the next overage is resolved from tracked state
+	// alone, evicting the oldest tracked entry.
+	writeCacheEntry(t, NewCacheManager(dir, 0), testHashC, payload)
+	writeCacheEntry(t, m, testHashD, payload)
+
+	if entryExists(t, dir, testHashA) {
+		t.Fatal("oldest tracked entry was not evicted")
+	}
+	if !entryExists(t, dir, testHashB) || !entryExists(t, dir, testHashD) {
+		t.Fatal("tracked entries within capacity were evicted")
+	}
+	if !entryExists(t, dir, testHashC) {
+		t.Fatal("foreign entry should survive eviction within the reconcile interval")
+	}
+	if got := trackedTotal(m); got != entrySize*2 {
+		t.Fatalf("throttled eviction should not adopt foreign entries: total %d, want %d", got, entrySize*2)
+	}
+}
+
+func TestCachePrepareScansOnce(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	m.prepare()
+
+	// A leftover appearing after the initial scan is only cleaned up on the
+	// slow path, not by later prepares.
+	orphan := writeOrphanEntry(t, dir, testHashA)
+	m.prepare()
+	if _, err := os.Stat(orphan); err != nil {
+		t.Fatalf("prepare after the initial scan should not walk the directory: %v", err)
+	}
+}
 
 func TestCacheEvictsLeastRecentlyUsed(t *testing.T) {
 	dir := t.TempDir()

--- a/download/decode_v1.go
+++ b/download/decode_v1.go
@@ -42,7 +42,8 @@ func NewReaderV1(ctx context.Context, client ClientAdapter, reconstruction *Reco
 		return nil, fmt.Errorf("no cache manager provided")
 	}
 	// Adopt pre-existing entries and clean up orphaned partial files before
-	// the download starts.
+	// the download starts; only the manager's first prepare walks the cache
+	// directory.
 	cache.prepare()
 
 	termFetches, tasks, err := planReaderV1(reconstruction)

--- a/download/decode_v2.go
+++ b/download/decode_v2.go
@@ -42,7 +42,8 @@ func NewReaderV2(ctx context.Context, client ClientAdapter, reconstruction *Reco
 		return nil, fmt.Errorf("no cache manager provided")
 	}
 	// Adopt pre-existing entries and clean up orphaned partial files before
-	// the download starts.
+	// the download starts; only the manager's first prepare walks the cache
+	// directory.
 	cache.prepare()
 
 	termFetches, tasks, err := planReaderV2(reconstruction)


### PR DESCRIPTION
Every `CacheManager.evaluate()` re-walked the entire cache tree via reconcile (a `ReadDir` of every prefix and hash directory), and evaluate runs at reader creation, after every published range, and when a range's refs are released — O(cache entries) directory IO per downloaded range. Now the walk is off the per-range path: publishing or releasing a range is O(1) in-memory bookkeeping while the tracked total stays under capacity, and the directory is only re-read on the slow path, mirroring xet-core's scan-once-then-track approach.

- `evaluate` returns immediately below capacity; once the tracked total reaches capacity it reconciles with the directory — throttled to at most once per minute — before evicting, so entries written by other managers or processes are still counted and the bound stays directory-wide.
- `prepare` runs the full scan once per manager (adopting pre-existing entries, cleaning up crashed leftovers) instead of on every reader creation; orphaned incomplete-entry cleanup stays on these slow paths.
- Between walks, eviction works from tracked state alone; names already unlinked by another process are simply dropped when their turn comes.
- The cache file format, key layout, and flock-based eviction safety are unchanged, and there is still no background daemon or timer — the throttle is a timestamp check.

Fixes #137