### PR TITLE
feat: add mark-and-sweep garbage collection for storage and the mirror index

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Implemented in this repository:
 - Upload and download client workflows
 - CAS server implementation for local or self-hosted usage
 - Mirror mode: full-cache middle layer bridging xet and plain hubs
+- Garbage collection for storage and the mirror index (periodic in-server via `xetd -gc-interval`)
 - Hugging Face token/LFS based integration helpers
 - Conformance and unit tests for key protocol paths
 

--- a/cmd/xetd/gc.go
+++ b/cmd/xetd/gc.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/wzshiming/xet/mirror"
+	"github.com/wzshiming/xet/storage"
+)
+
+// runPeriodicGC runs one in-process collection per interval on the serving
+// storage. With a mirror, retention is applied through the handler first so
+// memory and disk stay consistent, and its live entries become the roots;
+// otherwise every uploaded file is a root and only orphans are collected.
+func runPeriodicGC(st *storage.FileStorage, m *mirror.Handler, interval, grace, pruneAge time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		opts := []storage.GCOption{storage.WithGCGracePeriod(grace)}
+		if m != nil {
+			if pruneAge > 0 {
+				pruned, err := m.PruneIndex(pruneAge)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "gc: prune mirror index: %v\n", err)
+					continue
+				}
+				if pruned.RemovedEntries > 0 || pruned.RemovedBranches > 0 {
+					fmt.Printf("gc: pruned %d index entries, %d branch pins\n", pruned.RemovedEntries, pruned.RemovedBranches)
+				}
+			}
+			opts = append(opts, storage.WithGCRoots(m.GCRoots()))
+		}
+		res, err := st.GC(context.Background(), opts...)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gc: %v\n", err)
+			continue
+		}
+		if removed := res.RemovedFiles + res.RemovedShards + res.RemovedXorbs + res.RemovedChunks + res.RemovedSHA256s + res.RemovedTemps; removed > 0 {
+			fmt.Printf("gc: removed %d objects, reclaimed %d bytes (%d files, %d shards, %d xorbs live)\n",
+				removed, res.ReclaimedBytes, res.LiveFiles, res.LiveShards, res.LiveXorbs)
+		}
+	}
+}
+

--- a/cmd/xetd/gc.go
+++ b/cmd/xetd/gc.go
@@ -12,8 +12,10 @@ import (
 
 // runPeriodicGC runs one in-process collection per interval on the serving
 // storage. With a mirror, retention is applied through the handler first so
-// memory and disk stay consistent, and its live entries become the roots;
-// otherwise every uploaded file is a root and only orphans are collected.
+// memory and disk stay consistent, and its live entries become the roots -
+// together with pinned direct uploads, so self-hosted content coexisting
+// with the mirror is never collected; otherwise every uploaded file is a
+// root and only orphans are collected.
 func runPeriodicGC(st *storage.FileStorage, m *mirror.Handler, interval, grace, pruneAge time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -37,10 +39,9 @@ func runPeriodicGC(st *storage.FileStorage, m *mirror.Handler, interval, grace, 
 			fmt.Fprintf(os.Stderr, "gc: %v\n", err)
 			continue
 		}
-		if removed := res.RemovedFiles + res.RemovedShards + res.RemovedXorbs + res.RemovedChunks + res.RemovedSHA256s + res.RemovedTemps; removed > 0 {
+		if removed := res.RemovedFiles + res.RemovedShards + res.RemovedXorbs + res.RemovedChunks + res.RemovedSHA256s + res.RemovedPins + res.RemovedTemps; removed > 0 {
 			fmt.Printf("gc: removed %d objects, reclaimed %d bytes (%d files, %d shards, %d xorbs live)\n",
 				removed, res.ReclaimedBytes, res.LiveFiles, res.LiveShards, res.LiveXorbs)
 		}
 	}
 }
-

--- a/cmd/xetd/main.go
+++ b/cmd/xetd/main.go
@@ -23,6 +23,9 @@ func main() {
 	authToken := flag.String("token", "", "Authentication token; also the secret for minted short-lived tokens (optional, if set, clients must provide this token or a minted one)")
 	upstream := flag.String("upstream", "", "Upstream hub URL to mirror, e.g. https://huggingface.co (enables mirror mode)")
 	upstreamToken := flag.String("upstream-token", "", "Bearer token the mirror uses against the upstream hub")
+	gcInterval := flag.Duration("gc-interval", 0, "Run in-process garbage collection at this interval while serving (0 disables); roots are the mirror index in mirror mode, every uploaded file otherwise")
+	gcGrace := flag.Duration("gc-grace", storage.DefaultGCGracePeriod, "GC never removes objects modified within this window; must exceed the longest upload or ingest")
+	gcPruneIndex := flag.Duration("gc-prune-index", 0, "During periodic GC, drop mirror index entries and branch pins not used within this window (0 disables)")
 	flag.Parse()
 
 	// Create storage
@@ -56,12 +59,13 @@ func main() {
 	}
 
 	var next http.Handler
+	var mirrorHandler *mirror.Handler
 
 	if *upstream != "" {
 		// Mirror mode: full-cache middle layer in front of the upstream hub.
 		// The mirror handles resolve/token requests and proxies the rest to
 		// the upstream; the CAS server below matches its own routes first.
-		next, err = mirror.NewHandler(
+		mirrorHandler, err = mirror.NewHandler(
 			mirror.WithStorage(storage),
 			mirror.WithUpstream(*upstream),
 			mirror.WithUpstreamToken(*upstreamToken),
@@ -73,8 +77,14 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Failed to create mirror: %v\n", err)
 			os.Exit(1)
 		}
+		next = mirrorHandler
 
 		fmt.Printf("Mirror mode enabled, upstream: %s\n", *upstream)
+	}
+
+	if *gcInterval > 0 {
+		go runPeriodicGC(storage, mirrorHandler, *gcInterval, *gcGrace, *gcPruneIndex)
+		fmt.Printf("Periodic GC enabled, interval: %s, grace: %s\n", *gcInterval, *gcGrace)
 	}
 
 	// Create server

--- a/cmd/xetd/main.go
+++ b/cmd/xetd/main.go
@@ -23,7 +23,7 @@ func main() {
 	authToken := flag.String("token", "", "Authentication token; also the secret for minted short-lived tokens (optional, if set, clients must provide this token or a minted one)")
 	upstream := flag.String("upstream", "", "Upstream hub URL to mirror, e.g. https://huggingface.co (enables mirror mode)")
 	upstreamToken := flag.String("upstream-token", "", "Bearer token the mirror uses against the upstream hub")
-	gcInterval := flag.Duration("gc-interval", 0, "Run in-process garbage collection at this interval while serving (0 disables); roots are the mirror index in mirror mode, every uploaded file otherwise")
+	gcInterval := flag.Duration("gc-interval", 0, "Run in-process garbage collection at this interval while serving (0 disables); roots are the mirror index plus pinned direct uploads in mirror mode, every uploaded file otherwise")
 	gcGrace := flag.Duration("gc-grace", storage.DefaultGCGracePeriod, "GC never removes objects modified within this window; must exceed the longest upload or ingest")
 	gcPruneIndex := flag.Duration("gc-prune-index", 0, "During periodic GC, drop mirror index entries and branch pins not used within this window (0 disables)")
 	flag.Parse()

--- a/mirror/gc.go
+++ b/mirror/gc.go
@@ -1,0 +1,135 @@
+package mirror
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/wzshiming/xet"
+)
+
+// GCRoots returns the file hashes of the handler's current ready entries:
+// the live root set for an in-process storage collection on a running
+// mirror. In-flight ingests are not listed; their freshly written storage is
+// protected by the GC grace period.
+func (h *Handler) GCRoots() []xet.FileHash {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	seen := make(map[xet.FileHash]struct{}, len(h.entries))
+	roots := make([]xet.FileHash, 0, len(h.entries))
+	for _, e := range h.entries {
+		if e.State != stateReady || e.FileHash == "" {
+			continue
+		}
+		fh, err := xet.ParseFileHash(e.FileHash)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[fh]; ok {
+			continue
+		}
+		seen[fh] = struct{}{}
+		roots = append(roots, fh)
+	}
+	return roots
+}
+
+// PruneIndex applies age-based retention to the mirror index. Branch
+// mappings not re-checked within maxAge are dropped first; then every ready
+// entry whose commit is not pinned by a surviving branch mapping and whose
+// CheckedAt is older than maxAge is removed. Entries under pinned commits
+// are kept regardless of age: they are the current content of a live branch,
+// and commit-keyed entries are never revalidated so their CheckedAt stays at
+// ingest time.
+//
+// Entries and branch pins leave memory and disk together, so pruned content
+// is re-ingested on the next request instead of being served against storage
+// a following GC removed. A subsequent storage GC rooted in GCRoots reclaims
+// the shards and xorbs only the pruned entries referenced.
+func (h *Handler) PruneIndex(maxAge time.Duration) (*PruneResult, error) {
+	if maxAge <= 0 {
+		return nil, fmt.Errorf("mirror: retention age must be positive")
+	}
+	cutoff := time.Now().Add(-maxAge)
+	res := &PruneResult{}
+	branchDir := h.branchDir()
+	var paths []string
+
+	h.mu.Lock()
+	pinned := map[string]struct{}{}
+	for key, b := range h.branches {
+		if b.CheckedAt.Before(cutoff) {
+			delete(h.branches, key)
+			paths = append(paths, branchEntryPath(branchDir, b.Repo, b.Rev))
+			res.RemovedBranches++
+			continue
+		}
+		if b.Commit != "" {
+			pinned[b.Commit] = struct{}{}
+		}
+	}
+	for key, e := range h.entries {
+		if e.State != stateReady {
+			continue // failure records are transient and memory-only
+		}
+		if _, ok := pinned[e.Commit]; ok && e.Commit != "" {
+			continue
+		}
+		if !e.CheckedAt.Before(cutoff) {
+			continue
+		}
+		delete(h.entries, key)
+		paths = append(paths, indexEntryPath(h.indexDir, e.Commit, e.Key))
+		res.RemovedEntries++
+	}
+	h.mu.Unlock()
+
+	for _, p := range paths {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return res, fmt.Errorf("remove pruned index file: %w", err)
+		}
+	}
+	removeEmptyCommitDirs(h.indexDir)
+	removeEmptyDirs(branchDir)
+	return res, nil
+}
+
+// PruneResult summarizes one retention pass over the mirror index.
+type PruneResult struct {
+	RemovedEntries  int
+	RemovedBranches int
+}
+
+// removeEmptyCommitDirs removes commit directories left empty by pruning.
+func removeEmptyCommitDirs(indexDir string) {
+	ents, err := os.ReadDir(indexDir)
+	if err != nil {
+		return
+	}
+	for _, de := range ents {
+		if de.IsDir() && commitRevRe.MatchString(de.Name()) {
+			_ = os.Remove(filepath.Join(indexDir, de.Name())) // fails while non-empty
+		}
+	}
+}
+
+// removeEmptyDirs removes directories under root left empty by pruning,
+// children before parents; root itself is kept.
+func removeEmptyDirs(root string) {
+	var dirs []string
+	_ = filepath.WalkDir(root, func(path string, de fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if de.IsDir() && path != root {
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+	// WalkDir is pre-order, so the reverse visits children before parents.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		_ = os.Remove(dirs[i]) // fails while non-empty, which keeps it
+	}
+}

--- a/mirror/gc_test.go
+++ b/mirror/gc_test.go
@@ -1,0 +1,176 @@
+package mirror
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/storage"
+)
+
+// newIndexHandler creates a handler over an existing cache dir, loading the
+// persisted index like a server restart would.
+func newIndexHandler(t *testing.T, cacheDir string) *Handler {
+	t.Helper()
+	stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := NewHandler(
+		WithStorage(stor),
+		WithUpstream("http://upstream.invalid"),
+		WithCacheDir(cacheDir),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func TestHandlerGCRoots(t *testing.T) {
+	cacheDir := t.TempDir()
+	indexDir := filepath.Join(cacheDir, "index")
+	commit := strings.Repeat("a", 40)
+	hashA := xet.FileHash{1, 2, 3}.String()
+	hashB := xet.FileHash{4, 5, 6}.String()
+
+	entries := []*fileEntry{
+		{Key: "/org/repo/resolve/" + commit + "/a.bin", State: stateReady, FileHash: hashA, Commit: commit, CheckedAt: time.Now()},
+		{Key: "/org/repo/resolve/" + commit + "/b.bin", State: stateReady, FileHash: hashB, Commit: commit, CheckedAt: time.Now()},
+		// Duplicate hash under another key: must be returned once.
+		{Key: "/org/other/resolve/main/a.bin", State: stateReady, FileHash: hashA, CheckedAt: time.Now()},
+		// Empty file: no storage behind it.
+		{Key: "/org/repo/resolve/" + commit + "/empty.bin", State: stateReady, Commit: commit, CheckedAt: time.Now()},
+		// Corrupt hash: cannot address storage.
+		{Key: "/org/repo/resolve/" + commit + "/broken.bin", State: stateReady, FileHash: "not-a-hash", Commit: commit, CheckedAt: time.Now()},
+	}
+	for _, e := range entries {
+		if err := persistEntry(indexDir, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	roots := newIndexHandler(t, cacheDir).GCRoots()
+	got := map[string]bool{}
+	for _, h := range roots {
+		got[h.String()] = true
+	}
+	if len(roots) != 2 || !got[hashA] || !got[hashB] {
+		t.Fatalf("roots = %v, want exactly {%s, %s}", got, hashA, hashB)
+	}
+}
+
+func TestHandlerPruneIndex(t *testing.T) {
+	cacheDir := t.TempDir()
+	indexDir := filepath.Join(cacheDir, "index")
+	branchDir := filepath.Join(indexDir, "branches")
+	now := time.Now()
+	old := now.Add(-48 * time.Hour)
+	pinnedCommit := strings.Repeat("1", 40)
+	staleCommit := strings.Repeat("2", 40)
+	abandonedCommit := strings.Repeat("3", 40)
+
+	// A live branch pins pinnedCommit; a branch not checked for two days
+	// pinned staleCommit and must lose its pin.
+	branches := []*branchEntry{
+		{Repo: "org/live", Rev: "main", Commit: pinnedCommit, CheckedAt: now},
+		{Repo: "org/stale", Rev: "main", Commit: staleCommit, CheckedAt: old},
+	}
+	for _, b := range branches {
+		if err := persistBranch(branchDir, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	entries := []*fileEntry{
+		// Old but pinned by the live branch: kept.
+		{Key: "/org/live/resolve/" + pinnedCommit + "/model.bin", State: stateReady, FileHash: xet.FileHash{1}.String(), Commit: pinnedCommit, CheckedAt: old},
+		// Old under the stale branch's commit: pin gone, pruned.
+		{Key: "/org/stale/resolve/" + staleCommit + "/model.bin", State: stateReady, FileHash: xet.FileHash{2}.String(), Commit: staleCommit, CheckedAt: old},
+		// Old under a commit no branch ever pinned: pruned.
+		{Key: "/org/live/resolve/" + abandonedCommit + "/model.bin", State: stateReady, FileHash: xet.FileHash{3}.String(), Commit: abandonedCommit, CheckedAt: old},
+		// Recently checked flat entry (pseudo-commit upstream): kept.
+		{Key: "/org/flat/resolve/main/fresh.bin", State: stateReady, FileHash: xet.FileHash{4}.String(), CheckedAt: now},
+		// Flat entry not revalidated for two days: pruned.
+		{Key: "/org/flat/resolve/main/stale.bin", State: stateReady, FileHash: xet.FileHash{5}.String(), CheckedAt: old},
+	}
+	for _, e := range entries {
+		if err := persistEntry(indexDir, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	h := newIndexHandler(t, cacheDir)
+	if _, err := h.PruneIndex(0); err == nil {
+		t.Fatal("PruneIndex(0) should fail")
+	}
+	if roots := h.GCRoots(); len(roots) != 5 {
+		t.Fatalf("GCRoots before prune = %d, want 5", len(roots))
+	}
+
+	res, err := h.PruneIndex(24 * time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RemovedEntries != 3 || res.RemovedBranches != 1 {
+		t.Fatalf("prune = %+v, want 3 entries, 1 branch", res)
+	}
+
+	// Memory and disk agree: pruned entries are gone from both, so a new
+	// request re-ingests instead of serving storage a later GC removes.
+	assertEntry := func(e *fileEntry, want bool) {
+		t.Helper()
+		h.mu.Lock()
+		_, inMemory := h.entries[e.Key]
+		h.mu.Unlock()
+		if inMemory != want {
+			t.Fatalf("entry %s in memory = %v, want %v", e.Key, inMemory, want)
+		}
+		_, err := os.Stat(indexEntryPath(indexDir, e.Commit, e.Key))
+		if want && err != nil {
+			t.Fatalf("entry %s should remain on disk: %v", e.Key, err)
+		}
+		if !want && !os.IsNotExist(err) {
+			t.Fatalf("entry %s should be pruned from disk (err=%v)", e.Key, err)
+		}
+	}
+	assertEntry(entries[0], true)
+	assertEntry(entries[1], false)
+	assertEntry(entries[2], false)
+	assertEntry(entries[3], true)
+	assertEntry(entries[4], false)
+
+	h.mu.Lock()
+	_, staleBranchInMemory := h.branches["org/stale\x00main"]
+	_, liveBranchInMemory := h.branches["org/live\x00main"]
+	h.mu.Unlock()
+	if staleBranchInMemory || !liveBranchInMemory {
+		t.Fatalf("branches in memory: stale=%v live=%v", staleBranchInMemory, liveBranchInMemory)
+	}
+	if _, err := os.Stat(branchEntryPath(branchDir, "org/live", "main")); err != nil {
+		t.Fatalf("live branch mapping should remain: %v", err)
+	}
+	if _, err := os.Stat(branchEntryPath(branchDir, "org/stale", "main")); !os.IsNotExist(err) {
+		t.Fatalf("stale branch mapping should be pruned (err=%v)", err)
+	}
+	// Emptied commit directories and branch repo directories are cleaned up.
+	if _, err := os.Stat(filepath.Join(indexDir, staleCommit)); !os.IsNotExist(err) {
+		t.Fatalf("empty commit dir should be pruned (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(branchDir, "org", "stale")); !os.IsNotExist(err) {
+		t.Fatalf("empty branch repo dir should be pruned (err=%v)", err)
+	}
+
+	// The surviving entries are exactly the storage GC roots.
+	roots := h.GCRoots()
+	got := map[string]bool{}
+	for _, r := range roots {
+		got[r.String()] = true
+	}
+	if len(roots) != 2 || !got[entries[0].FileHash] || !got[entries[3].FileHash] {
+		t.Fatalf("GCRoots after prune = %v, want pinned and fresh hashes", got)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -466,6 +466,13 @@ func (s *Handler) storeUploadedShard(r *http.Request) (bool, int, error) {
 	if err != nil {
 		return false, http.StatusInternalServerError, fmt.Errorf("failed to store shard")
 	}
+	// Direct uploads are pinned as permanent GC roots; pinning also when the
+	// shard already existed covers re-uploads of content the mirror ingested.
+	for _, fileBlock := range shardObj.Files {
+		if err := s.storage.PinFile(r.Context(), "default", fileBlock.FileHash); err != nil {
+			return false, http.StatusInternalServerError, fmt.Errorf("failed to pin uploaded file")
+		}
+	}
 	return wasInserted, http.StatusOK, nil
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -125,6 +125,81 @@ func TestXetBridgeExtractsCompleteFileBySHA256(t *testing.T) {
 	})
 }
 
+// TestUploadedShardIsPinnedAgainstMirrorRootedGC uploads a file through the
+// HTTP shard endpoint and proves it survives a collection rooted only in a
+// (here empty) mirror index, the mixed mirror + self-hosted deployment.
+func TestUploadedShardIsPinnedAgainstMirrorRootedGC(t *testing.T) {
+	ctx := context.Background()
+	stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := NewHandler(WithStorage(stor))
+
+	content := []byte("self-hosted model weights")
+	var encoded bytes.Buffer
+	encoder := xorb.NewEncoder(&encoded, true)
+	if _, err := encoder.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatal(err)
+	}
+	xorbHash := encoder.SummoryHash()
+	if _, err := stor.PutXorb(ctx, "default", xorbHash, bytes.NewReader(encoded.Bytes())); err != nil {
+		t.Fatal(err)
+	}
+	chunkHash := xet.ComputeChunkHash(content)
+	shardObj := shard.NewShard()
+	shardObj.AddFile(shard.FileBlock{
+		FileHash: xet.ComputeFileHash([]xet.ChunkHash{chunkHash}, []uint64{uint64(len(content))}),
+		Entries: []shard.FileDataSequenceEntry{
+			{CASHash: xorbHash, UnpackedSegBytes: uint32(len(content)), ChunkIndexEnd: 1},
+		},
+	})
+	shardObj.AddCASBlock(shard.CASBlock{
+		CASHash:       xorbHash,
+		Chunks:        []shard.CASChunkSequenceEntry{{ChunkHash: chunkHash, UnpackedSegBytes: uint32(len(content))}},
+		NumBytesInCAS: uint32(len(content)),
+	})
+	shardBody, err := shardObj.Encode(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := io.ReadAll(shardBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/shards", bytes.NewReader(raw)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upload status = %d, body = %q", rec.Code, rec.Body.String())
+	}
+
+	// A mirror-rooted collection with no ready entries would otherwise
+	// remove everything the upload just stored.
+	res, err := stor.GC(ctx, storage.WithGCGracePeriod(0), storage.WithGCRoots(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.LiveFiles != 1 || res.RemovedShards != 0 || res.RemovedXorbs != 0 {
+		t.Fatalf("GC = %+v, upload was not pinned", res)
+	}
+
+	digest := sha256.Sum256(content)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/xet-bridge/"+hex.EncodeToString(digest[:]), nil))
+	resp := rec.Result()
+	defer resp.Body.Close()
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK || !bytes.Equal(got, content) {
+		t.Fatalf("status = %d, body = %q, want the uploaded content", resp.StatusCode, got)
+	}
+}
+
 func TestXetBridgeRejectsInvalidAndUnknownSHA256(t *testing.T) {
 	stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
 	if err != nil {

--- a/server/shard_v2.go
+++ b/server/shard_v2.go
@@ -208,6 +208,14 @@ func (s *Handler) handleUploadShardV2(w http.ResponseWriter, r *http.Request) {
 		finishWithError("failed to store shard", true)
 		return
 	}
+	// Direct uploads are pinned as permanent GC roots; pinning also when the
+	// shard already existed covers re-uploads of content the mirror ingested.
+	for _, fileBlock := range shardObj.Files {
+		if err := s.storage.PinFile(r.Context(), "default", fileBlock.FileHash); err != nil {
+			finishWithError("failed to pin uploaded file", true)
+			return
+		}
+	}
 	if err := stream.committing("syncing"); err != nil {
 		return
 	}

--- a/server/shard_v2_test.go
+++ b/server/shard_v2_test.go
@@ -35,6 +35,10 @@ func (s *shardV2TestStorage) PutShard(context.Context, *shard.Shard) (bool, erro
 	return true, nil
 }
 
+func (s *shardV2TestStorage) PinFile(context.Context, string, xet.FileHash) error {
+	return nil
+}
+
 type shardUploadWireEvent struct {
 	Type      string `json:"type"`
 	Verified  uint64 `json:"verified"`

--- a/storage/gc.go
+++ b/storage/gc.go
@@ -1,0 +1,360 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/shard"
+)
+
+// DefaultGCGracePeriod is the default modification-time window inside which
+// GC never removes anything, protecting in-flight uploads and ingests whose
+// objects are not yet referenced. It must exceed the longest expected upload.
+const DefaultGCGracePeriod = 24 * time.Hour
+
+// GCResult summarizes one mark-and-sweep collection.
+type GCResult struct {
+	// LiveFiles, LiveShards and LiveXorbs count the objects reachable from
+	// the roots (including grace-pinned in-flight files).
+	LiveFiles  int
+	LiveShards int
+	LiveXorbs  int
+
+	// BrokenRoots counts roots that no longer resolve to a stored shard;
+	// their leftover index entries are swept like any other garbage.
+	BrokenRoots int
+
+	RemovedFiles   int
+	RemovedShards  int
+	RemovedXorbs   int
+	RemovedChunks  int
+	RemovedSHA256s int
+	RemovedTemps   int
+
+	ReclaimedBytes int64
+}
+
+type gcConfig struct {
+	roots    []xet.FileHash
+	hasRoots bool
+	grace    time.Duration
+	dryRun   bool
+}
+
+// GCOption configures a garbage collection run.
+type GCOption func(*gcConfig)
+
+// WithGCRoots restricts the live set to the given root file hashes, e.g. the
+// mirror's ready index entries. Without this option every stored file index
+// entry is a root, which is the model for a standalone CAS server: uploaded
+// files stay forever and only orphaned shards, xorbs and dangling index
+// entries are collected.
+func WithGCRoots(roots []xet.FileHash) GCOption {
+	return func(c *gcConfig) {
+		c.roots = roots
+		c.hasRoots = true
+	}
+}
+
+// WithGCGracePeriod sets the window inside which recently modified objects
+// are never removed. Defaults to DefaultGCGracePeriod.
+func WithGCGracePeriod(d time.Duration) GCOption {
+	return func(c *gcConfig) { c.grace = d }
+}
+
+// WithGCDryRun reports what would be removed without deleting anything.
+func WithGCDryRun(dryRun bool) GCOption {
+	return func(c *gcConfig) { c.dryRun = dryRun }
+}
+
+// objectNameRe matches on-disk object names: both xet hashes and SHA-256
+// digests render as 64 lowercase hex characters.
+var objectNameRe = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// GC performs a mark-and-sweep collection over the storage directory. Roots
+// are file hashes (see WithGCRoots); from each root the files index resolves
+// to a shard, and the shard to every xorb it references. Everything else -
+// file and sha256 index entries of unreachable files, shards nobody
+// references, xorbs no live shard uses, chunk index entries pointing at dead
+// shards, and stale temporary files - is removed, oldest-reference first so a
+// crash mid-sweep never leaves an index entry pointing at a removed object
+// that a live one referenced.
+//
+// Objects modified within the grace period are neither collected nor treated
+// as broken; file index entries younger than the grace period additionally
+// pin their shard and xorbs even when they are not roots, so a just-finished
+// ingest whose root registration has not landed yet keeps its storage. The
+// grace period must exceed the longest expected upload or ingest.
+//
+// GC may run in-process while the server is serving: the sweep order and the
+// final cache flush keep dedup answers consistent, and PutShard verifies
+// every referenced xorb by reconstructing the file, so an upload that raced a
+// collection fails and retries instead of storing a broken reference.
+// Collecting a live server's directory from a separate process is not
+// supported, because that server's in-memory state would go stale.
+func (fs *FileStorage) GC(ctx context.Context, opts ...GCOption) (*GCResult, error) {
+	cfg := gcConfig{grace: DefaultGCGracePeriod}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.grace < 0 {
+		return nil, fmt.Errorf("gc: grace period must not be negative")
+	}
+	cutoff := time.Now().Add(-cfg.grace)
+	res := &GCResult{}
+
+	// Mark phase: gather candidate roots. With an explicit root set, file
+	// index entries still inside the grace window are pinned as well.
+	candidates := map[string]struct{}{}
+	for _, h := range cfg.roots {
+		candidates[h.String()] = struct{}{}
+	}
+	err := fs.gcWalk("files", func(name, _ string, info os.FileInfo, isObject bool) error {
+		if !isObject {
+			return nil
+		}
+		if !cfg.hasRoots || info.ModTime().After(cutoff) {
+			candidates[name] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	liveFiles := make(map[string]struct{}, len(candidates))
+	liveShards := map[string]struct{}{}
+	liveXorbs := map[string]struct{}{}
+	for name := range candidates {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		b, err := os.ReadFile(fs.objectPath("files", name))
+		if err != nil {
+			res.BrokenRoots++
+			continue
+		}
+		shardHash := strings.TrimSpace(string(b))
+		if _, ok := liveShards[shardHash]; ok {
+			liveFiles[name] = struct{}{}
+			continue
+		}
+		s, err := fs.readShardForGC(shardHash)
+		if err != nil {
+			res.BrokenRoots++
+			continue
+		}
+		liveFiles[name] = struct{}{}
+		liveShards[shardHash] = struct{}{}
+		// A shard references xorbs in two places: CASInfos for the xorbs it
+		// uploaded itself, and file term entries for xorbs deduplicated from
+		// other shards. Both must stay for its files to reconstruct.
+		for _, casBlock := range s.CASInfos {
+			liveXorbs[casBlock.CASHash.String()] = struct{}{}
+		}
+		for _, fileBlock := range s.Files {
+			for _, entry := range fileBlock.Entries {
+				liveXorbs[entry.CASHash.String()] = struct{}{}
+			}
+		}
+	}
+	res.LiveFiles = len(liveFiles)
+	res.LiveShards = len(liveShards)
+	res.LiveXorbs = len(liveXorbs)
+
+	// Sweep phase: index entries first, then the objects they point at, so
+	// an interrupted run leaves unreferenced objects (collected by the next
+	// run) rather than dangling references.
+	sweeps := []struct {
+		kind    string
+		removed *int
+		dead    func(name, path string) bool
+	}{
+		{"files", &res.RemovedFiles, func(name, _ string) bool {
+			_, live := liveFiles[name]
+			return !live
+		}},
+		{"sha256", &res.RemovedSHA256s, func(_, path string) bool {
+			target, err := os.ReadFile(path)
+			if err != nil {
+				return false
+			}
+			_, live := liveFiles[strings.TrimSpace(string(target))]
+			return !live
+		}},
+		{"chunks", &res.RemovedChunks, func(_, path string) bool {
+			target, err := os.ReadFile(path)
+			if err != nil {
+				return false
+			}
+			_, live := liveShards[strings.TrimSpace(string(target))]
+			return !live
+		}},
+		{"shards", &res.RemovedShards, func(name, _ string) bool {
+			_, live := liveShards[name]
+			return !live
+		}},
+		{"xorbs", &res.RemovedXorbs, func(name, _ string) bool {
+			_, live := liveXorbs[name]
+			return !live
+		}},
+	}
+	for _, sw := range sweeps {
+		if err := fs.gcSweep(ctx, sw.kind, cutoff, &cfg, res, sw.removed, sw.dead); err != nil {
+			return nil, err
+		}
+	}
+
+	// Drop the in-memory caches: they may hold mappings and open handles for
+	// objects that no longer exist.
+	if !cfg.dryRun {
+		fs.fileMut.Lock()
+		fs.fileIndex.Clear()
+		fs.fileMut.Unlock()
+		fs.shardMut.Lock()
+		fs.shardIndex.Clear()
+		fs.shardMut.Unlock()
+		fs.chunkMut.Lock()
+		fs.chunkIndex.Clear()
+		fs.chunkMut.Unlock()
+		fs.sha256Mut.Lock()
+		fs.sha256Index.Clear()
+		fs.sha256Mut.Unlock()
+		fs.xorbMut.Lock()
+		fs.xorbIndex.Clear() // OnEvicted closes the cached handles
+		fs.xorbMut.Unlock()
+	}
+
+	return res, nil
+}
+
+// readShardForGC loads a shard from disk without touching the in-memory
+// caches, which are cleared wholesale at the end of a collection.
+func (fs *FileStorage) readShardForGC(shardHash string) (*shard.Shard, error) {
+	f, err := os.Open(fs.objectPath("shards", shardHash))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	s := shard.NewShard()
+	if err := s.Decode(f, true); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// gcWalk visits every regular file under basePath/kind, reassembling fanout
+// names (bucket prefix + file name). Entries whose name is not a well-formed
+// object name (temp files, strays) are reported with isObject=false.
+func (fs *FileStorage) gcWalk(kind string, fn func(name, path string, info os.FileInfo, isObject bool) error) error {
+	root := filepath.Join(fs.basePath, kind)
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s directory: %w", kind, err)
+	}
+	visit := func(name, path string, de os.DirEntry) error {
+		info, err := de.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		return fn(name, path, info, objectNameRe.MatchString(name))
+	}
+	for _, ent := range ents {
+		if !ent.IsDir() {
+			if err := visit(ent.Name(), filepath.Join(root, ent.Name()), ent); err != nil {
+				return err
+			}
+			continue
+		}
+		bucket := ent.Name()
+		subEnts, err := os.ReadDir(filepath.Join(root, bucket))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("read %s bucket %s: %w", kind, bucket, err)
+		}
+		for _, se := range subEnts {
+			if se.IsDir() {
+				continue
+			}
+			if err := visit(bucket+se.Name(), filepath.Join(root, bucket, se.Name()), se); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// isTempName reports whether name is a leftover from an interrupted atomic
+// write: the ".tmp" rename staging files and CreateTemp shard files.
+func isTempName(name string) bool {
+	return strings.HasSuffix(name, ".tmp") || strings.HasPrefix(filepath.Base(name), ".shard-")
+}
+
+// gcSweep removes the entries under kind for which dead returns true, plus
+// stale temporary files, honoring the grace cutoff and dry-run mode. Emptied
+// fanout buckets are pruned afterwards.
+func (fs *FileStorage) gcSweep(ctx context.Context, kind string, cutoff time.Time, cfg *gcConfig, res *GCResult, removed *int, dead func(name, path string) bool) error {
+	err := fs.gcWalk(kind, func(name, path string, info os.FileInfo, isObject bool) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if info.ModTime().After(cutoff) {
+			return nil
+		}
+		counter := removed
+		if !isObject {
+			if !isTempName(name) {
+				return nil // stray file: leave it for the operator
+			}
+			counter = &res.RemovedTemps
+		} else if !dead(name, path) {
+			return nil
+		}
+		if !cfg.dryRun {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove %s: %w", path, err)
+			}
+		}
+		*counter++
+		res.ReclaimedBytes += info.Size()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if !cfg.dryRun {
+		fs.pruneEmptyBuckets(kind)
+	}
+	return nil
+}
+
+// pruneEmptyBuckets removes fanout directories emptied by a sweep. Removal
+// of a non-empty directory fails, which is exactly the keep signal.
+func (fs *FileStorage) pruneEmptyBuckets(kind string) {
+	root := filepath.Join(fs.basePath, kind)
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	for _, ent := range ents {
+		if ent.IsDir() {
+			_ = os.Remove(filepath.Join(root, ent.Name()))
+		}
+	}
+}

--- a/storage/gc.go
+++ b/storage/gc.go
@@ -35,6 +35,7 @@ type GCResult struct {
 	RemovedXorbs   int
 	RemovedChunks  int
 	RemovedSHA256s int
+	RemovedPins    int
 	RemovedTemps   int
 
 	ReclaimedBytes int64
@@ -51,10 +52,11 @@ type gcConfig struct {
 type GCOption func(*gcConfig)
 
 // WithGCRoots restricts the live set to the given root file hashes, e.g. the
-// mirror's ready index entries. Without this option every stored file index
-// entry is a root, which is the model for a standalone CAS server: uploaded
-// files stay forever and only orphaned shards, xorbs and dangling index
-// entries are collected.
+// mirror's ready index entries, plus every pinned file (see PinFile), so
+// directly uploaded content survives collections rooted in the mirror index.
+// Without this option every stored file index entry is a root, which is the
+// model for a standalone CAS server: uploaded files stay forever and only
+// orphaned shards, xorbs and dangling index entries are collected.
 func WithGCRoots(roots []xet.FileHash) GCOption {
 	return func(c *gcConfig) {
 		c.roots = roots
@@ -78,13 +80,14 @@ func WithGCDryRun(dryRun bool) GCOption {
 var objectNameRe = regexp.MustCompile(`^[0-9a-f]{64}$`)
 
 // GC performs a mark-and-sweep collection over the storage directory. Roots
-// are file hashes (see WithGCRoots); from each root the files index resolves
-// to a shard, and the shard to every xorb it references. Everything else -
-// file and sha256 index entries of unreachable files, shards nobody
-// references, xorbs no live shard uses, chunk index entries pointing at dead
-// shards, and stale temporary files - is removed, oldest-reference first so a
-// crash mid-sweep never leaves an index entry pointing at a removed object
-// that a live one referenced.
+// are file hashes: the set given via WithGCRoots plus every pinned file, or
+// every stored file when no explicit set is given. From each root the files
+// index resolves to a shard, and the shard to every xorb it references.
+// Everything else - file and sha256 index entries of unreachable files,
+// shards nobody references, xorbs no live shard uses, chunk index entries
+// pointing at dead shards, dangling pins, and stale temporary files - is
+// removed, oldest-reference first so a crash mid-sweep never leaves an index
+// entry pointing at a removed object that a live one referenced.
 //
 // Objects modified within the grace period are neither collected nor treated
 // as broken; file index entries younger than the grace period additionally
@@ -109,11 +112,23 @@ func (fs *FileStorage) GC(ctx context.Context, opts ...GCOption) (*GCResult, err
 	cutoff := time.Now().Add(-cfg.grace)
 	res := &GCResult{}
 
-	// Mark phase: gather candidate roots. With an explicit root set, file
-	// index entries still inside the grace window are pinned as well.
+	// Mark phase: gather candidate roots. With an explicit root set, pinned
+	// files (direct uploads) and file index entries still inside the grace
+	// window are roots as well.
 	candidates := map[string]struct{}{}
 	for _, h := range cfg.roots {
 		candidates[h.String()] = struct{}{}
+	}
+	if cfg.hasRoots {
+		err := fs.gcWalk("pins", func(name, _ string, _ os.FileInfo, isObject bool) error {
+			if isObject {
+				candidates[name] = struct{}{}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 	err := fs.gcWalk("files", func(name, _ string, info os.FileInfo, isObject bool) error {
 		if !isObject {
@@ -176,6 +191,10 @@ func (fs *FileStorage) GC(ctx context.Context, opts ...GCOption) (*GCResult, err
 		removed *int
 		dead    func(name, path string) bool
 	}{
+		{"pins", &res.RemovedPins, func(name, _ string) bool {
+			_, live := liveFiles[name]
+			return !live // only dangling pins: a resolvable pin makes its file live
+		}},
 		{"files", &res.RemovedFiles, func(name, _ string) bool {
 			_, live := liveFiles[name]
 			return !live

--- a/storage/gc_test.go
+++ b/storage/gc_test.go
@@ -385,6 +385,51 @@ func TestGCKeepsXorbsDeduplicatedFromDeadShards(t *testing.T) {
 	}
 }
 
+func TestGCPinnedFilesSurviveExplicitRoots(t *testing.T) {
+	ctx := context.Background()
+	fs, err := NewFileStorage(WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A direct upload (pinned) and a mirror ingest (unpinned), with no
+	// explicit roots at all: only the pin keeps content alive.
+	pinned := putTestFile(t, fs, []byte("self-hosted upload"))
+	unpinned := putTestFile(t, fs, []byte("mirror ingested content"))
+	if err := fs.PinFile(ctx, "default", pinned.fileHash); err != nil {
+		t.Fatal(err)
+	}
+	// A pin whose file never landed is itself garbage.
+	danglingHash := xet.FileHash{0xde, 0xad}
+	if err := fs.PinFile(ctx, "default", danglingHash); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := fs.GC(ctx,
+		WithGCGracePeriod(0),
+		WithGCRoots(nil),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.LiveFiles != 1 || res.RemovedFiles != 1 || res.RemovedShards != 1 || res.RemovedXorbs != 1 {
+		t.Fatalf("counts = live %d, files %d, shards %d, xorbs %d; want 1/1/1/1",
+			res.LiveFiles, res.RemovedFiles, res.RemovedShards, res.RemovedXorbs)
+	}
+	if res.RemovedPins != 1 || res.BrokenRoots != 1 {
+		t.Fatalf("RemovedPins = %d, BrokenRoots = %d; want dangling pin swept and counted", res.RemovedPins, res.BrokenRoots)
+	}
+
+	mustExist(t, fs.objectPath("pins", pinned.fileHash.String()))
+	mustExist(t, fs.objectPath("files", pinned.fileHash.String()))
+	mustExist(t, fs.objectPath("shards", pinned.shardHash))
+	mustExist(t, fs.objectPath("xorbs", pinned.xorbHash.String()))
+	mustNotExist(t, fs.objectPath("pins", danglingHash.String()))
+	mustNotExist(t, fs.objectPath("files", unpinned.fileHash.String()))
+	mustNotExist(t, fs.objectPath("shards", unpinned.shardHash))
+	mustNotExist(t, fs.objectPath("xorbs", unpinned.xorbHash.String()))
+}
+
 func TestGCSweepsStaleTempFiles(t *testing.T) {
 	basePath := t.TempDir()
 	fs, err := NewFileStorage(WithBasePath(basePath))

--- a/storage/gc_test.go
+++ b/storage/gc_test.go
@@ -1,0 +1,422 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/shard"
+	"github.com/wzshiming/xet/xorb"
+)
+
+// storedFile records the addresses of one file stored via putTestFile.
+type storedFile struct {
+	fileHash  xet.FileHash
+	chunkHash xet.ChunkHash
+	xorbHash  xet.XorbHash
+	shardHash string
+	sha256    [32]byte
+}
+
+// putTestXorb encodes content as a single-chunk xorb and stores it.
+func putTestXorb(t *testing.T, fs *FileStorage, content []byte) xet.XorbHash {
+	t.Helper()
+	var encoded bytes.Buffer
+	enc := xorb.NewEncoder(&encoded, true)
+	if _, err := enc.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	xorbHash := enc.SummoryHash()
+	if _, err := fs.PutXorb(context.Background(), "default", xorbHash, bytes.NewReader(encoded.Bytes())); err != nil {
+		t.Fatal(err)
+	}
+	return xorbHash
+}
+
+// putTestFile stores content as one single-chunk xorb plus a shard describing
+// the file, mirroring the normal upload pipeline output.
+func putTestFile(t *testing.T, fs *FileStorage, content []byte) storedFile {
+	t.Helper()
+	xorbHash := putTestXorb(t, fs, content)
+	chunkHash := xet.ComputeChunkHash(content)
+	fileHash := xet.ComputeFileHash([]xet.ChunkHash{chunkHash}, []uint64{uint64(len(content))})
+	s := shard.NewShard()
+	s.AddFile(shard.FileBlock{
+		FileHash: fileHash,
+		Entries: []shard.FileDataSequenceEntry{
+			{CASHash: xorbHash, UnpackedSegBytes: uint32(len(content)), ChunkIndexEnd: 1},
+		},
+	})
+	s.AddCASBlock(shard.CASBlock{
+		CASHash: xorbHash,
+		Chunks:  []shard.CASChunkSequenceEntry{{ChunkHash: chunkHash, UnpackedSegBytes: uint32(len(content))}},
+	})
+	if _, err := fs.PutShard(context.Background(), s); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(fs.objectPath("files", fileHash.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return storedFile{
+		fileHash:  fileHash,
+		chunkHash: chunkHash,
+		xorbHash:  xorbHash,
+		shardHash: string(b),
+		sha256:    sha256.Sum256(content),
+	}
+}
+
+func mustExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("%s should exist: %v", path, err)
+	}
+}
+
+func mustNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("%s should have been removed (err=%v)", path, err)
+	}
+}
+
+func TestGCStandaloneCollectsOrphans(t *testing.T) {
+	basePath := t.TempDir()
+	fs, err := NewFileStorage(WithBasePath(basePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	live := putTestFile(t, fs, []byte("live file content"))
+	orphanXorb := putTestXorb(t, fs, []byte("orphan xorb, upload never finished"))
+	dead := putTestFile(t, fs, []byte("superseded upload"))
+	// Simulate a superseded upload: the file index entry is gone but shard,
+	// xorb and the chunk/sha256 index entries linger.
+	if err := os.Remove(fs.objectPath("files", dead.fileHash.String())); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := fs.GC(context.Background(), WithGCGracePeriod(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.LiveFiles != 1 || res.LiveShards != 1 || res.LiveXorbs != 1 {
+		t.Fatalf("live counts = %d/%d/%d, want 1/1/1", res.LiveFiles, res.LiveShards, res.LiveXorbs)
+	}
+	if res.RemovedXorbs != 2 || res.RemovedShards != 1 || res.RemovedChunks != 1 || res.RemovedSHA256s != 1 {
+		t.Fatalf("removed counts = xorbs %d, shards %d, chunks %d, sha256 %d; want 2/1/1/1",
+			res.RemovedXorbs, res.RemovedShards, res.RemovedChunks, res.RemovedSHA256s)
+	}
+	if res.ReclaimedBytes <= 0 {
+		t.Fatalf("ReclaimedBytes = %d, want > 0", res.ReclaimedBytes)
+	}
+
+	mustNotExist(t, fs.objectPath("xorbs", orphanXorb.String()))
+	mustNotExist(t, fs.objectPath("shards", dead.shardHash))
+	mustNotExist(t, fs.objectPath("xorbs", dead.xorbHash.String()))
+	mustNotExist(t, fs.objectPath("chunks", dead.chunkHash.String()))
+	mustNotExist(t, fs.objectPath("sha256", shard.NewSHA256Hash(dead.sha256).String()))
+
+	mustExist(t, fs.objectPath("files", live.fileHash.String()))
+	mustExist(t, fs.objectPath("shards", live.shardHash))
+	mustExist(t, fs.objectPath("xorbs", live.xorbHash.String()))
+	mustExist(t, fs.objectPath("chunks", live.chunkHash.String()))
+	mustExist(t, fs.objectPath("sha256", shard.NewSHA256Hash(live.sha256).String()))
+
+	// The surviving file must still reconstruct through a fresh storage.
+	fs2, err := NewFileStorage(WithBasePath(basePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc, err := fs2.GetReconstructedFile(context.Background(), "default", live.sha256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "live file content" {
+		t.Fatalf("reconstructed = %q", got)
+	}
+}
+
+func TestGCWithExplicitRoots(t *testing.T) {
+	fs, err := NewFileStorage(WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kept := putTestFile(t, fs, []byte("still referenced by the mirror index"))
+	dropped := putTestFile(t, fs, []byte("old commit content"))
+
+	res, err := fs.GC(context.Background(),
+		WithGCGracePeriod(0),
+		WithGCRoots([]xet.FileHash{kept.fileHash}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RemovedFiles != 1 || res.RemovedShards != 1 || res.RemovedXorbs != 1 {
+		t.Fatalf("removed counts = files %d, shards %d, xorbs %d; want 1/1/1",
+			res.RemovedFiles, res.RemovedShards, res.RemovedXorbs)
+	}
+
+	mustNotExist(t, fs.objectPath("files", dropped.fileHash.String()))
+	mustNotExist(t, fs.objectPath("shards", dropped.shardHash))
+	mustNotExist(t, fs.objectPath("xorbs", dropped.xorbHash.String()))
+	mustNotExist(t, fs.objectPath("chunks", dropped.chunkHash.String()))
+	mustNotExist(t, fs.objectPath("sha256", shard.NewSHA256Hash(dropped.sha256).String()))
+
+	mustExist(t, fs.objectPath("files", kept.fileHash.String()))
+	mustExist(t, fs.objectPath("shards", kept.shardHash))
+	mustExist(t, fs.objectPath("xorbs", kept.xorbHash.String()))
+
+	// The dedup path must not resurrect the removed shard.
+	if _, err := fs.GetShardByChunkHash(context.Background(), "default", dropped.chunkHash); err == nil {
+		t.Fatal("GetShardByChunkHash should fail for a collected chunk")
+	}
+	if _, err := fs.GetShard(context.Background(), kept.fileHash); err != nil {
+		t.Fatalf("kept file lookup: %v", err)
+	}
+}
+
+func TestGCSharedShardKeepsStorageForNonRootFile(t *testing.T) {
+	ctx := context.Background()
+	fs, err := NewFileStorage(WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Two files described by one shard: collecting one root must keep the
+	// shard and every xorb it references, while the other file's own index
+	// entries go away.
+	contents := [][]byte{[]byte("file one content"), []byte("file two content")}
+	s := shard.NewShard()
+	var files []storedFile
+	for _, content := range contents {
+		xorbHash := putTestXorb(t, fs, content)
+		chunkHash := xet.ComputeChunkHash(content)
+		fileHash := xet.ComputeFileHash([]xet.ChunkHash{chunkHash}, []uint64{uint64(len(content))})
+		s.AddFile(shard.FileBlock{
+			FileHash: fileHash,
+			Entries: []shard.FileDataSequenceEntry{
+				{CASHash: xorbHash, UnpackedSegBytes: uint32(len(content)), ChunkIndexEnd: 1},
+			},
+		})
+		s.AddCASBlock(shard.CASBlock{
+			CASHash: xorbHash,
+			Chunks:  []shard.CASChunkSequenceEntry{{ChunkHash: chunkHash, UnpackedSegBytes: uint32(len(content))}},
+		})
+		files = append(files, storedFile{
+			fileHash:  fileHash,
+			chunkHash: chunkHash,
+			xorbHash:  xorbHash,
+			sha256:    sha256.Sum256(content),
+		})
+	}
+	if _, err := fs.PutShard(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+	shardHashBytes, err := os.ReadFile(fs.objectPath("files", files[0].fileHash.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	shardHash := string(shardHashBytes)
+
+	res, err := fs.GC(ctx,
+		WithGCGracePeriod(0),
+		WithGCRoots([]xet.FileHash{files[0].fileHash}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RemovedShards != 0 || res.RemovedXorbs != 0 || res.RemovedChunks != 0 {
+		t.Fatalf("shared shard storage was collected: shards %d, xorbs %d, chunks %d",
+			res.RemovedShards, res.RemovedXorbs, res.RemovedChunks)
+	}
+
+	mustExist(t, fs.objectPath("shards", shardHash))
+	mustExist(t, fs.objectPath("xorbs", files[1].xorbHash.String()))
+	mustExist(t, fs.objectPath("chunks", files[1].chunkHash.String()))
+	mustNotExist(t, fs.objectPath("files", files[1].fileHash.String()))
+	mustNotExist(t, fs.objectPath("sha256", shard.NewSHA256Hash(files[1].sha256).String()))
+	mustExist(t, fs.objectPath("files", files[0].fileHash.String()))
+	mustExist(t, fs.objectPath("sha256", shard.NewSHA256Hash(files[0].sha256).String()))
+}
+
+func TestGCGracePeriodProtectsRecentObjects(t *testing.T) {
+	fs, err := NewFileStorage(WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orphanXorb := putTestXorb(t, fs, []byte("just uploaded, shard not registered yet"))
+	fresh := putTestFile(t, fs, []byte("ingest finished moments ago"))
+
+	// No roots at all: without the grace period everything would go.
+	res, err := fs.GC(context.Background(),
+		WithGCGracePeriod(time.Hour),
+		WithGCRoots(nil),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total := res.RemovedFiles + res.RemovedShards + res.RemovedXorbs + res.RemovedChunks + res.RemovedSHA256s; total != 0 {
+		t.Fatalf("removed %d objects inside the grace period", total)
+	}
+	// The young file index entry pins its shard and xorb as in-flight work.
+	if res.LiveFiles != 1 || res.LiveShards != 1 || res.LiveXorbs != 1 {
+		t.Fatalf("live counts = %d/%d/%d, want grace-pinned 1/1/1", res.LiveFiles, res.LiveShards, res.LiveXorbs)
+	}
+	mustExist(t, fs.objectPath("xorbs", orphanXorb.String()))
+	mustExist(t, fs.objectPath("shards", fresh.shardHash))
+}
+
+func TestGCDryRunRemovesNothing(t *testing.T) {
+	fs, err := NewFileStorage(WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orphanXorb := putTestXorb(t, fs, []byte("orphan"))
+	dead := putTestFile(t, fs, []byte("unreferenced file"))
+
+	res, err := fs.GC(context.Background(),
+		WithGCGracePeriod(0),
+		WithGCRoots(nil),
+		WithGCDryRun(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RemovedXorbs != 2 || res.RemovedShards != 1 || res.RemovedFiles != 1 {
+		t.Fatalf("dry run counts = xorbs %d, shards %d, files %d; want 2/1/1",
+			res.RemovedXorbs, res.RemovedShards, res.RemovedFiles)
+	}
+	mustExist(t, fs.objectPath("xorbs", orphanXorb.String()))
+	mustExist(t, fs.objectPath("files", dead.fileHash.String()))
+	mustExist(t, fs.objectPath("shards", dead.shardHash))
+	mustExist(t, fs.objectPath("xorbs", dead.xorbHash.String()))
+}
+
+func TestGCKeepsXorbsDeduplicatedFromDeadShards(t *testing.T) {
+	ctx := context.Background()
+	basePath := t.TempDir()
+	fs, err := NewFileStorage(WithBasePath(basePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// File A owns the xorb; file B deduplicated against it, so B's shard
+	// references A's xorb only through its file term entries, never through
+	// its own CASInfos. Collecting A must keep the xorb alive for B.
+	content := []byte("shared deduplicated content")
+	a := putTestFile(t, fs, content)
+
+	bContent := []byte("unique b content")
+	bXorb := putTestXorb(t, fs, bContent)
+	bChunk := xet.ComputeChunkHash(bContent)
+	bFileHash := xet.ComputeFileHash(
+		[]xet.ChunkHash{a.chunkHash, bChunk},
+		[]uint64{uint64(len(content)), uint64(len(bContent))},
+	)
+	s := shard.NewShard()
+	s.AddFile(shard.FileBlock{
+		FileHash: bFileHash,
+		Entries: []shard.FileDataSequenceEntry{
+			{CASHash: a.xorbHash, UnpackedSegBytes: uint32(len(content)), ChunkIndexEnd: 1},
+			{CASHash: bXorb, UnpackedSegBytes: uint32(len(bContent)), ChunkIndexEnd: 1},
+		},
+	})
+	// Only the newly uploaded xorb appears in CASInfos, like BuildShard
+	// produces after a dedup hit.
+	s.AddCASBlock(shard.CASBlock{
+		CASHash: bXorb,
+		Chunks:  []shard.CASChunkSequenceEntry{{ChunkHash: bChunk, UnpackedSegBytes: uint32(len(bContent))}},
+	})
+	if _, err := fs.PutShard(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := fs.GC(ctx,
+		WithGCGracePeriod(0),
+		WithGCRoots([]xet.FileHash{bFileHash}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RemovedXorbs != 0 {
+		t.Fatalf("RemovedXorbs = %d, deduplicated xorb was collected", res.RemovedXorbs)
+	}
+	mustExist(t, fs.objectPath("xorbs", a.xorbHash.String()))
+	mustNotExist(t, fs.objectPath("shards", a.shardHash))
+	mustNotExist(t, fs.objectPath("files", a.fileHash.String()))
+
+	// B must still reconstruct byte for byte through a fresh storage.
+	fs2, err := NewFileStorage(WithBasePath(basePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bSHA := sha256.Sum256(append(append([]byte{}, content...), bContent...))
+	rc, err := fs2.GetReconstructedFile(ctx, "default", bSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, append(append([]byte{}, content...), bContent...)) {
+		t.Fatalf("reconstructed = %q", got)
+	}
+}
+
+func TestGCSweepsStaleTempFiles(t *testing.T) {
+	basePath := t.TempDir()
+	fs, err := NewFileStorage(WithBasePath(basePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	staleShardTemp := filepath.Join(basePath, "shards", ".shard-12345")
+	if err := os.WriteFile(staleShardTemp, []byte("interrupted"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	xorbTempDir := filepath.Join(basePath, "xorbs", "ab")
+	if err := os.MkdirAll(xorbTempDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	staleXorbTemp := filepath.Join(xorbTempDir, "cdef.tmp")
+	if err := os.WriteFile(staleXorbTemp, []byte("interrupted"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stray := filepath.Join(basePath, "xorbs", "README")
+	if err := os.WriteFile(stray, []byte("not garbage"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := fs.GC(context.Background(), WithGCGracePeriod(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RemovedTemps != 2 {
+		t.Fatalf("RemovedTemps = %d, want 2", res.RemovedTemps)
+	}
+	mustNotExist(t, staleShardTemp)
+	mustNotExist(t, staleXorbTemp)
+	mustExist(t, stray)
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -37,6 +37,11 @@ type Storage interface {
 	// PutShard stores a shard by its hash
 	PutShard(ctx context.Context, shard *shard.Shard) (bool, error)
 
+	// PinFile marks a file as a permanent GC root, exempting it and the
+	// storage it references from garbage collection. Direct uploads are
+	// pinned; mirror ingests are not, so retention can reclaim them.
+	PinFile(ctx context.Context, namespace string, fileHash xet.FileHash) error
+
 	// GetShard retrieves a shard by file hash
 	GetShard(ctx context.Context, fileHash xet.FileHash) (*shard.Shard, error)
 
@@ -167,6 +172,7 @@ func NewFileStorage(opts ...Option) (*FileStorage, error) {
 		filepath.Join(fs.basePath, "files"),
 		filepath.Join(fs.basePath, "chunks"),
 		filepath.Join(fs.basePath, "sha256"),
+		filepath.Join(fs.basePath, "pins"),
 	}
 
 	for _, dir := range dirs {
@@ -452,6 +458,17 @@ func (fs *FileStorage) PutShard(ctx context.Context, s *shard.Shard) (bool, erro
 	}
 
 	return wasInserted, nil
+}
+
+// PinFile marks a file as a permanent GC root with an empty marker file at
+// pins/<file-hash>. Pinning is idempotent and does not require the file to
+// exist yet; a pin that never gains a file index entry is swept as garbage.
+func (fs *FileStorage) PinFile(_ context.Context, _ string, fileHash xet.FileHash) error {
+	pinPath := fs.objectPath("pins", fileHash.String())
+	if err := writeIndexFile(pinPath, nil); err != nil {
+		return fmt.Errorf("write pin for file %s: %w", fileHash.String(), err)
+	}
+	return nil
 }
 
 // openXorb returns a cached read handle for the given xorb, opening it on


### PR DESCRIPTION
Nothing ever deleted anything: the content-addressed storage and the mirror index only grew. This adds a mark-and-sweep GC over the reference model settled in #143 — roots are the mirror's ready index entries (`(*mirror.Handler).GCRoots`; every uploaded file block for a standalone CAS), from which `files/` resolves to a shard and the shard to every xorb it references. Marking traverses both `CASInfos` and the file term entries: `BuildShard` only lists newly uploaded xorbs in `CASInfos`, so xorbs reused through dedup appear in the terms alone, and marking `CASInfos` by itself would collect xorbs still needed by files that deduplicated against since-pruned content. Everything unreachable is swept with index entries going before the objects they point at: file/sha256 entries of dead files, unreferenced shards and xorbs, chunk entries pointing at dead shards (so dedup stops resurrecting references to missing shards), and stale `.tmp`/`.shard-*` leftovers, with in-memory caches flushed at the end.

Rather than an offline subcommand, GC runs in-process on the serving storage (`xetd -gc-interval`). In-flight ingests and uploads are respected by a grace period (`-gc-grace`, default 24h, must exceed the longest upload): recently modified objects are never touched, and a young `files/` entry pins its shard and xorbs even before its root registration lands. The dedup-vs-sweep race degrades to a failed-and-retried upload rather than corruption, because `PutShard` verifies every referenced xorb by reconstructing the file's SHA-256 — a shard referencing a deleted xorb cannot land, and the retry finds the chunk entries gone and re-uploads in full.

Retention layers on the same traversal: `-gc-prune-index <age>` drops branch pins not re-checked within the window, then ready entries under unpinned commits older than it. Pruning goes through the running handler so entries leave memory and disk together — pruned content is re-ingested on the next request instead of being served against storage a later cycle removed. Entries under a live branch's pinned commit are kept regardless of age (commit-keyed entries are never revalidated, so their `CheckedAt` stays at ingest time); serving old pinned commits stays free until retention reclaims them.

Fixes #143

Mixed deployments (mirror plus directly uploaded self-hosted content) are covered by pins: the shard upload endpoints record a `pins/<file-hash>` marker for every file block they store, and a collection with explicit roots unions the pins into the root set. Direct uploads keep the standalone semantics — never collected — while mirror ingests carry no pin and stay reclaimable by retention; a pin covering both (the same content uploaded directly and ingested by the mirror) keeps it after the mirror entry is pruned. Dangling pins whose file never landed are swept as garbage.
