### PR TITLE
refactor: group storage key-value indexes under an index/ directory

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -30,9 +30,9 @@ import (
 const defaultPresignExpiry = time.Hour
 
 // S3Storage implements Storage backed by an S3-compatible object store. It
-// uses the same object layout as FileStorage (xorbs/, shards/, files/,
-// chunks/, sha256/ with a two-character fanout), so a bucket populated by
-// syncing a FileStorage directory is directly usable.
+// uses the same object layout as FileStorage (xorbs/, shards/, index/files/,
+// index/chunks/, index/sha256/ with a two-character fanout), so a bucket
+// populated by syncing a FileStorage directory is directly usable.
 type S3Storage struct {
 	client          *s3.Client
 	presignClient   *s3.PresignClient
@@ -392,7 +392,7 @@ func (ss *S3Storage) hasFile(ctx context.Context, fileHash xet.FileHash) (bool, 
 		return true, nil
 	}
 
-	_, exists, err := ss.headObject(ctx, ss.objectKey("files", fileHash.String()))
+	_, exists, err := ss.headObject(ctx, ss.objectKey("index/files", fileHash.String()))
 	if err != nil {
 		return false, fmt.Errorf("check file index: %w", err)
 	}
@@ -489,24 +489,24 @@ func (ss *S3Storage) PutShard(ctx context.Context, s *shard.Shard) (bool, error)
 		return false, fmt.Errorf("upload shard: %w", err)
 	}
 
-	// The files/ index is written last: hasFile treats it as the commit
+	// The index/files/ index is written last: hasFile treats it as the commit
 	// marker, so a partial failure leaves a retryable shard instead of one
 	// that reports "already exists" with missing chunk/sha256 indexes.
 	shardHashData := []byte(shardHash)
 	for _, casBlock := range s.CASInfos {
 		for _, chunk := range casBlock.Chunks {
-			if err := ss.putIndexObject(ctx, ss.objectKey("chunks", chunk.ChunkHash.String()), shardHashData); err != nil {
+			if err := ss.putIndexObject(ctx, ss.objectKey("index/chunks", chunk.ChunkHash.String()), shardHashData); err != nil {
 				return wasInserted, fmt.Errorf("write chunk index: %w", err)
 			}
 		}
 	}
 	for _, file := range s.Files {
-		if err := ss.putIndexObject(ctx, ss.objectKey("sha256", file.MetadataExt.SHA256Hash.String()), []byte(file.FileHash.String())); err != nil {
+		if err := ss.putIndexObject(ctx, ss.objectKey("index/sha256", file.MetadataExt.SHA256Hash.String()), []byte(file.FileHash.String())); err != nil {
 			return wasInserted, fmt.Errorf("write SHA-256 index for file %s: %w", file.FileHash.String(), err)
 		}
 	}
 	for _, file := range s.Files {
-		if err := ss.putIndexObject(ctx, ss.objectKey("files", file.FileHash.String()), shardHashData); err != nil {
+		if err := ss.putIndexObject(ctx, ss.objectKey("index/files", file.FileHash.String()), shardHashData); err != nil {
 			return wasInserted, fmt.Errorf("write file index for file %s: %w", file.FileHash.String(), err)
 		}
 	}
@@ -562,7 +562,7 @@ func (ss *S3Storage) GetShard(ctx context.Context, fileHash xet.FileHash) (*shar
 		return ss.getShardByHash(ctx, value.(string))
 	}
 
-	data, err := ss.getObject(ctx, ss.objectKey("files", fileHash.String()))
+	data, err := ss.getObject(ctx, ss.objectKey("index/files", fileHash.String()))
 	if err != nil {
 		return nil, fmt.Errorf("read file index: %w", err)
 	}
@@ -582,7 +582,7 @@ func (ss *S3Storage) GetShardByChunkHash(ctx context.Context, _ string, chunkHas
 		return ss.getShardByHash(ctx, value.(string))
 	}
 
-	data, err := ss.getObject(ctx, ss.objectKey("chunks", chunkHash.String()))
+	data, err := ss.getObject(ctx, ss.objectKey("index/chunks", chunkHash.String()))
 	if err != nil {
 		if isS3NotFound(err) {
 			return nil, fmt.Errorf("chunk not found")
@@ -606,7 +606,7 @@ func (ss *S3Storage) GetFileHashBySHA256(ctx context.Context, _ string, digest [
 		return value.(xet.FileHash), nil
 	}
 
-	data, err := ss.getObject(ctx, ss.objectKey("sha256", hex.EncodeToString(digest[:])))
+	data, err := ss.getObject(ctx, ss.objectKey("index/sha256", hex.EncodeToString(digest[:])))
 	if err != nil {
 		if isS3NotFound(err) {
 			return xet.FileHash{}, fmt.Errorf("SHA-256 not found")

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -399,7 +399,7 @@ func TestS3StoragePutShardRetryAfterPartialFailure(t *testing.T) {
 	// First attempt dies while writing SHA-256 indexes, after the shard
 	// object and chunk indexes are already stored.
 	fc.setFail(func(req *http.Request) bool {
-		return req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/sha256/")
+		return req.Method == http.MethodPut && strings.Contains(req.URL.Path, "/index/sha256/")
 	})
 	if _, err := ss.PutShard(ctx, shardObj); err == nil {
 		t.Fatal("PutShard() succeeded despite injected failure")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -172,9 +172,9 @@ func NewFileStorage(opts ...Option) (*FileStorage, error) {
 	dirs := []string{
 		filepath.Join(fs.basePath, "xorbs"),
 		filepath.Join(fs.basePath, "shards"),
-		filepath.Join(fs.basePath, "files"),
-		filepath.Join(fs.basePath, "chunks"),
-		filepath.Join(fs.basePath, "sha256"),
+		filepath.Join(fs.basePath, "index", "files"),
+		filepath.Join(fs.basePath, "index", "chunks"),
+		filepath.Join(fs.basePath, "index", "sha256"),
 	}
 
 	for _, dir := range dirs {
@@ -205,7 +205,7 @@ func (fs *FileStorage) hasFile(fileHash xet.FileHash) (bool, error) {
 		return true, nil
 	}
 
-	filePath := fs.objectPath("files", fileHash.String())
+	filePath := fs.objectPath("index/files", fileHash.String())
 	if _, err := os.Stat(filePath); err == nil {
 		return true, nil
 	} else if !os.IsNotExist(err) {
@@ -214,8 +214,8 @@ func (fs *FileStorage) hasFile(fileHash xet.FileHash) (bool, error) {
 	return false, nil
 }
 
-// getShard resolves a file hash through files/<file-hash>, whose contents are
-// the hash of the serialized shard stored at shards/<shard-hash>.
+// getShard resolves a file hash through index/files/<file-hash>, whose contents
+// are the hash of the serialized shard stored at shards/<shard-hash>.
 func (fs *FileStorage) getShard(fileHash xet.FileHash) (*shard.Shard, error) {
 	fs.fileMut.Lock()
 	value, exists := fs.fileIndex.Get(fileHash)
@@ -224,7 +224,7 @@ func (fs *FileStorage) getShard(fileHash xet.FileHash) (*shard.Shard, error) {
 		return fs.getShardByHash(value.(string))
 	}
 
-	indexPath := fs.objectPath("files", fileHash.String())
+	indexPath := fs.objectPath("index/files", fileHash.String())
 	indexData, err := os.ReadFile(indexPath)
 	if err != nil {
 		return nil, fmt.Errorf("read file index: %w", err)
@@ -437,7 +437,7 @@ func (fs *FileStorage) PutShard(ctx context.Context, s *shard.Shard) (bool, erro
 		fs.fileMut.Lock()
 		fs.fileIndex.Add(file.FileHash, shardHash)
 		fs.fileMut.Unlock()
-		indexPath := fs.objectPath("files", file.FileHash.String())
+		indexPath := fs.objectPath("index/files", file.FileHash.String())
 		if err := writeIndexFile(indexPath, shardHashData); err != nil {
 			return wasInserted, fmt.Errorf("write file index for file %s: %w", file.FileHash.String(), err)
 		}
@@ -445,7 +445,7 @@ func (fs *FileStorage) PutShard(ctx context.Context, s *shard.Shard) (bool, erro
 
 	for _, casBlock := range s.CASInfos {
 		for _, chunk := range casBlock.Chunks {
-			chunkPath := fs.objectPath("chunks", chunk.ChunkHash.String())
+			chunkPath := fs.objectPath("index/chunks", chunk.ChunkHash.String())
 			err := writeIndexFile(chunkPath, shardHashData)
 			if err != nil {
 				return wasInserted, fmt.Errorf("write chunk index: %w", err)
@@ -453,7 +453,7 @@ func (fs *FileStorage) PutShard(ctx context.Context, s *shard.Shard) (bool, erro
 		}
 	}
 	for _, file := range s.Files {
-		sha256Path := fs.objectPath("sha256", file.MetadataExt.SHA256Hash.String())
+		sha256Path := fs.objectPath("index/sha256", file.MetadataExt.SHA256Hash.String())
 		if err := writeIndexFile(sha256Path, []byte(file.FileHash.String())); err != nil {
 			return wasInserted, fmt.Errorf("write SHA-256 index for file %s: %w", file.FileHash.String(), err)
 		}
@@ -577,7 +577,7 @@ func (fs *FileStorage) GetFileHashBySHA256(ctx context.Context, _ string, digest
 		return value.(xet.FileHash), nil
 	}
 
-	indexPath := fs.objectPath("sha256", hex.EncodeToString(digest[:]))
+	indexPath := fs.objectPath("index/sha256", hex.EncodeToString(digest[:]))
 	b, err := os.ReadFile(indexPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -620,7 +620,7 @@ func (fs *FileStorage) GetShardByChunkHash(ctx context.Context, namespace string
 		return fs.getShardByHash(value.(string))
 	}
 
-	chunkPath := fs.objectPath("chunks", chunkHash.String())
+	chunkPath := fs.objectPath("index/chunks", chunkHash.String())
 	b, err := os.ReadFile(chunkPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -55,7 +55,7 @@ func TestChunkIndexPersistsAndShardReloadsAfterEviction(t *testing.T) {
 	}
 
 	for _, hash := range []xet.FileHash{fileHash, secondFileHash} {
-		indexData, err := os.ReadFile(fs.objectPath("files", hash.String()))
+		indexData, err := os.ReadFile(fs.objectPath("index/files", hash.String()))
 		if err != nil {
 			t.Fatalf("read file index %s: %v", hash, err)
 		}
@@ -67,7 +67,7 @@ func TestChunkIndexPersistsAndShardReloadsAfterEviction(t *testing.T) {
 		t.Fatalf("legacy shard-index directory exists: %v", err)
 	}
 
-	indexData, err := os.ReadFile(fs.objectPath("chunks", chunkHash.String()))
+	indexData, err := os.ReadFile(fs.objectPath("index/chunks", chunkHash.String()))
 	if err != nil {
 		t.Fatalf("read chunk index: %v", err)
 	}


### PR DESCRIPTION
The storage backends keep two kinds of objects side by side at the top level: real blob data (`xorbs/`, `shards/`) and simple key-value mappings (`files/` file hash → shard hash, `chunks/` chunk hash → shard hash, `sha256/` SHA-256 → file hash). This moves the three mappings under a common `index/` directory (`index/files/`, `index/chunks/`, `index/sha256/`) in both FileStorage and S3Storage, so the layout separates blobs from indexes.

No migration or read fallback: existing deployments need a one-off `mv files index/files` (same for `chunks`, `sha256`) or a re-ingest. S3 buckets need a re-sync from the filesystem layout.

`go build ./...` and `go test ./storage/ ./server/ ./mirror/` pass.
