### PR TITLE
feat: match tree xetHash by lfs sha256 oid and drop upstream headers

### DIFF
--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -414,6 +414,16 @@ func (h *Handler) branchCommit(key string, m []string) (string, *probeResult, bo
 // irrelevant. The array is rewritten in a streaming pass, so a listing is
 // never buffered whole; no upstream header is forwarded, only the body is
 // relayed.
+// treeLFS is the lfs pointer block of a hub tree entry; OID is the sha256
+// naming the file bytes. The entry itself stays a raw map because expand
+// requests add fields (lastCommit, securityFileStatus, ...) that must pass
+// through untouched.
+type treeLFS struct {
+	OID         string `json:"oid"`
+	PointerSize int64  `json:"pointerSize"`
+	Size        int64  `json:"size"`
+}
+
 func (h *Handler) handleTree(w http.ResponseWriter, r *http.Request) {
 	u := h.upstreamURL(r.URL.EscapedPath())
 	if r.URL.RawQuery != "" {
@@ -445,29 +455,29 @@ func (h *Handler) handleTree(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
 	dec := json.NewDecoder(body)
-	dec.UseNumber() // keep large sizes byte-exact through the re-encode
 	if _, err := dec.Token(); err != nil {
 		return
 	}
 	_, _ = io.WriteString(w, "[")
 	for first := true; dec.More(); first = false {
-		var item map[string]any
+		// Raw values keep every untouched field byte-exact through the re-encode.
+		var item map[string]json.RawMessage
 		if err := dec.Decode(&item); err != nil {
 			// Mid-stream failure: stop without the closing bracket so the
 			// client sees invalid JSON rather than a truncated listing.
 			return
 		}
 		if _, ok := item["xetHash"]; ok {
-			var sha string
-			if lfs, _ := item["lfs"].(map[string]any); lfs != nil {
-				sha, _ = lfs["oid"].(string)
-				sha = strings.TrimPrefix(sha, "sha256:")
+			var lfs treeLFS
+			if raw, ok := item["lfs"]; ok {
+				_ = json.Unmarshal(raw, &lfs)
 			}
 			h.mu.Lock()
-			hash, ok := h.sha256s[sha]
+			hash, ok := h.sha256s[lfs.OID]
 			h.mu.Unlock()
 			if ok {
-				item["xetHash"] = hash
+				quoted, _ := json.Marshal(hash)
+				item["xetHash"] = quoted
 			} else {
 				delete(item, "xetHash")
 			}

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -19,6 +19,7 @@
 package mirror
 
 import (
+	"bufio"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -105,6 +106,7 @@ type Handler struct {
 	mu       sync.Mutex
 	flight   singleflight.Group
 	entries  map[string]*fileEntry
+	sha256s  map[string]string // sha256 -> xet hash of ready entries
 	branches map[string]*branchEntry
 	tasks    map[string]*task
 }
@@ -200,6 +202,10 @@ func NewHandler(opts ...Option) (*Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mirror: load index: %w", err)
 	}
+	h.sha256s = map[string]string{}
+	for _, e := range h.entries {
+		h.indexSHA256(e)
+	}
 	h.branches, err = loadBranches(branchDir)
 	if err != nil {
 		return nil, fmt.Errorf("mirror: load branches: %w", err)
@@ -240,6 +246,20 @@ func NewHandler(opts ...Option) (*Handler, error) {
 			if h.upstreamToken != "" {
 				pr.Out.Header.Set("Authorization", "Bearer "+h.upstreamToken)
 			}
+		},
+		// Upstream response headers are dropped; only the body is relayed,
+		// plus its type and the redirect target without which 3xx cannot work.
+		ModifyResponse: func(resp *http.Response) error {
+			ct := resp.Header.Get("Content-Type")
+			loc := resp.Header.Get("Location")
+			resp.Header = http.Header{}
+			if ct != "" {
+				resp.Header.Set("Content-Type", ct)
+			}
+			if loc != "" {
+				resp.Header.Set("Location", loc)
+			}
+			return nil
 		},
 	}
 	if h.next == nil {
@@ -386,16 +406,16 @@ func (h *Handler) branchCommit(key string, m []string) (string, *probeResult, bo
 }
 
 // handleTree proxies a tree listing API request, rewriting each entry's
-// xetHash: files the mirror already holds advertise the mirror's own hash so
-// xet clients reconstruct them from the mirror CAS; all other entries lose
-// the hash so clients fall back to the resolve flow, which ingests through
-// the mirror. Left untouched, upstream hashes would send clients directly to
-// the upstream CAS, bypassing the mirror entirely. Hashes are only looked up
-// under immutable commits: branch revisions go through their pinned commit
-// mapping when fresh and are otherwise stripped, so a live listing is never
-// paired with hashes of content the branch no longer points at.
+// xetHash: entries whose lfs sha256 oid matches a file the mirror already
+// holds advertise the mirror's own hash so xet clients reconstruct them from
+// the mirror CAS; all other entries lose the hash so clients fall back to
+// the resolve flow, which ingests through the mirror. Left untouched,
+// upstream hashes would send clients directly to the upstream CAS, bypassing
+// the mirror entirely. Matching by content makes revision and repo
+// irrelevant. The array is rewritten in a streaming pass, so a listing is
+// never buffered whole; no upstream header is forwarded, only the body is
+// relayed.
 func (h *Handler) handleTree(w http.ResponseWriter, r *http.Request) {
-	m := apiTreeRe.FindStringSubmatch(r.URL.EscapedPath())
 	u := h.upstreamURL(r.URL.EscapedPath())
 	if r.URL.RawQuery != "" {
 		u += "?" + r.URL.RawQuery
@@ -414,113 +434,95 @@ func (h *Handler) handleTree(w http.ResponseWriter, r *http.Request) {
 		_ = resp.Body.Close()
 	}()
 
-	// Pagination (Link) and the other upstream headers pass through; entity
-	// headers are recomputed for the rewritten body.
-	for k, vs := range resp.Header {
-		switch http.CanonicalHeaderKey(k) {
-		case "Content-Length", "Content-Encoding", "Transfer-Encoding":
-			continue
-		}
-		for _, v := range vs {
-			w.Header().Add(k, v)
-		}
+	body := bufio.NewReader(resp.Body)
+	if resp.StatusCode != http.StatusOK || !startsJSONArray(body) {
+		// Error status or unexpected shape: relay the bytes untouched.
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, body)
+		return
 	}
 
-	var items []map[string]any
-	var body []byte
-	if resp.StatusCode == http.StatusOK {
-		body, err = io.ReadAll(resp.Body)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	dec := json.NewDecoder(body)
+	dec.UseNumber() // keep large sizes byte-exact through the re-encode
+	if _, err := dec.Token(); err != nil {
+		return
+	}
+	_, _ = io.WriteString(w, "[")
+	for first := true; dec.More(); first = false {
+		var item map[string]any
+		if err := dec.Decode(&item); err != nil {
+			// Mid-stream failure: stop without the closing bracket so the
+			// client sees invalid JSON rather than a truncated listing.
+			return
+		}
+		if _, ok := item["xetHash"]; ok {
+			var sha string
+			if lfs, _ := item["lfs"].(map[string]any); lfs != nil {
+				sha, _ = lfs["oid"].(string)
+				sha = strings.TrimPrefix(sha, "sha256:")
+			}
+			h.mu.Lock()
+			hash, ok := h.sha256s[sha]
+			h.mu.Unlock()
+			if ok {
+				item["xetHash"] = hash
+			} else {
+				delete(item, "xetHash")
+			}
+		}
+		out, err := json.Marshal(item)
 		if err != nil {
-			http.Error(w, "read upstream tree failed", http.StatusBadGateway)
+			return
+		}
+		if !first {
+			_, _ = io.WriteString(w, ",")
+		}
+		if _, err := w.Write(out); err != nil {
 			return
 		}
 	}
-	if body == nil || json.Unmarshal(body, &items) != nil {
-		// Error status or unexpected shape: relay untouched.
-		w.WriteHeader(resp.StatusCode)
-		if body != nil {
-			_, _ = w.Write(body)
-		} else {
-			_, _ = io.Copy(w, resp.Body)
-		}
-		return
-	}
-
-	var ready map[string]string
-	lookupRev := m[3]
-	if !commitRevRe.MatchString(lookupRev) {
-		// Branch trees only advertise hashes through a fresh pinned commit;
-		// probing is left to the resolve path.
-		lookupRev = ""
-		name := strings.TrimPrefix(repoResolvePrefix(m[1], m[2]), "/") + "\x00" + m[3]
-		h.mu.Lock()
-		if b := h.branches[name]; b != nil && !h.branchStale(b) {
-			lookupRev = b.Commit
-		}
-		h.mu.Unlock()
-	}
-	if lookupRev != "" {
-		ready = h.readyFileHashes(repoResolvePrefix(m[1], m[2]), lookupRev)
-	}
-	for _, item := range items {
-		if _, ok := item["xetHash"]; !ok {
-			continue
-		}
-		path, _ := item["path"].(string)
-		if hash, ok := ready[path]; ok {
-			item["xetHash"] = hash
-		} else {
-			delete(item, "xetHash")
-		}
-	}
-
-	out, err := json.Marshal(items)
-	if err != nil {
-		http.Error(w, "encode tree failed", http.StatusInternalServerError)
-		return
-	}
-	w.Header().Del("Etag") // body differs from upstream
-	w.Header().Set("Content-Length", strconv.Itoa(len(out)))
-	w.WriteHeader(resp.StatusCode)
-	_, _ = w.Write(out)
+	_, _ = io.WriteString(w, "]")
 }
 
-// repoResolvePrefix maps an API repo type and id to the repo prefix used in
-// resolve keys: models live at the root, other types keep their segment.
-func repoResolvePrefix(repoType, repoID string) string {
-	if repoType == "models" {
-		return "/" + repoID
+// startsJSONArray peeks past leading whitespace and reports whether the next
+// byte opens a JSON array, consuming nothing.
+func startsJSONArray(br *bufio.Reader) bool {
+	for i := 1; ; i++ {
+		buf, _ := br.Peek(i)
+		if len(buf) < i {
+			return false
+		}
+		switch buf[i-1] {
+		case ' ', '\t', '\r', '\n':
+		default:
+			return buf[i-1] == '['
+		}
 	}
-	return "/" + repoType + "/" + repoID
 }
 
-// readyFileHashes returns path -> local xet hash for ready entries of the
-// given repo whose key revision or ingested commit matches rev.
-func (h *Handler) readyFileHashes(repoPrefix, rev string) map[string]string {
-	prefix := repoPrefix + "/resolve/"
-	out := map[string]string{}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	for key, e := range h.entries {
-		if e.State != stateReady || e.FileHash == "" || !strings.HasPrefix(key, prefix) {
-			continue
-		}
-		rest := key[len(prefix):]
-		i := strings.IndexByte(rest, '/')
-		if i < 0 {
-			continue
-		}
-		if rest[:i] != rev && e.Commit != rev {
-			continue
-		}
-		// Keys hold escaped paths; tree entries carry them unescaped.
-		path := rest[i+1:]
-		if unescaped, err := url.PathUnescape(path); err == nil {
-			path = unescaped
-		}
-		out[path] = e.FileHash
+// indexSHA256 records e's content mapping for tree rewrites; the caller
+// holds h.mu (or is still single-threaded).
+func (h *Handler) indexSHA256(e *fileEntry) {
+	if e.State == stateReady && e.FileHash != "" && e.SHA256 != "" {
+		h.sha256s[e.SHA256] = e.FileHash
 	}
-	return out
+}
+
+// dropSHA256 removes old's content mapping unless another ready entry still
+// names the same bytes; the caller holds h.mu.
+func (h *Handler) dropSHA256(old *fileEntry) {
+	if old.SHA256 == "" {
+		return
+	}
+	for _, e := range h.entries {
+		if e.State == stateReady && e.SHA256 == old.SHA256 {
+			return
+		}
+	}
+	delete(h.sha256s, old.SHA256)
 }
 
 // task tracks one in-flight ingestion. All concurrent requests for the same
@@ -757,6 +759,7 @@ func (h *Handler) runTask(key string, t *task, pre *probeResult) {
 
 	h.mu.Lock()
 	h.entries[key] = entry
+	h.indexSHA256(entry)
 	delete(h.tasks, key)
 	h.mu.Unlock()
 	t.spool.markRemove() // bytes now live in storage; drop the spool when drained
@@ -965,6 +968,7 @@ func (h *Handler) revalidate(ctx context.Context, key string, e *fileEntry) *fil
 	h.mu.Lock()
 	if h.entries[key] == e {
 		delete(h.entries, key)
+		h.dropSHA256(e)
 	}
 	h.mu.Unlock()
 	_ = os.Remove(indexEntryPath(h.indexDir, e.Commit, key))

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -106,7 +106,6 @@ type Handler struct {
 	mu       sync.Mutex
 	flight   singleflight.Group
 	entries  map[string]*fileEntry
-	sha256s  map[string]string // sha256 -> xet hash of ready entries
 	branches map[string]*branchEntry
 	tasks    map[string]*task
 }
@@ -201,10 +200,6 @@ func NewHandler(opts ...Option) (*Handler, error) {
 	h.entries, err = loadIndex(h.indexDir)
 	if err != nil {
 		return nil, fmt.Errorf("mirror: load index: %w", err)
-	}
-	h.sha256s = map[string]string{}
-	for _, e := range h.entries {
-		h.indexSHA256(e)
 	}
 	h.branches, err = loadBranches(branchDir)
 	if err != nil {
@@ -404,16 +399,6 @@ func (h *Handler) branchCommit(key string, m []string) (string, *probeResult, bo
 	return "", pr, false
 }
 
-// handleTree proxies a tree listing API request, rewriting each entry's
-// xetHash: entries whose lfs sha256 oid matches a file the mirror already
-// holds advertise the mirror's own hash so xet clients reconstruct them from
-// the mirror CAS; all other entries lose the hash so clients fall back to
-// the resolve flow, which ingests through the mirror. Left untouched,
-// upstream hashes would send clients directly to the upstream CAS, bypassing
-// the mirror entirely. Matching by content makes revision and repo
-// irrelevant. The array is rewritten in a streaming pass, so a listing is
-// never buffered whole; no upstream header is forwarded, only the body is
-// relayed.
 // treeLFS is the lfs pointer block of a hub tree entry; OID is the sha256
 // naming the file bytes. The entry itself stays a raw map because expand
 // requests add fields (lastCommit, securityFileStatus, ...) that must pass
@@ -424,6 +409,15 @@ type treeLFS struct {
 	Size        int64  `json:"size"`
 }
 
+// handleTree proxies a tree listing API request, rewriting each entry's
+// xetHash: entries whose lfs sha256 oid resolves in local storage advertise
+// the mirror's own hash so xet clients reconstruct them from the mirror CAS;
+// all other entries lose the hash so clients fall back to the resolve flow,
+// which ingests through the mirror. Left untouched, upstream hashes would
+// send clients directly to the upstream CAS, bypassing the mirror entirely.
+// Matching by content makes revision and repo irrelevant. The array is
+// rewritten in a streaming pass, so a listing is never buffered whole; no
+// upstream header is forwarded, only the body is relayed.
 func (h *Handler) handleTree(w http.ResponseWriter, r *http.Request) {
 	u := h.upstreamURL(r.URL.EscapedPath())
 	if r.URL.RawQuery != "" {
@@ -472,10 +466,7 @@ func (h *Handler) handleTree(w http.ResponseWriter, r *http.Request) {
 			if raw, ok := item["lfs"]; ok {
 				_ = json.Unmarshal(raw, &lfs)
 			}
-			h.mu.Lock()
-			hash, ok := h.sha256s[lfs.OID]
-			h.mu.Unlock()
-			if ok {
+			if hash, ok := h.lookupXetHash(r.Context(), lfs.OID); ok {
 				quoted, _ := json.Marshal(hash)
 				item["xetHash"] = quoted
 			} else {
@@ -512,26 +503,18 @@ func startsJSONArray(br *bufio.Reader) bool {
 	}
 }
 
-// indexSHA256 records e's content mapping for tree rewrites; the caller
-// holds h.mu (or is still single-threaded).
-func (h *Handler) indexSHA256(e *fileEntry) {
-	if e.State == stateReady && e.FileHash != "" && e.SHA256 != "" {
-		h.sha256s[e.SHA256] = e.FileHash
+// lookupXetHash resolves an lfs sha256 oid to the local xet file hash through
+// the storage sha256 index; ok is false when the content is not held locally.
+func (h *Handler) lookupXetHash(ctx context.Context, oid string) (string, bool) {
+	digest, err := hex.DecodeString(oid)
+	if err != nil || len(digest) != sha256.Size {
+		return "", false
 	}
-}
-
-// dropSHA256 removes old's content mapping unless another ready entry still
-// names the same bytes; the caller holds h.mu.
-func (h *Handler) dropSHA256(old *fileEntry) {
-	if old.SHA256 == "" {
-		return
+	fileHash, err := h.storage.GetFileHashBySHA256(ctx, "default", [32]byte(digest))
+	if err != nil {
+		return "", false
 	}
-	for _, e := range h.entries {
-		if e.State == stateReady && e.SHA256 == old.SHA256 {
-			return
-		}
-	}
-	delete(h.sha256s, old.SHA256)
+	return fileHash.String(), true
 }
 
 // task tracks one in-flight ingestion. All concurrent requests for the same
@@ -768,7 +751,6 @@ func (h *Handler) runTask(key string, t *task, pre *probeResult) {
 
 	h.mu.Lock()
 	h.entries[key] = entry
-	h.indexSHA256(entry)
 	delete(h.tasks, key)
 	h.mu.Unlock()
 	t.spool.markRemove() // bytes now live in storage; drop the spool when drained
@@ -977,7 +959,6 @@ func (h *Handler) revalidate(ctx context.Context, key string, e *fileEntry) *fil
 	h.mu.Lock()
 	if h.entries[key] == e {
 		delete(h.entries, key)
-		h.dropSHA256(e)
 	}
 	h.mu.Unlock()
 	_ = os.Remove(indexEntryPath(h.indexDir, e.Commit, key))

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -247,18 +247,17 @@ func NewHandler(opts ...Option) (*Handler, error) {
 				pr.Out.Header.Set("Authorization", "Bearer "+h.upstreamToken)
 			}
 		},
-		// Upstream response headers are dropped; only the body is relayed,
-		// plus its type and the redirect target without which 3xx cannot work.
+		// Upstream response headers are dropped except the entity headers
+		// describing the relayed body and the redirect target without which
+		// 3xx cannot work.
 		ModifyResponse: func(resp *http.Response) error {
-			ct := resp.Header.Get("Content-Type")
-			loc := resp.Header.Get("Location")
-			resp.Header = http.Header{}
-			if ct != "" {
-				resp.Header.Set("Content-Type", ct)
+			kept := http.Header{}
+			for _, k := range []string{"Content-Type", "Content-Length", "Etag", "Date", "Location"} {
+				if v := resp.Header.Get(k); v != "" {
+					kept.Set(k, v)
+				}
 			}
-			if loc != "" {
-				resp.Header.Set("Location", loc)
-			}
+			resp.Header = kept
 			return nil
 		},
 	}

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -855,9 +855,10 @@ func TestMirrorTreeRewrite(t *testing.T) {
 	// upstream must serve the commit-keyed path the ingest will fetch.
 	upstream.commit = strings.Repeat("ab", 20)
 	upstream.set("/org/repo/resolve/"+upstream.commit+"/model.bin", data)
+	oid := fmt.Sprintf("%x", sha256.Sum256(data))
 	treeJSON := []byte(`[
-		{"type":"file","path":"model.bin","size":131072,"xetHash":"upstream-hash-1"},
-		{"type":"file","path":"other.bin","size":7,"xetHash":"upstream-hash-2"},
+		{"type":"file","path":"model.bin","size":131072,"lfs":{"oid":"` + oid + `","size":131072,"pointerSize":134},"xetHash":"upstream-hash-1"},
+		{"type":"file","path":"other.bin","size":7,"lfs":{"oid":"` + strings.Repeat("00", 32) + `","size":7,"pointerSize":133},"xetHash":"upstream-hash-2"},
 		{"type":"directory","path":"sub"}
 	]`)
 	upstream.api["/api/models/org/repo/tree/main"] = treeJSON
@@ -923,9 +924,8 @@ func TestMirrorTreeRewrite(t *testing.T) {
 		}
 	})
 
-	// Branch trees resolve through the pinned commit mapping established by
-	// the resolve requests above.
-	t.Run("branch rev advertises via pinned commit", func(t *testing.T) {
+	// Branch trees match by content too; no pinned commit is involved.
+	t.Run("branch rev advertises local hash", func(t *testing.T) {
 		for _, item := range fetchTree("main") {
 			hash, ok := item["xetHash"]
 			switch item["path"] {
@@ -941,7 +941,7 @@ func TestMirrorTreeRewrite(t *testing.T) {
 		}
 	})
 
-	// The tree rev the client uses must not resolve entries of other repos.
+	// Entries without a matching lfs oid (here: none at all) lose the hash.
 	t.Run("other repo unaffected", func(t *testing.T) {
 		upstream.mu.Lock()
 		upstream.api["/api/models/org/other/tree/main"] = []byte(`[{"type":"file","path":"model.bin","size":1,"xetHash":"h"}]`)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -46,6 +46,9 @@ type Storage interface {
 
 	// GetReconstructedFile returns a ReadSeekCloser for a file reconstructed from a shard by its SHA-256 digest.
 	GetReconstructedFile(ctx context.Context, namespace string, sha256 [32]byte) (io.ReadSeekCloser, error)
+
+	// GetFileHashBySHA256 resolves a file's SHA-256 digest to the xet file hash recorded at ingest.
+	GetFileHashBySHA256(ctx context.Context, namespace string, sha256 [32]byte) (xet.FileHash, error)
 }
 
 // FileStorage implements Storage using the filesystem
@@ -564,29 +567,39 @@ func (fs *FileStorage) GetShard(ctx context.Context, fileHash xet.FileHash) (*sh
 	return fs.getShard(fileHash)
 }
 
-func (fs *FileStorage) getShardBySHA256(ctx context.Context, _ string, digest [32]byte) (*shard.Shard, error) {
+// GetFileHashBySHA256 resolves a SHA-256 digest to the xet file hash recorded
+// at ingest, reading the sha256 index file through the bounded cache.
+func (fs *FileStorage) GetFileHashBySHA256(ctx context.Context, _ string, digest [32]byte) (xet.FileHash, error) {
 	fs.sha256Mut.Lock()
 	value, exists := fs.sha256Index.Get(digest)
 	fs.sha256Mut.Unlock()
 	if exists {
-		return fs.GetShard(ctx, value.(xet.FileHash))
+		return value.(xet.FileHash), nil
 	}
 
 	indexPath := fs.objectPath("sha256", hex.EncodeToString(digest[:]))
 	b, err := os.ReadFile(indexPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("SHA-256 not found")
+			return xet.FileHash{}, fmt.Errorf("SHA-256 not found")
 		}
-		return nil, fmt.Errorf("read SHA-256 index: %w", err)
+		return xet.FileHash{}, fmt.Errorf("read SHA-256 index: %w", err)
 	}
 	fileHash, err := xet.ParseFileHash(strings.TrimSpace(string(b)))
 	if err != nil {
-		return nil, fmt.Errorf("invalid SHA-256 index: %w", err)
+		return xet.FileHash{}, fmt.Errorf("invalid SHA-256 index: %w", err)
 	}
 	fs.sha256Mut.Lock()
 	fs.sha256Index.Add(digest, fileHash)
 	fs.sha256Mut.Unlock()
+	return fileHash, nil
+}
+
+func (fs *FileStorage) getShardBySHA256(ctx context.Context, namespace string, digest [32]byte) (*shard.Shard, error) {
+	fileHash, err := fs.GetFileHashBySHA256(ctx, namespace, digest)
+	if err != nil {
+		return nil, err
+	}
 	return fs.GetShard(ctx, fileHash)
 }
 


### PR DESCRIPTION
Tree rewrites keyed the ready-hash lookup by repo prefix, revision, and path (`readyFileHashes`), so a listing only advertised the mirror's hash when the request revision matched the entry's key or ingested commit, branch trees additionally depended on a fresh pinned-commit mapping, and the whole upstream body was buffered with `io.ReadAll` before rewriting.

Each tree entry's `lfs.oid` already names the exact bytes, so the lookup is now content-addressed: each item resolves its lfs oid through the sha256 index files storage already persists at ingest (exposed as `GetFileHashBySHA256`, read through the existing bounded LRU), so there is no mirror-side bookkeeping to keep in sync. Revision, repo, and branch pinning drop out of the tree path entirely, and identical content dedups across repos. The array is decoded and re-encoded item by item (`UseNumber` keeps large sizes byte-exact), so listings stream through without being held whole; a non-array or error body is relayed untouched.

Upstream headers also stop reaching downstream: `handleTree` emits only its own `Content-Type`, and the fallthrough reverse proxy clears the upstream response headers, keeping the entity headers that still describe the relayed body (`Content-Type`, `Content-Length`, `Etag`, `Date`) and `Location` (without which 3xx cannot work). The tree test fixtures now carry lfs oids and cover the match, mismatch, and missing-oid cases.


