### PR TITLE
refactor: keep the mirror to its own cache and inject the xet client

### DIFF
--- a/cmd/xetd/main.go
+++ b/cmd/xetd/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/handlers"
+	"github.com/wzshiming/xet/client"
 	"github.com/wzshiming/xet/mirror"
 	"github.com/wzshiming/xet/server"
 	"github.com/wzshiming/xet/storage"
@@ -61,12 +62,21 @@ func main() {
 		// Mirror mode: full-cache middle layer in front of the upstream hub.
 		// The mirror handles resolve/token requests and proxies the rest to
 		// the upstream; the CAS server below matches its own routes first.
+		xetClient, err := client.NewClient(
+			client.WithCacheDir(filepath.Join(*storageDir, "mirror", "chunks")),
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create xet client: %v\n", err)
+			os.Exit(1)
+		}
+
 		next, err = mirror.NewHandler(
 			mirror.WithStorage(storage),
 			mirror.WithUpstream(*upstream),
 			mirror.WithUpstreamToken(*upstreamToken),
 			mirror.WithExternalURL(*baseURL),
 			mirror.WithCacheDir(filepath.Join(*storageDir, "mirror")),
+			mirror.WithClient(xetClient),
 			mirror.WithMintToken(issuer.Mint),
 		)
 		if err != nil {

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -129,10 +129,17 @@ func WithUpstreamToken(token string) Option {
 	return func(h *Handler) { h.upstreamToken = token }
 }
 
-// WithCacheDir sets the directory holding the persisted index, in-flight
-// spool files, and the xet chunk cache. Defaults to ./xet-mirror.
+// WithCacheDir sets the directory holding the persisted index and in-flight
+// spool files. Defaults to ./xet-mirror.
 func WithCacheDir(dir string) Option {
 	return func(h *Handler) { h.cacheDir = dir }
+}
+
+// WithClient sets the xet client used for upstream xet downloads, letting
+// the caller configure it (chunk cache location, concurrency, ...). When
+// unset a default client is created.
+func WithClient(c *client.Client) Option {
+	return func(h *Handler) { h.xetClient = c }
 }
 
 // WithExternalURL sets the externally visible base URL used in Link headers
@@ -190,8 +197,7 @@ func NewHandler(opts ...Option) (*Handler, error) {
 	h.indexDir = filepath.Join(h.cacheDir, "index")
 	h.spoolDir = filepath.Join(h.cacheDir, "spool")
 	branchDir := h.branchDir()
-	chunkCacheDir := filepath.Join(h.cacheDir, "chunks")
-	for _, dir := range []string{h.indexDir, branchDir, h.spoolDir, chunkCacheDir} {
+	for _, dir := range []string{h.indexDir, branchDir, h.spoolDir} {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return nil, fmt.Errorf("mirror: create %s: %w", dir, err)
 		}
@@ -224,11 +230,11 @@ func NewHandler(opts ...Option) (*Handler, error) {
 		}),
 	}
 
-	// Without an explicit cache dir the client would fall back to a shared
-	// location under os.TempDir; keep the chunk cache with the mirror data.
-	h.xetClient, err = client.NewClient(client.WithCacheDir(chunkCacheDir))
-	if err != nil {
-		return nil, fmt.Errorf("mirror: create xet client: %w", err)
+	if h.xetClient == nil {
+		h.xetClient, err = client.NewClient()
+		if err != nil {
+			return nil, fmt.Errorf("mirror: create xet client: %w", err)
+		}
 	}
 
 	h.localAdapter = &localCAS{storage: h.storage, namespace: "default"}
@@ -921,7 +927,6 @@ func (h *Handler) ingestSpool(ctx context.Context, t *task, key string) (*fileEn
 		fileHash, err := upload.UploadFile(ctx, h.localAdapter, f,
 			upload.WithEnableSHA256(true),
 			upload.WithConcurrency(4),
-			upload.WithCacheDir(h.spoolDir),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("ingest into storage: %w", err)


### PR DESCRIPTION
`NewHandler` carved the embedded client's chunk cache out of the mirror's own cache dir (`<cacheDir>/chunks`, created eagerly) and `ingestSpool` pointed the upload pipeline's temp files at the spool dir, so the mirror managed caches it does not own — and the spool dir collected `xet-upload-xorb-*` leftovers that survive a crashed ingest but never match the `.spool` sweep. Storage was already clean: the mirror only reads and writes through the injected `Storage` interface and never touches its layout.

The chunk cache now belongs entirely to the client: a new `WithClient` option lets the caller inject a pre-configured client (xetd builds it with the cache at the same `<storage>/mirror/chunks` location, so nothing moves on disk), and `NewHandler` falls back to a plain default client when none is given. The upload pipeline uses its own temp default again, leaving the mirror's cache dir with only mirror-owned state: index, branches, and spool.
