### PR TITLE
feat: pin mirror branches to commits with human-readable mappings

### DIFF
--- a/mirror/index.go
+++ b/mirror/index.go
@@ -5,8 +5,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -38,9 +40,15 @@ type fileEntry struct {
 	notFound  bool
 }
 
-func indexEntryPath(dir, key string) string {
+// indexEntryPath returns the on-disk location of an entry: grouped under its
+// commit directory when the commit is a 40-hex id, flat otherwise.
+func indexEntryPath(dir, commit, key string) string {
 	sum := sha256.Sum256([]byte(key))
-	return filepath.Join(dir, hex.EncodeToString(sum[:])+".json")
+	name := hex.EncodeToString(sum[:]) + ".json"
+	if commitRevRe.MatchString(commit) {
+		return filepath.Join(dir, commit, name)
+	}
+	return filepath.Join(dir, name)
 }
 
 // persistEntry writes a ready entry to disk so it survives restarts.
@@ -49,7 +57,10 @@ func persistEntry(dir string, e *fileEntry) error {
 	if err != nil {
 		return fmt.Errorf("marshal index entry: %w", err)
 	}
-	path := indexEntryPath(dir, e.Key)
+	path := indexEntryPath(dir, e.Commit, e.Key)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create index dir: %w", err)
+	}
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0644); err != nil {
 		return fmt.Errorf("write index entry: %w", err)
@@ -61,7 +72,23 @@ func persistEntry(dir string, e *fileEntry) error {
 	return nil
 }
 
-// loadIndex reads all persisted entries from dir.
+// readEntry loads one persisted entry, returning nil for anything unreadable
+// or not ready.
+func readEntry(path string) *fileEntry {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var e fileEntry
+	if err := json.Unmarshal(data, &e); err != nil || e.Key == "" || e.State != stateReady {
+		return nil
+	}
+	return &e
+}
+
+// loadIndex reads all persisted entries from dir: entries grouped under
+// per-commit directories plus legacy flat files, which are moved under their
+// commit directory as they are seen.
 func loadIndex(dir string) (map[string]*fileEntry, error) {
 	files := make(map[string]*fileEntry)
 	dirEntries, err := os.ReadDir(dir)
@@ -72,18 +99,170 @@ func loadIndex(dir string) (map[string]*fileEntry, error) {
 		return nil, fmt.Errorf("read index dir: %w", err)
 	}
 	for _, de := range dirEntries {
-		if de.IsDir() || filepath.Ext(de.Name()) != ".json" {
+		if de.IsDir() {
+			// Commit directories only; skips branches/ and strays.
+			if !commitRevRe.MatchString(de.Name()) {
+				continue
+			}
+			subEntries, err := os.ReadDir(filepath.Join(dir, de.Name()))
+			if err != nil {
+				continue
+			}
+			for _, se := range subEntries {
+				if se.IsDir() || filepath.Ext(se.Name()) != ".json" {
+					continue
+				}
+				if e := readEntry(filepath.Join(dir, de.Name(), se.Name())); e != nil {
+					files[e.Key] = e
+				}
+			}
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(dir, de.Name()))
-		if err != nil {
+		if filepath.Ext(de.Name()) != ".json" {
 			continue
 		}
-		var e fileEntry
-		if err := json.Unmarshal(data, &e); err != nil || e.Key == "" || e.State != stateReady {
+		path := filepath.Join(dir, de.Name())
+		e := readEntry(path)
+		if e == nil {
 			continue
 		}
-		files[e.Key] = &e
+		files[e.Key] = e
+		// Legacy flat entry: move it under its commit directory.
+		if indexEntryPath(dir, e.Commit, e.Key) != path && persistEntry(dir, e) == nil {
+			_ = os.Remove(path)
+		}
 	}
 	return files, nil
+}
+
+// branchEntry pins a mutable branch revision to the upstream commit it
+// pointed at when last checked. Commit is empty for upstreams without a real
+// commit concept, recording that canonicalization must be skipped.
+type branchEntry struct {
+	Repo      string    `json:"repo"` // resolve repo prefix, no leading slash
+	Rev       string    `json:"rev"`
+	Commit    string    `json:"commit,omitempty"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// key returns the in-memory map key. NUL separates repo from rev so a repo
+// containing the separator cannot alias another (repo, rev) pair.
+func (b *branchEntry) key() string {
+	return b.Repo + "\x00" + b.Rev
+}
+
+// escapeSegment percent-encodes the bytes of one request-derived path segment
+// that could escape its directory or produce hostile file names: the escape
+// byte itself, separators, control bytes, Windows-reserved punctuation, and a
+// leading dot (which covers ".", "..", and dotfiles). Typical hub names pass
+// through unchanged, keeping the tree readable.
+func escapeSegment(s string) string {
+	if s == "" {
+		return "%00" // impossible in real segments: '%' is always encoded
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '%' || c == '/' || c == '\\' || c < 0x20 || c == 0x7f,
+			c == ':' || c == '*' || c == '?' || c == '"' || c == '<' || c == '>' || c == '|':
+			fmt.Fprintf(&b, "%%%02X", c)
+		case c == '.' && i == 0:
+			b.WriteString("%2E")
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
+
+// escapeDirSegment escapes a repo segment used as a directory name. A
+// trailing ".json" is additionally encoded so directories can never collide
+// with the "<rev>.json" mapping files living beside them.
+func escapeDirSegment(s string) string {
+	s = escapeSegment(s)
+	if strings.HasSuffix(s, ".json") {
+		s = strings.TrimSuffix(s, ".json") + "%2Ejson"
+	}
+	return s
+}
+
+// branchEntryPath maps a branch mapping to its human-readable location,
+// nested by repo path: <dir>/<repo...>/<rev>.json. Every segment is escaped
+// so request-derived names cannot traverse outside dir; pathological segments
+// that would exceed the file name limit fall back to the legacy hashed
+// location.
+func branchEntryPath(dir, repo, rev string) string {
+	segs := strings.Split(repo, "/")
+	parts := make([]string, 0, len(segs)+1)
+	for _, seg := range segs {
+		parts = append(parts, escapeDirSegment(seg))
+	}
+	parts = append(parts, escapeSegment(rev)+".json")
+	for _, p := range parts {
+		if len(p) > 255 {
+			sum := sha256.Sum256([]byte(repo + "@" + rev))
+			return filepath.Join(dir, hex.EncodeToString(sum[:])+".json")
+		}
+	}
+	return filepath.Join(dir, filepath.Join(parts...))
+}
+
+// persistBranch writes a branch mapping to disk so it survives restarts.
+func persistBranch(dir string, b *branchEntry) error {
+	data, err := json.Marshal(b)
+	if err != nil {
+		return fmt.Errorf("marshal branch entry: %w", err)
+	}
+	path := branchEntryPath(dir, b.Repo, b.Rev)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create branch dir: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("write branch entry: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("finalize branch entry: %w", err)
+	}
+	return nil
+}
+
+// loadBranches reads all persisted branch mappings under dir. Mappings found
+// away from their canonical human-readable path (legacy hashed names) are
+// moved as they are seen; the JSON body carries repo and rev, so no name
+// needs decoding.
+func loadBranches(dir string) (map[string]*branchEntry, error) {
+	branches := make(map[string]*branchEntry)
+	err := filepath.WalkDir(dir, func(path string, de fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if de.IsDir() || filepath.Ext(de.Name()) != ".json" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		var b branchEntry
+		if err := json.Unmarshal(data, &b); err != nil || b.Repo == "" || b.Rev == "" {
+			return nil
+		}
+		branches[b.key()] = &b
+		if canonical := branchEntryPath(dir, b.Repo, b.Rev); canonical != path {
+			if persistBranch(dir, &b) == nil {
+				_ = os.Remove(path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read branch dir: %w", err)
+	}
+	return branches, nil
 }

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -50,6 +50,15 @@ import (
 // treated as an opaque repo identity, so no platform-specific routing exists.
 var resolveRe = regexp.MustCompile(`^/(.+?)/resolve/([^/]+)/(.+)$`)
 
+// apiTreeRe matches hub tree listing API paths. Their entries carry per-file
+// xet hashes that would steer downstream clients straight to the upstream CAS.
+var apiTreeRe = regexp.MustCompile(`^/api/(models|datasets|spaces)/(.+?)/tree/([^/]+)(/.*)?$`)
+
+// xetTokenRe matches the hub token refresh route hub clients construct
+// themselves ({endpoint}/api/{type}s/{repo}/xet-read-token/{revision})
+// when the resolve response carries no xet-auth Link header.
+var xetTokenRe = regexp.MustCompile(`^/api/(models|datasets|spaces)/(.+?)/xet-read-token/([^/]+)$`)
+
 // commitRevRe matches revision strings that pin an immutable commit.
 var commitRevRe = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
@@ -93,10 +102,11 @@ type Handler struct {
 	next         http.Handler
 	localAdapter *localCAS
 
-	mu      sync.Mutex
-	flight  singleflight.Group
-	entries map[string]*fileEntry
-	tasks   map[string]*task
+	mu       sync.Mutex
+	flight   singleflight.Group
+	entries  map[string]*fileEntry
+	branches map[string]*branchEntry
+	tasks    map[string]*task
 }
 
 // Option configures the Handler.
@@ -178,8 +188,9 @@ func NewHandler(opts ...Option) (*Handler, error) {
 
 	h.indexDir = filepath.Join(h.cacheDir, "index")
 	h.spoolDir = filepath.Join(h.cacheDir, "spool")
+	branchDir := h.branchDir()
 	chunkCacheDir := filepath.Join(h.cacheDir, "chunks")
-	for _, dir := range []string{h.indexDir, h.spoolDir, chunkCacheDir} {
+	for _, dir := range []string{h.indexDir, branchDir, h.spoolDir, chunkCacheDir} {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return nil, fmt.Errorf("mirror: create %s: %w", dir, err)
 		}
@@ -188,6 +199,10 @@ func NewHandler(opts ...Option) (*Handler, error) {
 	h.entries, err = loadIndex(h.indexDir)
 	if err != nil {
 		return nil, fmt.Errorf("mirror: load index: %w", err)
+	}
+	h.branches, err = loadBranches(branchDir)
+	if err != nil {
+		return nil, fmt.Errorf("mirror: load branches: %w", err)
 	}
 
 	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
@@ -242,6 +257,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleToken(w, r)
 		return
 	}
+	if r.Method == http.MethodGet && xetTokenRe.MatchString(p) {
+		// Clients that skipped the resolve HEAD (hub tree caches) refresh
+		// their CAS credential here; answer locally so they stay on the
+		// mirror instead of the upstream CAS.
+		h.handleToken(w, r)
+		return
+	}
+	if r.Method == http.MethodGet && apiTreeRe.MatchString(p) {
+		h.handleTree(w, r)
+		return
+	}
 	if (r.Method == http.MethodGet || r.Method == http.MethodHead) && resolveRe.MatchString(p) {
 		h.handleResolve(w, r, p)
 		return
@@ -286,6 +312,217 @@ func (h *Handler) upstreamURL(key string) string {
 	return strings.TrimRight(h.upstream.String(), "/") + key
 }
 
+func (h *Handler) branchDir() string {
+	return filepath.Join(h.indexDir, "branches")
+}
+
+// branchStale reports whether a branch mapping must be re-checked, following
+// the revalidation cadence: zero interval re-checks every request, negative
+// never does.
+func (h *Handler) branchStale(b *branchEntry) bool {
+	if h.revalidateInterval < 0 {
+		return false
+	}
+	return time.Since(b.CheckedAt) >= h.revalidateInterval
+}
+
+// branchProbe is the singleflight result of a branch mapping refresh. The
+// probe result is handed back to the caller whose key was probed so its
+// ingest task can reuse it instead of probing again.
+type branchProbe struct {
+	b   *branchEntry
+	key string
+	pr  *probeResult
+}
+
+// branchCommit resolves a branch revision to the upstream commit it points
+// at, probing the upstream when the cached mapping is stale. It reports
+// ok=false when no real commit is available (upstreams that synthesize
+// pseudo-commits keep the branch-keyed flow with per-entry revalidation);
+// probe failures fall back to the last known commit so cached content stays
+// served while the upstream is unreachable. The returned probe result is
+// non-nil when this call probed the upstream for exactly this key.
+func (h *Handler) branchCommit(key string, m []string) (string, *probeResult, bool) {
+	name := m[1] + "\x00" + m[2]
+	h.mu.Lock()
+	b := h.branches[name]
+	h.mu.Unlock()
+	if b != nil && !h.branchStale(b) {
+		return b.Commit, nil, b.Commit != ""
+	}
+
+	v, _, _ := h.flight.Do("branch\x00"+name, func() (any, error) {
+		h.mu.Lock()
+		b := h.branches[name]
+		h.mu.Unlock()
+		if b != nil && !h.branchStale(b) {
+			return &branchProbe{b: b}, nil
+		}
+		// Background context: the probe result is shared by every request of
+		// the repo branch, so one disconnecting client must not fail it.
+		pr, err := h.probe(context.Background(), key)
+		if err != nil {
+			return &branchProbe{b: b}, nil // unreachable upstream: serve the last known commit
+		}
+		nb := &branchEntry{Repo: m[1], Rev: m[2], CheckedAt: time.Now()}
+		if pr.realCommit && commitRevRe.MatchString(pr.commit) {
+			nb.Commit = pr.commit
+		}
+		h.mu.Lock()
+		h.branches[name] = nb
+		h.mu.Unlock()
+		_ = persistBranch(h.branchDir(), nb)
+		return &branchProbe{b: nb, key: key, pr: pr}, nil
+	})
+	bp := v.(*branchProbe)
+	var pr *probeResult
+	if bp.key == key {
+		pr = bp.pr
+	}
+	if bp.b != nil {
+		return bp.b.Commit, pr, bp.b.Commit != ""
+	}
+	return "", pr, false
+}
+
+// handleTree proxies a tree listing API request, rewriting each entry's
+// xetHash: files the mirror already holds advertise the mirror's own hash so
+// xet clients reconstruct them from the mirror CAS; all other entries lose
+// the hash so clients fall back to the resolve flow, which ingests through
+// the mirror. Left untouched, upstream hashes would send clients directly to
+// the upstream CAS, bypassing the mirror entirely. Hashes are only looked up
+// under immutable commits: branch revisions go through their pinned commit
+// mapping when fresh and are otherwise stripped, so a live listing is never
+// paired with hashes of content the branch no longer points at.
+func (h *Handler) handleTree(w http.ResponseWriter, r *http.Request) {
+	m := apiTreeRe.FindStringSubmatch(r.URL.EscapedPath())
+	u := h.upstreamURL(r.URL.EscapedPath())
+	if r.URL.RawQuery != "" {
+		u += "?" + r.URL.RawQuery
+	}
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, u, nil)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	resp, err := h.fetchClient.Do(req)
+	if err != nil {
+		http.Error(w, "upstream tree fetch failed", http.StatusBadGateway)
+		return
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	// Pagination (Link) and the other upstream headers pass through; entity
+	// headers are recomputed for the rewritten body.
+	for k, vs := range resp.Header {
+		switch http.CanonicalHeaderKey(k) {
+		case "Content-Length", "Content-Encoding", "Transfer-Encoding":
+			continue
+		}
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+
+	var items []map[string]any
+	var body []byte
+	if resp.StatusCode == http.StatusOK {
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			http.Error(w, "read upstream tree failed", http.StatusBadGateway)
+			return
+		}
+	}
+	if body == nil || json.Unmarshal(body, &items) != nil {
+		// Error status or unexpected shape: relay untouched.
+		w.WriteHeader(resp.StatusCode)
+		if body != nil {
+			_, _ = w.Write(body)
+		} else {
+			_, _ = io.Copy(w, resp.Body)
+		}
+		return
+	}
+
+	var ready map[string]string
+	lookupRev := m[3]
+	if !commitRevRe.MatchString(lookupRev) {
+		// Branch trees only advertise hashes through a fresh pinned commit;
+		// probing is left to the resolve path.
+		lookupRev = ""
+		name := strings.TrimPrefix(repoResolvePrefix(m[1], m[2]), "/") + "\x00" + m[3]
+		h.mu.Lock()
+		if b := h.branches[name]; b != nil && !h.branchStale(b) {
+			lookupRev = b.Commit
+		}
+		h.mu.Unlock()
+	}
+	if lookupRev != "" {
+		ready = h.readyFileHashes(repoResolvePrefix(m[1], m[2]), lookupRev)
+	}
+	for _, item := range items {
+		if _, ok := item["xetHash"]; !ok {
+			continue
+		}
+		path, _ := item["path"].(string)
+		if hash, ok := ready[path]; ok {
+			item["xetHash"] = hash
+		} else {
+			delete(item, "xetHash")
+		}
+	}
+
+	out, err := json.Marshal(items)
+	if err != nil {
+		http.Error(w, "encode tree failed", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Del("Etag") // body differs from upstream
+	w.Header().Set("Content-Length", strconv.Itoa(len(out)))
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(out)
+}
+
+// repoResolvePrefix maps an API repo type and id to the repo prefix used in
+// resolve keys: models live at the root, other types keep their segment.
+func repoResolvePrefix(repoType, repoID string) string {
+	if repoType == "models" {
+		return "/" + repoID
+	}
+	return "/" + repoType + "/" + repoID
+}
+
+// readyFileHashes returns path -> local xet hash for ready entries of the
+// given repo whose key revision or ingested commit matches rev.
+func (h *Handler) readyFileHashes(repoPrefix, rev string) map[string]string {
+	prefix := repoPrefix + "/resolve/"
+	out := map[string]string{}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for key, e := range h.entries {
+		if e.State != stateReady || e.FileHash == "" || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		rest := key[len(prefix):]
+		i := strings.IndexByte(rest, '/')
+		if i < 0 {
+			continue
+		}
+		if rest[:i] != rev && e.Commit != rev {
+			continue
+		}
+		// Keys hold escaped paths; tree entries carry them unescaped.
+		path := rest[i+1:]
+		if unescaped, err := url.PathUnescape(path); err == nil {
+			path = unescaped
+		}
+		out[path] = e.FileHash
+	}
+	return out
+}
+
 // task tracks one in-flight ingestion. All concurrent requests for the same
 // key attach to it, so the upstream is downloaded exactly once per file.
 type task struct {
@@ -312,6 +549,20 @@ func (t *task) setSize(n int64) {
 func (h *Handler) handleResolve(w http.ResponseWriter, r *http.Request, key string) {
 	m := resolveRe.FindStringSubmatch(key)
 	rev := m[2]
+
+	// Branch revisions are pinned to the upstream commit they point at, so
+	// entries, tasks, and spools are all keyed by immutable content. The
+	// branch mapping is re-checked on the revalidation cadence; one probe
+	// covers every file of the repo branch and is reused by the ingest task.
+	var preProbe *probeResult
+	if !commitRevRe.MatchString(rev) {
+		commit, pr, ok := h.branchCommit(key, m)
+		preProbe = pr
+		if ok {
+			rev = commit
+			key = "/" + m[1] + "/resolve/" + rev + "/" + m[3]
+		}
+	}
 
 	h.mu.Lock()
 	t := h.tasks[key]
@@ -341,7 +592,7 @@ func (h *Handler) handleResolve(w http.ResponseWriter, r *http.Request, key stri
 		}
 	}
 
-	t, e, err := h.startTask(key)
+	t, e, err := h.startTask(key, preProbe)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -383,8 +634,9 @@ func (h *Handler) serveTaskOrEntry(w http.ResponseWriter, r *http.Request, key s
 // startTask returns the in-flight ingestion task for key, or the entry when
 // the ingest already completed (or failed and is backing off). Only the task
 // startup itself runs inside the singleflight, so the task is registered
-// exactly once per key.
-func (h *Handler) startTask(key string) (*task, *fileEntry, error) {
+// exactly once per key. A pre-probe result from the branch mapping refresh is
+// handed to the task so the upstream is not probed twice.
+func (h *Handler) startTask(key string, pre *probeResult) (*task, *fileEntry, error) {
 	v, err, _ := h.flight.Do(key, func() (any, error) {
 		// A previous flight may have registered a task, or finished the whole
 		// ingest, between the caller's check and this one.
@@ -408,7 +660,7 @@ func (h *Handler) startTask(key string) (*task, *fileEntry, error) {
 		h.mu.Lock()
 		h.tasks[key] = nt
 		h.mu.Unlock()
-		go h.runTask(key, nt)
+		go h.runTask(key, nt, pre)
 		return nt, nil
 	})
 	if err != nil {
@@ -423,11 +675,14 @@ func (h *Handler) startTask(key string) (*task, *fileEntry, error) {
 // runTask executes one ingestion end to end on a background context; client
 // disconnects never cancel it. The spool opens after the probe so partial
 // bytes from a previous failed task (or a previous process) are resumed when
-// the upstream etag still matches.
-func (h *Handler) runTask(key string, t *task) {
+// the upstream etag still matches. A non-nil pre stands in for the probe.
+func (h *Handler) runTask(key string, t *task, pre *probeResult) {
 	ctx := context.Background()
 
-	pr, err := h.probe(ctx, key)
+	pr, err := pre, error(nil)
+	if pr == nil {
+		pr, err = h.probe(ctx, key)
+	}
 	if err == nil {
 		switch {
 		case pr.status == http.StatusNotFound:
@@ -712,7 +967,7 @@ func (h *Handler) revalidate(ctx context.Context, key string, e *fileEntry) *fil
 		delete(h.entries, key)
 	}
 	h.mu.Unlock()
-	_ = os.Remove(indexEntryPath(h.indexDir, key))
+	_ = os.Remove(indexEntryPath(h.indexDir, e.Commit, key))
 	return nil
 }
 

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -207,6 +208,7 @@ func downloadViaXet(t *testing.T, resolveURL string) []byte {
 type plainUpstream struct {
 	mu       sync.Mutex
 	files    map[string][]byte
+	api      map[string][]byte // raw JSON served under /api/ paths
 	commit   string
 	dataGETs atomic.Int64
 	seenAuth sync.Map // Authorization values observed on any request
@@ -215,7 +217,7 @@ type plainUpstream struct {
 }
 
 func newPlainUpstream() *plainUpstream {
-	return &plainUpstream{files: map[string][]byte{}, commit: "commit-1"}
+	return &plainUpstream{files: map[string][]byte{}, api: map[string][]byte{}, commit: "commit-1"}
 }
 
 func (u *plainUpstream) set(path string, data []byte) {
@@ -234,6 +236,19 @@ func (u *plainUpstream) get(path string) ([]byte, bool) {
 func (u *plainUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		u.seenAuth.Store(auth, true)
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		u.mu.Lock()
+		data, ok := u.api[r.URL.Path]
+		u.mu.Unlock()
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+		return
 	}
 
 	if strings.HasPrefix(r.URL.Path, "/cdn") {
@@ -798,26 +813,380 @@ func TestMirrorTokenEndpoint(t *testing.T) {
 
 	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
 
-	resp, err := http.Get(fx.srv.URL + "/xet-token")
+	for _, path := range []string{"/xet-token", "/api/models/org/repo/xet-read-token/main"} {
+		resp, err := http.Get(fx.srv.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var tok struct {
+			CASURL string `json:"casUrl"`
+			Token  string `json:"accessToken"`
+			Exp    int64  `json:"exp"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&tok)
+		resp.Body.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tok.CASURL != fx.srv.URL {
+			t.Fatalf("%s: casUrl = %q, want %q", path, tok.CASURL, fx.srv.URL)
+		}
+		if tok.Exp <= time.Now().Unix() {
+			t.Fatalf("%s: exp = %d, want in the future", path, tok.Exp)
+		}
+		if !fx.issuer.Validate(tok.Token, time.Now()) {
+			t.Fatalf("%s: minted token does not validate", path)
+		}
+	}
+}
+
+func TestMirrorTreeRewrite(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	data := make([]byte, 128*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	const resolvePath = "/org/repo/resolve/main/model.bin"
+	upstream.set(resolvePath, data)
+	// A real commit revision: branch requests get pinned to it, so the
+	// upstream must serve the commit-keyed path the ingest will fetch.
+	upstream.commit = strings.Repeat("ab", 20)
+	upstream.set("/org/repo/resolve/"+upstream.commit+"/model.bin", data)
+	treeJSON := []byte(`[
+		{"type":"file","path":"model.bin","size":131072,"xetHash":"upstream-hash-1"},
+		{"type":"file","path":"other.bin","size":7,"xetHash":"upstream-hash-2"},
+		{"type":"directory","path":"sub"}
+	]`)
+	upstream.api["/api/models/org/repo/tree/main"] = treeJSON
+	upstream.api["/api/models/org/repo/tree/"+upstream.commit] = treeJSON
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+
+	fetchTree := func(rev string) []map[string]any {
+		t.Helper()
+		resp, err := http.Get(fx.srv.URL + "/api/models/org/repo/tree/" + rev)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("tree status = %d, want 200", resp.StatusCode)
+		}
+		var items []map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 3 {
+			t.Fatalf("tree has %d entries, want 3", len(items))
+		}
+		return items
+	}
+
+	t.Run("uncached files lose xetHash", func(t *testing.T) {
+		for _, item := range fetchTree("main") {
+			if _, ok := item["xetHash"]; ok {
+				t.Fatalf("entry %v still carries xetHash", item["path"])
+			}
+		}
+	})
+
+	// Ingest model.bin, then the tree must advertise the mirror's own hash.
+	resolveURL := fx.srv.URL + resolvePath
+	resp, err := http.Get(resolveURL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	var tok struct {
-		CASURL string `json:"casUrl"`
-		Token  string `json:"accessToken"`
-		Exp    int64  `json:"exp"`
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	ready := waitReady(t, resolveURL)
+	localHash := ready.Header.Get("X-Xet-Hash")
+	if localHash == "" {
+		t.Fatal("ready resolve response has no X-Xet-Hash")
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+
+	t.Run("cached file advertises local hash on commit rev", func(t *testing.T) {
+		for _, item := range fetchTree(upstream.commit) {
+			hash, ok := item["xetHash"]
+			switch item["path"] {
+			case "model.bin":
+				if hash != localHash {
+					t.Fatalf("model.bin xetHash = %v, want %q", hash, localHash)
+				}
+			default:
+				if ok {
+					t.Fatalf("entry %v still carries xetHash", item["path"])
+				}
+			}
+		}
+	})
+
+	// Branch trees resolve through the pinned commit mapping established by
+	// the resolve requests above.
+	t.Run("branch rev advertises via pinned commit", func(t *testing.T) {
+		for _, item := range fetchTree("main") {
+			hash, ok := item["xetHash"]
+			switch item["path"] {
+			case "model.bin":
+				if hash != localHash {
+					t.Fatalf("model.bin xetHash = %v, want %q", hash, localHash)
+				}
+			default:
+				if ok {
+					t.Fatalf("entry %v still carries xetHash", item["path"])
+				}
+			}
+		}
+	})
+
+	// The tree rev the client uses must not resolve entries of other repos.
+	t.Run("other repo unaffected", func(t *testing.T) {
+		upstream.mu.Lock()
+		upstream.api["/api/models/org/other/tree/main"] = []byte(`[{"type":"file","path":"model.bin","size":1,"xetHash":"h"}]`)
+		upstream.mu.Unlock()
+		resp, err := http.Get(fx.srv.URL + "/api/models/org/other/tree/main")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		var items []map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := items[0]["xetHash"]; ok {
+			t.Fatal("other repo's entry kept xetHash despite no cache")
+		}
+	})
+}
+
+func TestMirrorBranchPinning(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	commit1 := strings.Repeat("11", 20)
+	commit2 := strings.Repeat("22", 20)
+	data1 := []byte("content at commit one")
+	data2 := []byte("content at commit two, updated")
+
+	upstream.commit = commit1
+	upstream.set("/org/repo/resolve/main/f.bin", data1)
+	upstream.set("/org/repo/resolve/"+commit1+"/f.bin", data1)
+
+	// Zero interval: the branch mapping is re-checked on every request.
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir(), WithRevalidateInterval(0))
+	resolveURL := fx.srv.URL + "/org/repo/resolve/main/f.bin"
+
+	fetch := func(url string) []byte {
+		t.Helper()
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		return body
+	}
+
+	if got := fetch(resolveURL); !bytes.Equal(got, data1) {
+		t.Fatal("initial branch fetch mismatch")
+	}
+	waitReady(t, resolveURL)
+
+	// The entry is keyed by the pinned commit, so a commit-pinned request
+	// serves from cache without touching the branch.
+	if got := fetch(fx.srv.URL + "/org/repo/resolve/" + commit1 + "/f.bin"); !bytes.Equal(got, data1) {
+		t.Fatal("commit-pinned fetch mismatch")
+	}
+
+	// Move the branch upstream: the next branch request re-pins and ingests
+	// the new content, while the old commit stays served from cache.
+	upstream.commit = commit2
+	upstream.set("/org/repo/resolve/main/f.bin", data2)
+	upstream.set("/org/repo/resolve/"+commit2+"/f.bin", data2)
+
+	if got := fetch(resolveURL); !bytes.Equal(got, data2) {
+		t.Fatal("branch fetch after move mismatch")
+	}
+	waitReady(t, resolveURL)
+	if got := fetch(fx.srv.URL + "/org/repo/resolve/" + commit1 + "/f.bin"); !bytes.Equal(got, data1) {
+		t.Fatal("old commit no longer served after branch move")
+	}
+}
+
+func TestBranchEntryPath(t *testing.T) {
+	dir := filepath.Join("idx", "branches")
+
+	cases := []struct {
+		repo, rev string
+		want      string // relative to dir
+	}{
+		{"Qwen/Qwen3-0.6B", "main", "Qwen/Qwen3-0.6B/main.json"},
+		{"gpt2", "main", "gpt2/main.json"},
+		{"datasets/org/repo", "refs%2Fpr%2F1", "datasets/org/repo/refs%252Fpr%252F1.json"},
+		// Traversal and hostile names stay escaped.
+		{"..", "main", "%2E./main.json"},
+		{"org/..", "..", "org/%2E./%2E..json"},
+		{".hidden/repo", ".rev", "%2Ehidden/repo/%2Erev.json"},
+		{"a%b", "r", "a%25b/r.json"},
+		{"org/", "r", "org/%00/r.json"},
+		// A repo segment ending in .json cannot collide with mapping files.
+		{"org/main.json", "x", "org/main%2Ejson/x.json"},
+	}
+	for _, c := range cases {
+		want := filepath.Join(dir, filepath.FromSlash(c.want))
+		if got := branchEntryPath(dir, c.repo, c.rev); got != want {
+			t.Errorf("branchEntryPath(%q, %q) = %q, want %q", c.repo, c.rev, got, want)
+		}
+	}
+
+	t.Run("never escapes the branch dir", func(t *testing.T) {
+		hostile := []struct{ repo, rev string }{
+			{"../../etc", "passwd"},
+			{"..", ".."},
+			{"a/../../b", "r"},
+			{"", ""},
+			{"./.", "."},
+		}
+		for _, c := range hostile {
+			p := branchEntryPath(dir, c.repo, c.rev)
+			rel, err := filepath.Rel(dir, p)
+			if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				t.Errorf("branchEntryPath(%q, %q) = %q escapes %q", c.repo, c.rev, p, dir)
+			}
+		}
+	})
+
+	t.Run("overlong segment falls back to hashed name", func(t *testing.T) {
+		repo := strings.Repeat("x", 300)
+		sum := sha256.Sum256([]byte(repo + "@main"))
+		want := filepath.Join(dir, hex.EncodeToString(sum[:])+".json")
+		if got := branchEntryPath(dir, repo, "main"); got != want {
+			t.Errorf("branchEntryPath overlong = %q, want hashed fallback %q", got, want)
+		}
+	})
+}
+
+// TestMirrorIndexLayout: branch mappings land at human-readable nested paths
+// and file entries group under their commit directory.
+func TestMirrorIndexLayout(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	commit := strings.Repeat("ab", 20)
+	data := []byte("layout test content")
+	upstream.commit = commit
+	upstream.set("/Qwen/Qwen3-0.6B/resolve/main/f.bin", data)
+	upstream.set("/Qwen/Qwen3-0.6B/resolve/"+commit+"/f.bin", data)
+
+	cacheDir := t.TempDir()
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), cacheDir)
+	resolveURL := fx.srv.URL + "/Qwen/Qwen3-0.6B/resolve/main/f.bin"
+
+	resp, err := http.Get(resolveURL)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if tok.CASURL != fx.srv.URL {
-		t.Fatalf("casUrl = %q, want %q", tok.CASURL, fx.srv.URL)
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	waitReady(t, resolveURL)
+
+	mappingPath := filepath.Join(cacheDir, "index", "branches", "Qwen", "Qwen3-0.6B", "main.json")
+	raw, err := os.ReadFile(mappingPath)
+	if err != nil {
+		t.Fatalf("read branch mapping: %v", err)
 	}
-	if tok.Exp <= time.Now().Unix() {
-		t.Fatalf("exp = %d, want in the future", tok.Exp)
+	var b branchEntry
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatal(err)
 	}
-	if !fx.issuer.Validate(tok.Token, time.Now()) {
-		t.Fatal("minted token does not validate")
+	if b.Repo != "Qwen/Qwen3-0.6B" || b.Rev != "main" || b.Commit != commit {
+		t.Fatalf("branch mapping = %+v, want repo Qwen/Qwen3-0.6B rev main commit %s", b, commit)
+	}
+
+	key := "/Qwen/Qwen3-0.6B/resolve/" + commit + "/f.bin"
+	sum := sha256.Sum256([]byte(key))
+	entryPath := filepath.Join(cacheDir, "index", commit, hex.EncodeToString(sum[:])+".json")
+	if _, err := os.Stat(entryPath); err != nil {
+		t.Fatalf("file entry not grouped under commit dir: %v", err)
+	}
+}
+
+// TestMirrorIndexMigration: entries persisted by older layouts (hashed branch
+// mapping names, flat file entries) move to their canonical locations on
+// startup and stay loaded.
+func TestMirrorIndexMigration(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	cacheDir := t.TempDir()
+	commit := strings.Repeat("cd", 20)
+
+	// Legacy hashed branch mapping.
+	branchDir := filepath.Join(cacheDir, "index", "branches")
+	if err := os.MkdirAll(branchDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	b := &branchEntry{Repo: "org/repo", Rev: "main", Commit: commit, CheckedAt: time.Now()}
+	rawB, err := json.Marshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bSum := sha256.Sum256([]byte("org/repo@main"))
+	legacyBranch := filepath.Join(branchDir, hex.EncodeToString(bSum[:])+".json")
+	if err := os.WriteFile(legacyBranch, rawB, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Legacy flat file entry.
+	key := "/org/repo/resolve/" + commit + "/f.bin"
+	e := &fileEntry{Key: key, State: stateReady, Size: 1, ETag: "etag-1", Commit: commit, CheckedAt: time.Now()}
+	rawE, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eSum := sha256.Sum256([]byte(key))
+	flatEntry := filepath.Join(cacheDir, "index", hex.EncodeToString(eSum[:])+".json")
+	if err := os.WriteFile(flatEntry, rawE, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), cacheDir)
+
+	if _, err := os.Stat(legacyBranch); !os.IsNotExist(err) {
+		t.Fatalf("legacy hashed branch mapping still present: %v", err)
+	}
+	readable := filepath.Join(branchDir, "org", "repo", "main.json")
+	if _, err := os.Stat(readable); err != nil {
+		t.Fatalf("migrated branch mapping missing: %v", err)
+	}
+
+	if _, err := os.Stat(flatEntry); !os.IsNotExist(err) {
+		t.Fatalf("legacy flat entry still present: %v", err)
+	}
+	moved := filepath.Join(cacheDir, "index", commit, hex.EncodeToString(eSum[:])+".json")
+	if _, err := os.Stat(moved); err != nil {
+		t.Fatalf("migrated file entry missing: %v", err)
+	}
+
+	fx.handler.mu.Lock()
+	loadedEntry := fx.handler.entries[key]
+	loadedBranch := fx.handler.branches["org/repo\x00main"]
+	fx.handler.mu.Unlock()
+	if loadedEntry == nil {
+		t.Fatal("migrated file entry not loaded")
+	}
+	if loadedBranch == nil || loadedBranch.Commit != commit {
+		t.Fatalf("migrated branch mapping not loaded: %+v", loadedBranch)
 	}
 }

--- a/mirror/upstream.go
+++ b/mirror/upstream.go
@@ -38,7 +38,10 @@ type probeResult struct {
 	etag   string
 	sha256 string // set when the upstream etag looks like a SHA-256
 	commit string
-	xet    bool // upstream advertised xet link headers on the resolve response
+	// realCommit records that commit came from the upstream rather than
+	// being synthesized; only real commits may pin branch revisions.
+	realCommit bool
+	xet        bool // upstream advertised xet link headers on the resolve response
 }
 
 var hexSHA256Re = regexp.MustCompile(`^[0-9a-f]{64}$`)
@@ -93,6 +96,7 @@ func (h *Handler) probe(ctx context.Context, key string) (*probeResult, error) {
 	if hexSHA256Re.MatchString(res.etag) {
 		res.sha256 = res.etag
 	}
+	res.realCommit = res.commit != ""
 	if res.commit == "" {
 		// Hub clients (huggingface_hub) refuse to download when the resolve
 		// response has no X-Repo-Commit; synthesize one for upstreams (e.g.

--- a/test/e2e/mirror_test.go
+++ b/test/e2e/mirror_test.go
@@ -7,9 +7,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -239,17 +239,32 @@ func pollResolveStatus(t *testing.T, resolveURL string, want int) string {
 }
 
 // waitIndexPersisted waits for the on-disk index entry, the mirror's
-// persistence contract for ready files.
+// persistence contract for ready files. Entries live under per-commit
+// directories; branch mappings under index/branches do not count.
 func waitIndexPersisted(t *testing.T, cacheDir string) {
 	t.Helper()
 	dir := filepath.Join(cacheDir, "index")
 	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
-		entries, _ := os.ReadDir(dir)
-		for _, de := range entries {
-			if strings.HasSuffix(de.Name(), ".json") {
-				return
+		found := false
+		_ = filepath.WalkDir(dir, func(path string, de fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
 			}
+			if de.IsDir() {
+				if de.Name() == "branches" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(de.Name(), ".json") {
+				found = true
+				return filepath.SkipAll
+			}
+			return nil
+		})
+		if found {
+			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}


### PR DESCRIPTION
Branch mappings were stored as `index/branches/<sha256(repo@rev)>.json`, so `ls` said nothing about which repo/branch a file pins. They now live at human-readable nested paths — `index/branches/Qwen/Qwen3-0.6B/main.json` — with the JSON body still carrying `repo`/`rev`/`commit`. Repo and rev come from request paths, so every segment goes through a small escaper: `%`, separators, control bytes, Windows-reserved punctuation, and a leading dot are percent-encoded (which covers `.`/`..` traversal), a directory segment ending in `.json` has its dot encoded so it can never collide with a mapping file beside it, and a segment that would exceed the filename limit falls back to the hashed name. `loadBranches` walks the tree on startup and moves anything found away from its canonical path, so existing hashed files migrate without decoding names — the body carries repo and rev.

This also lands the branch-pinning layer itself, which #133 was merged without: a branch revision resolves to the upstream commit it points at (one probe per repo branch on the revalidate cadence, reused by the ingest task), so entries, tasks, and spools are keyed by immutable content, and a commit-pinned request keeps serving the old bytes after the branch moves. Upstreams without a real commit keep the previous branch-keyed flow with per-entry revalidation. File entries group under their commit directory (`index/<commit>/<sha256(key)>.json`) with flat legacy files moved on load; tree listings rewrite `xetHash` through the pinned commit and `xet-read-token` is answered locally so hub clients stay on the mirror.

Fixes #147
