### PR TITLE
fix: keep Content-Encoding on proxied responses

### DIFF
--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -247,7 +247,7 @@ func NewHandler(opts ...Option) (*Handler, error) {
 		// 3xx cannot work.
 		ModifyResponse: func(resp *http.Response) error {
 			kept := http.Header{}
-			for _, k := range []string{"Content-Type", "Content-Length", "Etag", "Date", "Location"} {
+			for _, k := range []string{"Content-Type", "Content-Length", "Content-Encoding", "Etag", "Date", "Location"} {
 				if v := resp.Header.Get(k); v != "" {
 					kept.Set(k, v)
 				}


### PR DESCRIPTION
`hf download` against the mirror fails with `Error: Invalid value. 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte` — 0x8b is the second byte of the gzip magic. #154 made the fallthrough proxy drop upstream response headers behind a whitelist, but the proxy still relays the body byte-for-byte: the client advertises `Accept-Encoding: gzip`, the upstream answers compressed, and with `Content-Encoding` stripped the client parses raw gzip as JSON.

Content-Encoding describes the relayed bytes just like Content-Length, so add it to the kept set.
