### PR TITLE
perf: scan the bufio buffer directly in the gearhash chunker

### DIFF
--- a/gearhash.go
+++ b/gearhash.go
@@ -152,40 +152,52 @@ func ChunkData(r io.Reader, fn func(offset int64, chunk []byte) error) error {
 }
 
 // findChunkBoundary fills buf with the next chunk and returns its size.
+// It scans the bufio internal buffer via Peek/Discard to avoid per-byte ReadByte overhead.
 func findChunkBoundary(reader *bufio.Reader, buf []byte) (int, error) {
 	var (
 		hash uint64
 		size int
 	)
 
-	for size < MinChunkSize {
-		b, err := reader.ReadByte()
-		if err != nil {
-			if err == io.EOF {
-				return size, io.EOF
-			}
-			return 0, fmt.Errorf("read chunk prefix: %w", err)
-		}
-
-		buf[size] = b
-		size++
-		hash = (hash << 1) + lookupTable[b]
-	}
-
 	for size < MaxChunkSize {
-		b, err := reader.ReadByte()
+		data, err := reader.Peek(1)
 		if err != nil {
 			if err == io.EOF {
 				return size, io.EOF
 			}
 			return 0, fmt.Errorf("read chunk data: %w", err)
 		}
+		if buffered := reader.Buffered(); buffered > len(data) {
+			data, _ = reader.Peek(buffered)
+		}
+		if remain := MaxChunkSize - size; len(data) > remain {
+			data = data[:remain]
+		}
 
-		buf[size] = b
-		size++
-		hash = (hash << 1) + lookupTable[b]
+		consumed := len(data)
+		found := false
 
-		if (hash & GearhashMask) == 0 {
+		i := 0
+		// No boundary checks until the chunk reaches MinChunkSize.
+		for prefix := MinChunkSize - size; i < len(data) && i < prefix; i++ {
+			hash = (hash << 1) + lookupTable[data[i]]
+		}
+		for ; i < len(data); i++ {
+			hash = (hash << 1) + lookupTable[data[i]]
+			if (hash & GearhashMask) == 0 {
+				consumed = i + 1
+				found = true
+				break
+			}
+		}
+
+		copy(buf[size:], data[:consumed])
+		size += consumed
+		if _, err := reader.Discard(consumed); err != nil {
+			return 0, fmt.Errorf("read chunk data: %w", err)
+		}
+
+		if found {
 			return size, nil
 		}
 	}


### PR DESCRIPTION
findChunkBoundary consumed input one reader.ReadByte() call at a time, so every byte chunked for upload paid a method call and bufio bookkeeping on top of the gear hash update. This is the hot loop behind both Chunker and ChunkData.

It now peeks at the bufio internal buffer and scans it as a plain slice: bytes below MinChunkSize go through a check-free prefix loop, the rest carry the boundary test, and each scanned segment ends with a single copy into the chunk buffer plus a Discard. Boundary semantics are unchanged — the earliest byte eligible for a match is still the one right after MinChunkSize.

Chunk boundaries stay byte-identical: the conformance suite against the xet-core reference passes, and a throwaway old-vs-new equivalence test (including a one-byte-at-a-time reader) found no differences before I deleted it. A temporary benchmark chunking 64 MiB of random data went from ~360 MB/s to ~1365 MB/s (~3.8x). go vet ./... and go test ./... pass.
