### PR TITLE
perf: avoid hash string allocations in merkle merges

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -120,18 +120,27 @@ func (h VerificationHash) String() string {
 
 func formatHash(h hash) string {
 	var out [64]byte
+	return string(appendHash(out[:0], h))
+}
+
+// appendHash appends the XET-format hex encoding of h to dst without
+// allocating, always writing exactly 64 bytes.
+func appendHash(dst []byte, h hash) []byte {
+	var out [64]byte
 	for i := range out {
 		out[i] = '0'
 	}
 
-	var tmp [8]byte
+	// A uint64 in hex is up to 16 digits; undersizing this forces
+	// strconv.AppendUint to heap-allocate on every call.
+	var tmp [16]byte
 	for seg := range 4 {
 		offset := seg * 8
 		val := binary.LittleEndian.Uint64(h[offset : offset+8])
 		s := strconv.AppendUint(tmp[:0], val, 16)
 		copy(out[seg*16+16-len(s):], s)
 	}
-	return string(out[:])
+	return append(dst, out[:]...)
 }
 
 // ComputeChunkHash computes the hash of a chunk using DATA_KEY

--- a/merkle.go
+++ b/merkle.go
@@ -42,6 +42,9 @@ func (t *merkleTree) ComputeRoot() hash {
 	// Build initial list of entries
 	entries := t.node
 
+	// Scratch buffer shared by every merge; sized so appends never grow it.
+	buf := make([]byte, 0, MaxChildren*mergeLineMax)
+
 	// Iteratively collapse until single root remains
 	for len(entries) > 1 {
 		nextLevel := nodesPool.Get().([]node)[:0]
@@ -53,7 +56,7 @@ func (t *merkleTree) ComputeRoot() hash {
 			cutEnd := readIdx + cutSize
 
 			// Merge this group
-			merged := mergeNodes(entries[readIdx:cutEnd])
+			merged := mergeNodes(entries[readIdx:cutEnd], buf)
 			nextLevel = append(nextLevel, merged)
 
 			readIdx = cutEnd
@@ -104,16 +107,21 @@ func nextMergeCut(nodes []node) int {
 	return end
 }
 
-// mergeNodes merges a sequence of nodes into a single parent node
-func mergeNodes(nodes []node) node {
+// mergeLineMax is the longest encoded child line in an internal node input:
+// 64 (hash hex) + 3 (" : ") + 20 (max uint64 digits) + 1 ("\n").
+const mergeLineMax = 64 + 3 + 20 + 1
+
+// mergeNodes merges a sequence of nodes into a single parent node. buf is a
+// scratch buffer reused across calls; it needs capacity for
+// MaxChildren*mergeLineMax bytes to stay allocation-free.
+func mergeNodes(nodes []node, buf []byte) node {
 	// Build the input for the internal node hash
 	// Format: "{hash_hex} : {size}\n" for each child
-	// Each line: 64 (hash hex) + 3 (" : ") + 6 (chunk max digits) + 1 ("\n") = 88 bytes max
-	input := make([]byte, 0, len(nodes)*74)
+	input := buf[:0]
 	var totalSize uint64
 
 	for _, n := range nodes {
-		input = append(input, n.hash.String()...)
+		input = appendHash(input, n.hash)
 		input = append(input, " : "...)
 		input = strconv.AppendUint(input, n.size, 10)
 		input = append(input, '\n')

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -113,3 +113,23 @@ func decodeRawHash(hexStr string) (hash, error) {
 	copy(hash[:], bytes)
 	return hash, nil
 }
+
+func BenchmarkComputeFileHash(b *testing.B) {
+	const numChunks = 100000
+	chunkHashes := make([]ChunkHash, numChunks)
+	chunkSizes := make([]uint64, numChunks)
+	for i := range chunkHashes {
+		var seed [8]byte
+		seed[0] = byte(i)
+		seed[1] = byte(i >> 8)
+		seed[2] = byte(i >> 16)
+		chunkHashes[i] = ComputeChunkHash(seed[:])
+		chunkSizes[i] = uint64(40000 + i%50000)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ComputeFileHash(chunkHashes, chunkSizes)
+	}
+}


### PR DESCRIPTION
While profiling `ComputeFileHash` I found the merkle root computation allocating far more than expected. Two causes:

- `mergeNodes` built its hash input with a per-node `hash.String()` call and a fresh buffer for every merge.
- `formatHash`'s scratch buffer was 8 bytes, but a uint64 in hex needs up to 16 digits, so `strconv.AppendUint` heap-allocated on all four segments of every formatted hash. This one taxes every `String()` call site, not just merkle.

This adds `appendHash` to hex-encode straight into a caller-supplied buffer, makes `mergeNodes` reuse one scratch buffer allocated per `ComputeRoot`, and sizes the tmp buffer correctly.

New `BenchmarkComputeFileHash` (100k chunks, Apple M1):

```
before: 41.7ms/op   26.6MB/op   635336 allocs/op
after:  29.5ms/op    ~1KB/op         8 allocs/op
```

`go test ./...` and the conformance encoding tests against the rust reference pass.
