### PR TITLE
perf: compute xorb chunk ranges from footer offsets

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -49,19 +50,21 @@ type Storage interface {
 
 // FileStorage implements Storage using the filesystem
 type FileStorage struct {
-	basePath    string
-	baseURL     string
-	fileIndex   *lru.Cache // bounded file hash -> shard hash
-	shardIndex  *lru.Cache // bounded shard hash -> shard cache
-	chunkIndex  *lru.Cache // bounded chunk hash -> shard hash
-	sha256Index *lru.Cache // bounded SHA-256 -> file hash
-	xorbIndex   *lru.Cache // bounded xorb hash -> *xorbFile
+	basePath     string
+	baseURL      string
+	fileIndex    *lru.Cache // bounded file hash -> shard hash
+	shardIndex   *lru.Cache // bounded shard hash -> shard cache
+	chunkIndex   *lru.Cache // bounded chunk hash -> shard hash
+	sha256Index  *lru.Cache // bounded SHA-256 -> file hash
+	xorbIndex    *lru.Cache // bounded xorb hash -> *xorbFile
+	offsetsIndex *lru.Cache // bounded xorb hash -> []uint64 packed chunk end-offsets
 
-	fileMut   sync.Mutex // guards fileIndex
-	shardMut  sync.Mutex // guards shardIndex
-	chunkMut  sync.Mutex // guards chunkIndex
-	sha256Mut sync.Mutex // guards sha256Index
-	xorbMut   sync.Mutex // guards xorbIndex
+	fileMut    sync.Mutex // guards fileIndex
+	shardMut   sync.Mutex // guards shardIndex
+	chunkMut   sync.Mutex // guards chunkIndex
+	sha256Mut  sync.Mutex // guards sha256Index
+	xorbMut    sync.Mutex // guards xorbIndex
+	offsetsMut sync.Mutex // guards offsetsIndex
 }
 
 // xorbFile wraps an open xorb handle with its own mutex so that only uses of
@@ -77,6 +80,7 @@ const defaultShardCacheSize = 512
 const defaultChunkCacheSize = 4096
 const defaultSHA256CacheSize = 4096
 const defaultXorbCacheSize = 512
+const defaultOffsetsCacheSize = 512
 
 type Option func(*FileStorage)
 
@@ -136,13 +140,14 @@ func WithXorbCacheSize(size int) Option {
 // NewFileStorage creates a new filesystem-based storage
 func NewFileStorage(opts ...Option) (*FileStorage, error) {
 	fs := &FileStorage{
-		basePath:    "./xet",
-		baseURL:     "",
-		fileIndex:   lru.New(defaultFileCacheSize),
-		shardIndex:  lru.New(defaultShardCacheSize),
-		chunkIndex:  lru.New(defaultChunkCacheSize),
-		sha256Index: lru.New(defaultSHA256CacheSize),
-		xorbIndex:   lru.New(defaultXorbCacheSize),
+		basePath:     "./xet",
+		baseURL:      "",
+		fileIndex:    lru.New(defaultFileCacheSize),
+		shardIndex:   lru.New(defaultShardCacheSize),
+		chunkIndex:   lru.New(defaultChunkCacheSize),
+		sha256Index:  lru.New(defaultSHA256CacheSize),
+		xorbIndex:    lru.New(defaultXorbCacheSize),
+		offsetsIndex: lru.New(defaultOffsetsCacheSize),
 	}
 
 	for _, opt := range opts {
@@ -480,6 +485,38 @@ func (fs *FileStorage) openXorb(casHash xet.XorbHash) (*xorbFile, error) {
 	return xf, nil
 }
 
+// xorbChunkOffsets returns the cumulative packed end-offset of every chunk in
+// the xorb, from the in-memory cache, the xorb footer, or a full header scan
+// for footer-less xorbs. Once cached, chunk ranges are computed without
+// touching the xorb file.
+func (fs *FileStorage) xorbChunkOffsets(xorbHash xet.XorbHash) ([]uint64, error) {
+	fs.offsetsMut.Lock()
+	if v, ok := fs.offsetsIndex.Get(xorbHash); ok {
+		fs.offsetsMut.Unlock()
+		return v.([]uint64), nil
+	}
+	fs.offsetsMut.Unlock()
+
+	xf, err := fs.openXorb(xorbHash)
+	if err != nil {
+		return nil, err
+	}
+	xf.mut.Lock()
+	offsets, err := xorb.ReadChunkOffsets(xf.f)
+	if errors.Is(err, xorb.ErrNoFooter) {
+		offsets, err = xorb.ScanChunkOffsets(xf.f)
+	}
+	xf.mut.Unlock()
+	if err != nil {
+		return nil, fmt.Errorf("read xorb chunk offsets: %w", err)
+	}
+
+	fs.offsetsMut.Lock()
+	fs.offsetsIndex.Add(xorbHash, offsets)
+	fs.offsetsMut.Unlock()
+	return offsets, nil
+}
+
 func (fs *FileStorage) computeFileSHA256(ctx context.Context, fileBlock *shard.FileBlock) ([32]byte, error) {
 	if len(fileBlock.Entries) == 0 {
 		return [32]byte{}, nil
@@ -492,23 +529,21 @@ func (fs *FileStorage) computeFileSHA256(ctx context.Context, fileBlock *shard.F
 			return [32]byte{}, err
 		}
 
-		// Cached handles are shared, and their seek offsets are mutable, so the
-		// whole seek+read sequence is serialized per handle. Different xorbs
-		// proceed in parallel.
+		offsets, err := fs.xorbChunkOffsets(entry.CASHash)
+		if err != nil {
+			return [32]byte{}, fmt.Errorf("locate xorb chunks: %w", err)
+		}
+		start, end, err := xorb.ChunkDataRangeFromOffsets(offsets, entry.ChunkIndexStart, entry.ChunkIndexEnd)
+		if err != nil {
+			return [32]byte{}, fmt.Errorf("locate xorb chunks: %w", err)
+		}
+		// Cached handles are shared; holding the handle lock keeps eviction from
+		// closing the file mid-read. Different xorbs proceed in parallel.
 		xf, err := fs.openXorb(entry.CASHash)
 		if err != nil {
 			return [32]byte{}, err
 		}
 		xf.mut.Lock()
-		if _, err := xf.f.Seek(0, io.SeekStart); err != nil {
-			xf.mut.Unlock()
-			return [32]byte{}, fmt.Errorf("rewind xorb %s: %w", entry.CASHash.String(), err)
-		}
-		start, end, err := xorb.ChunkDataRange(xf.f, entry.ChunkIndexStart, entry.ChunkIndexEnd)
-		if err != nil {
-			xf.mut.Unlock()
-			return [32]byte{}, fmt.Errorf("locate xorb chunks: %w", err)
-		}
 		decoder := xorb.NewDecoder(io.NewSectionReader(xf.f, start, end-start+1), false)
 		written, err := io.CopyBuffer(h, decoder, buf)
 		xf.mut.Unlock()
@@ -620,17 +655,12 @@ func (fs *FileStorage) GetXorbURL(namespace string, xorbHash xet.XorbHash) strin
 // The returned range includes the 8-byte chunk header for each chunk, so that
 // xet-core can parse the header (version, compressed/uncompressed size,
 // compression type) when it downloads that byte range.
+// Ranges are computed from cached per-xorb chunk offsets, so the xorb file is
+// only read (footer or full scan) the first time it is seen.
 func (fs *FileStorage) GetXorbDataRange(ctx context.Context, _ string, xorbHash xet.XorbHash, chunkStart, chunkEnd uint32) (startByte, endByte int64, err error) {
-	xorbPath := fs.objectPath("xorbs", xorbHash.String())
-	f, err := os.Open(xorbPath)
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to open xorb file: %w", err)
-	}
-	defer f.Close()
-
-	startByte, endByte, err = xorb.ChunkDataRange(f, chunkStart, chunkEnd)
+	offsets, err := fs.xorbChunkOffsets(xorbHash)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get chunk data range: %w", err)
 	}
-	return startByte, endByte, nil
+	return xorb.ChunkDataRangeFromOffsets(offsets, chunkStart, chunkEnd)
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/wzshiming/xet"
 	"github.com/wzshiming/xet/shard"
+	"github.com/wzshiming/xet/xorb"
 )
 
 func TestChunkIndexPersistsAndShardReloadsAfterEviction(t *testing.T) {
@@ -122,4 +124,80 @@ func fanoutEntries(dir string) ([]string, error) {
 		}
 	}
 	return names, nil
+}
+
+// encodeTestXorb serializes chunks as an xorb, with or without footer.
+func encodeTestXorb(t *testing.T, withFooter bool, chunks ...[]byte) ([]byte, xet.XorbHash) {
+	t.Helper()
+	var encoded bytes.Buffer
+	enc := xorb.NewEncoder(&encoded, withFooter)
+	for _, c := range chunks {
+		if _, err := enc.Write(c); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return encoded.Bytes(), enc.SummoryHash()
+}
+
+func TestGetXorbDataRangeFromOffsets(t *testing.T) {
+	chunks := [][]byte{
+		bytes.Repeat([]byte{1}, 1000),
+		[]byte("second chunk"),
+		bytes.Repeat([]byte("abc"), 700),
+	}
+	numChunks := uint32(len(chunks))
+
+	// Reference ranges scanned from the chunk-data region, which is identical
+	// for footer and chunk-only formats.
+	reference, _ := encodeTestXorb(t, false, chunks...)
+
+	for _, format := range []struct {
+		name       string
+		withFooter bool
+	}{
+		{"footer", true},
+		{"chunk-only", false},
+	} {
+		t.Run(format.name, func(t *testing.T) {
+			fs, err := NewFileStorage(WithBasePath(t.TempDir()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			encoded, xorbHash := encodeTestXorb(t, format.withFooter, chunks...)
+			if _, err := fs.PutXorb(context.Background(), "default", xorbHash, bytes.NewReader(encoded)); err != nil {
+				t.Fatal(err)
+			}
+
+			for start := uint32(0); start < numChunks; start++ {
+				for end := start + 1; end <= numChunks; end++ {
+					wantStart, wantEnd, err := xorb.ChunkDataRange(bytes.NewReader(reference), start, end)
+					if err != nil {
+						t.Fatalf("ChunkDataRange(%d, %d): %v", start, end, err)
+					}
+					gotStart, gotEnd, err := fs.GetXorbDataRange(context.Background(), "default", xorbHash, start, end)
+					if err != nil {
+						t.Fatalf("GetXorbDataRange(%d, %d): %v", start, end, err)
+					}
+					if gotStart != wantStart || gotEnd != wantEnd {
+						t.Fatalf("range [%d, %d) = [%d, %d], want [%d, %d]", start, end, gotStart, gotEnd, wantStart, wantEnd)
+					}
+				}
+			}
+
+			if _, _, err := fs.GetXorbDataRange(context.Background(), "default", xorbHash, 0, numChunks+1); err == nil {
+				t.Fatal("GetXorbDataRange() accepted out-of-bounds chunk range")
+			}
+
+			// Cached offsets keep serving ranges without touching the xorb file.
+			if err := os.Remove(fs.objectPath("xorbs", xorbHash.String())); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := fs.GetXorbDataRange(context.Background(), "default", xorbHash, 1, 2); err != nil {
+				t.Fatalf("GetXorbDataRange() after xorb removal: %v", err)
+			}
+		})
+	}
 }

--- a/xorb/chunk_range.go
+++ b/xorb/chunk_range.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+
+	"github.com/wzshiming/xet"
 )
 
 // ChunkDataRange scans the chunk-data region of an xorb stream and returns
@@ -49,4 +51,58 @@ func ChunkDataRange(r io.ReadSeeker, chunkStart, chunkEnd uint32) (startByte, en
 			return startByte, offset - 1, nil
 		}
 	}
+}
+
+// ScanChunkOffsets scans every chunk header and returns the cumulative packed
+// end-offset (including the 8-byte header) of each chunk. It rewinds to the
+// stream start first and stops at EOF (chunk-only format) or at the footer.
+func ScanChunkOffsets(r io.ReadSeeker) ([]uint64, error) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("rewind xorb: %w", err)
+	}
+
+	var offsets []uint64
+	var headerBuf [8]byte
+	offset := int64(0)
+
+	for {
+		n, err := io.ReadFull(r, headerBuf[:])
+		if err == io.EOF {
+			return offsets, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read chunk header: %w", err)
+		}
+
+		if n >= 7 && bytes.Equal(headerBuf[:7], xorbIdentifier[:]) {
+			return offsets, nil
+		}
+
+		if len(offsets) >= xet.MaxChunksPerXorb {
+			return nil, fmt.Errorf("chunk count exceeds maximum %d", xet.MaxChunksPerXorb)
+		}
+
+		compressedSize := int64(headerBuf[1]) | int64(headerBuf[2])<<8 | int64(headerBuf[3])<<16
+		if _, err := r.Seek(compressedSize, io.SeekCurrent); err != nil {
+			return nil, fmt.Errorf("seek past chunk data: %w", err)
+		}
+		offset += 8 + compressedSize
+		offsets = append(offsets, uint64(offset))
+	}
+}
+
+// ChunkDataRangeFromOffsets computes the same inclusive [startByte, endByte]
+// range as ChunkDataRange from cumulative packed end-offsets, without stream
+// access.
+func ChunkDataRangeFromOffsets(offsets []uint64, chunkStart, chunkEnd uint32) (startByte, endByte int64, err error) {
+	if chunkStart >= chunkEnd {
+		return 0, 0, fmt.Errorf("invalid chunk range: chunkStart (%d) must be less than chunkEnd (%d)", chunkStart, chunkEnd)
+	}
+	if uint64(chunkEnd) > uint64(len(offsets)) {
+		return 0, 0, fmt.Errorf("chunk range [%d, %d) out of bounds: xorb has %d chunks", chunkStart, chunkEnd, len(offsets))
+	}
+	if chunkStart > 0 {
+		startByte = int64(offsets[chunkStart-1])
+	}
+	return startByte, int64(offsets[chunkEnd-1]) - 1, nil
 }

--- a/xorb/footer.go
+++ b/xorb/footer.go
@@ -1,0 +1,104 @@
+package xorb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/wzshiming/xet"
+)
+
+// ErrNoFooter indicates the xorb stream is chunk-only format (or its trailing
+// bytes do not form a parseable footer), so chunk offsets must be recovered by
+// scanning chunk headers instead.
+var ErrNoFooter = errors.New("xorb has no footer")
+
+// minFooterSize is the serialized footer size for a zero-chunk xorb:
+// main header (40) + hash section (12) + boundary section (12) + trailer (28) +
+// length field (4).
+const minFooterSize = 96
+
+// ReadChunkOffsets extracts the cumulative packed end-offset (including the
+// 8-byte per-chunk header) of every chunk from the footer of a full-format
+// xorb, without scanning chunk data. The reader may be at any position.
+// Returns ErrNoFooter when the stream does not end in a parseable footer.
+func ReadChunkOffsets(r io.ReadSeeker) ([]uint64, error) {
+	size, err := r.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, fmt.Errorf("seek xorb end: %w", err)
+	}
+	if size < minFooterSize {
+		return nil, ErrNoFooter
+	}
+
+	var lenBuf [4]byte
+	if _, err := r.Seek(size-4, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seek footer length: %w", err)
+	}
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return nil, fmt.Errorf("read footer length: %w", err)
+	}
+	footerLen := int64(binary.LittleEndian.Uint32(lenBuf[:]))
+
+	// footerLen counts all footer bytes except the length field itself and
+	// encodes the chunk count: 92 fixed bytes plus 40 per chunk.
+	total := footerLen + 4
+	if footerLen < minFooterSize-4 || total > size || (footerLen-92)%40 != 0 {
+		return nil, ErrNoFooter
+	}
+	numChunks := int((footerLen - 92) / 40)
+	if numChunks > xet.MaxChunksPerXorb {
+		return nil, ErrNoFooter
+	}
+
+	footerStart := size - total
+	if _, err := r.Seek(footerStart, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seek footer start: %w", err)
+	}
+	buf := make([]byte, total)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, fmt.Errorf("read footer: %w", err)
+	}
+
+	// Main header: XETBLOB ident (7) + version (1) + xorb hash (32).
+	if !bytes.Equal(buf[:7], xorbIdentifier[:]) || buf[7] != 1 {
+		return nil, ErrNoFooter
+	}
+	// Hash section: XBLBHSH ident (7) + version (1) + num_chunks (4) + hashes (32*N).
+	const hOff = 40
+	if !bytes.Equal(buf[hOff:hOff+7], hashSectionIdent[:]) || buf[hOff+7] != 0 {
+		return nil, ErrNoFooter
+	}
+	if int(binary.LittleEndian.Uint32(buf[hOff+8:hOff+12])) != numChunks {
+		return nil, ErrNoFooter
+	}
+	// Boundary section: XBLBBND ident (7) + version (1) + num_chunks (4) +
+	// packed offsets (4*N) + unpacked offsets (4*N).
+	bOff := hOff + 12 + numChunks*32
+	if !bytes.Equal(buf[bOff:bOff+7], boundarySectionIdent[:]) || buf[bOff+7] != 1 {
+		return nil, ErrNoFooter
+	}
+	if int(binary.LittleEndian.Uint32(buf[bOff+8:bOff+12])) != numChunks {
+		return nil, ErrNoFooter
+	}
+
+	packedBase := bOff + 12
+	offsets := make([]uint64, numChunks)
+	prev := uint64(0)
+	for i := range offsets {
+		off := uint64(binary.LittleEndian.Uint32(buf[packedBase+i*4:]))
+		// Each chunk contributes at least its 8-byte header.
+		if off < prev+8 {
+			return nil, ErrNoFooter
+		}
+		offsets[i] = off
+		prev = off
+	}
+	// The final offset must equal the size of the chunk-data region.
+	if numChunks > 0 && int64(prev) != footerStart {
+		return nil, ErrNoFooter
+	}
+	return offsets, nil
+}

--- a/xorb/footer_test.go
+++ b/xorb/footer_test.go
@@ -1,0 +1,144 @@
+package xorb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+// testFooterChunks returns deterministic chunks with mixed compressibility.
+func testFooterChunks(n int) [][]byte {
+	rng := rand.New(rand.NewSource(42))
+	chunks := make([][]byte, n)
+	for i := range chunks {
+		b := make([]byte, 1+rng.Intn(4096))
+		if i%2 == 0 {
+			rng.Read(b)
+		}
+		chunks[i] = b
+	}
+	return chunks
+}
+
+func encodeChunkOnlyXorbForTest(t *testing.T, chunks ...[]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	encoder := NewEncoder(&buf, false)
+	for _, chunk := range chunks {
+		if _, err := encoder.Write(chunk); err != nil {
+			t.Fatalf("Encoder.Write() failed: %v", err)
+		}
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatalf("Encoder.Close() failed: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// assertOffsetsMatchChunkDataRange checks every [start, end) pair against the
+// scanning ChunkDataRange reference implementation.
+func assertOffsetsMatchChunkDataRange(t *testing.T, data []byte, offsets []uint64, numChunks int) {
+	t.Helper()
+	for start := uint32(0); start < uint32(numChunks); start++ {
+		for end := start + 1; end <= uint32(numChunks); end++ {
+			wantStart, wantEnd, err := ChunkDataRange(bytes.NewReader(data), start, end)
+			if err != nil {
+				t.Fatalf("ChunkDataRange(%d, %d) failed: %v", start, end, err)
+			}
+			gotStart, gotEnd, err := ChunkDataRangeFromOffsets(offsets, start, end)
+			if err != nil {
+				t.Fatalf("ChunkDataRangeFromOffsets(%d, %d) failed: %v", start, end, err)
+			}
+			if gotStart != wantStart || gotEnd != wantEnd {
+				t.Fatalf("range [%d, %d) = [%d, %d], want [%d, %d]", start, end, gotStart, gotEnd, wantStart, wantEnd)
+			}
+		}
+	}
+}
+
+func TestReadChunkOffsetsMatchesScanAndChunkDataRange(t *testing.T) {
+	chunks := testFooterChunks(7)
+	data, _ := encodeXorbForTest(t, [4]byte{}, chunks...)
+
+	fromFooter, err := ReadChunkOffsets(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadChunkOffsets() failed: %v", err)
+	}
+	if len(fromFooter) != len(chunks) {
+		t.Fatalf("ReadChunkOffsets() returned %d offsets, want %d", len(fromFooter), len(chunks))
+	}
+
+	fromScan, err := ScanChunkOffsets(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ScanChunkOffsets() failed: %v", err)
+	}
+	if !reflect.DeepEqual(fromFooter, fromScan) {
+		t.Fatalf("footer offsets %v != scanned offsets %v", fromFooter, fromScan)
+	}
+
+	assertOffsetsMatchChunkDataRange(t, data, fromFooter, len(chunks))
+}
+
+func TestScanChunkOffsetsChunkOnlyFormat(t *testing.T) {
+	chunks := testFooterChunks(5)
+	data := encodeChunkOnlyXorbForTest(t, chunks...)
+
+	if _, err := ReadChunkOffsets(bytes.NewReader(data)); !errors.Is(err, ErrNoFooter) {
+		t.Fatalf("ReadChunkOffsets() error = %v, want ErrNoFooter", err)
+	}
+
+	offsets, err := ScanChunkOffsets(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ScanChunkOffsets() failed: %v", err)
+	}
+	if len(offsets) != len(chunks) {
+		t.Fatalf("ScanChunkOffsets() returned %d offsets, want %d", len(offsets), len(chunks))
+	}
+	if offsets[len(offsets)-1] != uint64(len(data)) {
+		t.Fatalf("last offset = %d, want stream size %d", offsets[len(offsets)-1], len(data))
+	}
+
+	assertOffsetsMatchChunkDataRange(t, data, offsets, len(chunks))
+}
+
+func TestReadChunkOffsetsRejectsUnparseableFooters(t *testing.T) {
+	data, _ := encodeXorbForTest(t, [4]byte{}, testFooterChunks(3)...)
+	footerLen := binary.LittleEndian.Uint32(data[len(data)-4:])
+	footerStart := len(data) - int(footerLen) - 4
+
+	corruptIdent := bytes.Clone(data)
+	corruptIdent[footerStart] ^= 0xFF
+
+	badLength := bytes.Clone(data)
+	binary.LittleEndian.PutUint32(badLength[len(badLength)-4:], uint32(len(badLength)+100))
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"corrupt identifier", corruptIdent},
+		{"footer length beyond stream", badLength},
+		{"smaller than minimal footer", data[:minFooterSize-1]},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ReadChunkOffsets(bytes.NewReader(tt.data)); !errors.Is(err, ErrNoFooter) {
+				t.Fatalf("ReadChunkOffsets() error = %v, want ErrNoFooter", err)
+			}
+		})
+	}
+}
+
+func TestChunkDataRangeFromOffsetsBounds(t *testing.T) {
+	offsets := []uint64{10, 30, 60}
+
+	if _, _, err := ChunkDataRangeFromOffsets(offsets, 1, 1); err == nil {
+		t.Fatal("ChunkDataRangeFromOffsets() accepted empty range")
+	}
+	if _, _, err := ChunkDataRangeFromOffsets(offsets, 0, 4); err == nil {
+		t.Fatal("ChunkDataRangeFromOffsets() accepted out-of-bounds range")
+	}
+}


### PR DESCRIPTION
Building a reconstruction response opened every referenced xorb and
walked its chunk headers sequentially (an os.Open plus a header-by-header
seek per term in GetXorbDataRange) just to turn chunk indexes into packed
byte ranges, so response cost grew with term count and chunk position
even though the answer never changes for a given xorb.

The footer boundary section already stores each chunk's cumulative packed
end-offset, so ReadChunkOffsets now recovers the whole table from the
footer in two small reads, with a single full header scan as the fallback
for footer-less xorbs, and FileStorage keeps the table in a bounded LRU.
GetXorbDataRange and shard SHA-256 verification do the range math in
memory, so reconstruction responses and reconstructed-file reads stop
touching xorb data after the first lookup per xorb. Tests check
footer-derived ranges against a ChunkDataRange scan for every range on
both formats, the corrupt-footer fallback, and that cached offsets keep
serving after the xorb file is removed.
