### PR TITLE
fix: match HMAC-keyed global-dedup shards and honor key expiry

### DIFF
--- a/client/shard.go
+++ b/client/shard.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/wzshiming/xet"
 	"github.com/wzshiming/xet/shard"
@@ -202,13 +203,18 @@ func parseShardUploadNDJSON(r io.Reader) (*upload.ShardUploadResponse, error) {
 // QueryDedupShard downloads the deduplication shard for the given chunk hash and
 // returns all chunk locations indexed by that shard, enabling local O(1) lookups
 // for any chunk that shares the same shard (xet-core style local dedup).
-func (c *Client) QueryDedupShard(ctx context.Context, chunkHash xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
-	return c.QueryDedupShardWithAuthProvider(ctx, nil, chunkHash)
+//
+// candidates are additional raw chunk hashes the caller wants dedup info for.
+// They are needed for HMAC-keyed shards (production CAS): stored hashes are
+// keyed and cannot be reversed, so only hashes offered as candidates can be
+// matched. Unkeyed shards ignore candidates and index every stored hash.
+func (c *Client) QueryDedupShard(ctx context.Context, chunkHash xet.ChunkHash, candidates ...xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
+	return c.QueryDedupShardWithAuthProvider(ctx, nil, chunkHash, candidates...)
 }
 
 // QueryDedupShard downloads the deduplication shard for the given chunk hash
 // with a per-call auth provider.
-func (c *Client) QueryDedupShardWithAuthProvider(ctx context.Context, provider AuthProvider, chunkHash xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
+func (c *Client) QueryDedupShardWithAuthProvider(ctx context.Context, provider AuthProvider, chunkHash xet.ChunkHash, candidates ...xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
 	baseURL, err := c.getBaseURL(ctx, provider)
 	if err != nil {
 		return nil, fmt.Errorf("get base URL: %w", err)
@@ -256,6 +262,17 @@ func (c *Client) QueryDedupShardWithAuthProvider(ctx context.Context, provider A
 			IsNew:     true,
 		},
 	}
+
+	if shardObj.Footer != nil && shardObj.Footer.IsExpired(time.Now()) {
+		// The shard key has expired, so its xorb references can no longer be
+		// relied on for dedup; treat the probe as new data.
+		return results, nil
+	}
+
+	if shardObj.Footer != nil && shardObj.Footer.IsKeyed() {
+		return matchKeyedDedupShard(shardObj, chunkHash, candidates, results), nil
+	}
+
 	for _, casBlock := range shardObj.CASInfos {
 		for i, casChunk := range casBlock.Chunks {
 			results[casChunk.ChunkHash] = &upload.DeduplicationResult{
@@ -270,16 +287,57 @@ func (c *Client) QueryDedupShardWithAuthProvider(ctx context.Context, provider A
 	return results, nil
 }
 
+// matchKeyedDedupShard resolves raw candidate hashes against a shard whose
+// stored chunk hashes are HMAC-keyed with the footer's ChunkHashKey
+// (xet-core MDBShardInfo::keyed_chunk_hash semantics).
+func matchKeyedDedupShard(shardObj *shard.Shard, chunkHash xet.ChunkHash, candidates []xet.ChunkHash, results map[xet.ChunkHash]*upload.DeduplicationResult) map[xet.ChunkHash]*upload.DeduplicationResult {
+	type chunkLocation struct {
+		xorbHash   xet.XorbHash
+		chunkIndex uint32
+	}
+
+	keyed := make(map[xet.ChunkHash]chunkLocation)
+	for _, casBlock := range shardObj.CASInfos {
+		for i, casChunk := range casBlock.Chunks {
+			keyed[casChunk.ChunkHash] = chunkLocation{
+				xorbHash:   casBlock.CASHash,
+				chunkIndex: uint32(i),
+			}
+		}
+	}
+
+	key := shardObj.Footer.ChunkHashKey
+	for _, candidate := range append([]xet.ChunkHash{chunkHash}, candidates...) {
+		if existing, ok := results[candidate]; ok && !existing.IsNew {
+			continue
+		}
+		location, ok := keyed[candidate.HMAC(key)]
+		if !ok {
+			continue
+		}
+		results[candidate] = &upload.DeduplicationResult{
+			ChunkHash:  candidate,
+			IsNew:      false,
+			XorbHash:   location.xorbHash,
+			ChunkIndex: location.chunkIndex,
+		}
+	}
+
+	return results
+}
+
 // QueryDedupShards checks multiple chunk hashes against the global
 // deduplication index. It prefers the batch endpoint and falls back to single
-// chunk queries when the batch endpoint is unavailable.
-func (c *Client) QueryDedupShards(ctx context.Context, chunkHashes []xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
-	return c.QueryDedupShardsWithAuthProvider(ctx, nil, chunkHashes)
+// chunk queries when the batch endpoint is unavailable. candidates are the
+// raw chunk hashes matched against HMAC-keyed shards on the fallback path;
+// see QueryDedupShard.
+func (c *Client) QueryDedupShards(ctx context.Context, chunkHashes []xet.ChunkHash, candidates ...xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
+	return c.QueryDedupShardsWithAuthProvider(ctx, nil, chunkHashes, candidates...)
 }
 
 // QueryDedupShards checks multiple chunk hashes against the global
 // deduplication index with a per-call auth provider.
-func (c *Client) QueryDedupShardsWithAuthProvider(ctx context.Context, provider AuthProvider, chunkHashes []xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
+func (c *Client) QueryDedupShardsWithAuthProvider(ctx context.Context, provider AuthProvider, chunkHashes []xet.ChunkHash, candidates ...xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
 	if len(chunkHashes) == 0 {
 		return nil, nil
 	}
@@ -317,7 +375,7 @@ func (c *Client) QueryDedupShardsWithAuthProvider(ctx context.Context, provider 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
-		return c.queryChunksDeduplicationFallback(ctx, provider, chunkHashes)
+		return c.queryChunksDeduplicationFallback(ctx, provider, chunkHashes, candidates)
 	}
 
 	if err := reqError(req, resp); err != nil {
@@ -362,16 +420,18 @@ func (c *Client) QueryDedupShardsWithAuthProvider(ctx context.Context, provider 
 	return results, nil
 }
 
-func (c *Client) queryChunksDeduplicationFallback(ctx context.Context, provider AuthProvider, chunkHashes []xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
+func (c *Client) queryChunksDeduplicationFallback(ctx context.Context, provider AuthProvider, chunkHashes []xet.ChunkHash, candidates []xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
 	results := make(map[xet.ChunkHash]*upload.DeduplicationResult, len(chunkHashes))
 	for _, chunkHash := range chunkHashes {
-		result, err := c.QueryDedupShardWithAuthProvider(ctx, provider, chunkHash)
+		result, err := c.QueryDedupShardWithAuthProvider(ctx, provider, chunkHash, candidates...)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, dedupResult := range result {
-			if _, ok := results[dedupResult.ChunkHash]; ok {
+			// Keep found locations; a hash marked new by one probe's shard
+			// may still be found in a later probe's shard.
+			if existing, ok := results[dedupResult.ChunkHash]; ok && !existing.IsNew {
 				continue
 			}
 			results[dedupResult.ChunkHash] = dedupResult

--- a/client/shard_test.go
+++ b/client/shard_test.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/wzshiming/xet"
 	"github.com/wzshiming/xet/shard"
 )
 
@@ -193,5 +194,193 @@ func TestUploadShardV2HandlesTrailingFrameWithoutNewline(t *testing.T) {
 	}
 	if response.Result != 1 {
 		t.Fatalf("result: got %d want 1", response.Result)
+	}
+}
+
+// buildDedupShardBytes serializes a single-xorb dedup shard whose stored
+// chunk hashes are given verbatim (pre-keyed by the caller when simulating a
+// keyed CAS response).
+func buildDedupShardBytes(t *testing.T, key [32]byte, keyExpiry uint64, xorbHash xet.XorbHash, storedChunks []xet.ChunkHash) []byte {
+	t.Helper()
+
+	s := shard.NewShard()
+	entries := make([]shard.CASChunkSequenceEntry, len(storedChunks))
+	var offset uint32
+	for i, storedChunk := range storedChunks {
+		entries[i] = shard.CASChunkSequenceEntry{
+			ChunkHash:        storedChunk,
+			ByteRangeStart:   offset,
+			UnpackedSegBytes: 100,
+		}
+		offset += 100
+	}
+	s.AddCASBlock(shard.CASBlock{
+		CASHash:        xorbHash,
+		Chunks:         entries,
+		NumBytesInCAS:  offset,
+		NumBytesOnDisk: offset,
+	})
+	s.SetFooter()
+	s.Footer.ChunkHashKey = key
+	if keyExpiry != 0 {
+		s.Footer.ShardKeyExpiry = keyExpiry
+	}
+
+	reader, err := s.Encode(true)
+	if err != nil {
+		t.Fatalf("encode shard: %v", err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read shard: %v", err)
+	}
+	return data
+}
+
+func serveDedupShard(t *testing.T, shardBytes []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ":query") {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/v1/chunks/default/") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(shardBytes)
+	}))
+}
+
+func TestQueryDedupShardKeyedShard(t *testing.T) {
+	var key [32]byte
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	probe := xet.ComputeChunkHash([]byte("chunk-0"))
+	other := xet.ComputeChunkHash([]byte("chunk-1"))
+	missing := xet.ComputeChunkHash([]byte("chunk-2"))
+	unrelated := xet.ComputeChunkHash([]byte("chunk-3"))
+	xorbHash := xet.XorbHash{0xAA}
+
+	shardBytes := buildDedupShardBytes(t, key, 0, xorbHash, []xet.ChunkHash{
+		probe.HMAC(key),
+		other.HMAC(key),
+		unrelated.HMAC(key),
+	})
+	srv := serveDedupShard(t, shardBytes)
+	defer srv.Close()
+
+	c, err := NewClient(WithBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	results, err := c.QueryDedupShard(t.Context(), probe, other, missing)
+	if err != nil {
+		t.Fatalf("QueryDedupShard: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("results: got %d entries want 2 (%v)", len(results), results)
+	}
+	probeResult := results[probe]
+	if probeResult == nil || probeResult.IsNew || probeResult.XorbHash != xorbHash || probeResult.ChunkIndex != 0 {
+		t.Fatalf("probe result: got %+v", probeResult)
+	}
+	otherResult := results[other]
+	if otherResult == nil || otherResult.IsNew || otherResult.XorbHash != xorbHash || otherResult.ChunkIndex != 1 {
+		t.Fatalf("candidate result: got %+v", otherResult)
+	}
+	if _, ok := results[missing]; ok {
+		t.Fatal("missing candidate must not appear in results")
+	}
+}
+
+func TestQueryDedupShardExpiredKeyIgnoresShard(t *testing.T) {
+	key := [32]byte{7}
+	probe := xet.ComputeChunkHash([]byte("chunk-0"))
+	xorbHash := xet.XorbHash{0xAB}
+
+	shardBytes := buildDedupShardBytes(t, key, 1000, xorbHash, []xet.ChunkHash{probe.HMAC(key)})
+	srv := serveDedupShard(t, shardBytes)
+	defer srv.Close()
+
+	c, err := NewClient(WithBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	results, err := c.QueryDedupShard(t.Context(), probe)
+	if err != nil {
+		t.Fatalf("QueryDedupShard: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results: got %d entries want 1", len(results))
+	}
+	if probeResult := results[probe]; probeResult == nil || !probeResult.IsNew {
+		t.Fatalf("probe from expired shard must be treated as new, got %+v", results[probe])
+	}
+}
+
+func TestQueryDedupShardUnkeyedShardIndexesRawHashes(t *testing.T) {
+	probe := xet.ComputeChunkHash([]byte("chunk-0"))
+	other := xet.ComputeChunkHash([]byte("chunk-1"))
+	xorbHash := xet.XorbHash{0xAC}
+
+	shardBytes := buildDedupShardBytes(t, [32]byte{}, 0, xorbHash, []xet.ChunkHash{probe, other})
+	srv := serveDedupShard(t, shardBytes)
+	defer srv.Close()
+
+	c, err := NewClient(WithBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	results, err := c.QueryDedupShard(t.Context(), probe)
+	if err != nil {
+		t.Fatalf("QueryDedupShard: %v", err)
+	}
+	probeResult := results[probe]
+	if probeResult == nil || probeResult.IsNew || probeResult.ChunkIndex != 0 {
+		t.Fatalf("probe result: got %+v", probeResult)
+	}
+	otherResult := results[other]
+	if otherResult == nil || otherResult.IsNew || otherResult.ChunkIndex != 1 {
+		t.Fatalf("unkeyed shard must index all raw hashes, got %+v", otherResult)
+	}
+}
+
+func TestQueryDedupShardsFallbackMatchesKeyedCandidates(t *testing.T) {
+	key := [32]byte{9}
+	probe := xet.ComputeChunkHash([]byte("chunk-0"))
+	candidate := xet.ComputeChunkHash([]byte("chunk-1"))
+	xorbHash := xet.XorbHash{0xAD}
+
+	shardBytes := buildDedupShardBytes(t, key, 0, xorbHash, []xet.ChunkHash{
+		probe.HMAC(key),
+		candidate.HMAC(key),
+	})
+	srv := serveDedupShard(t, shardBytes)
+	defer srv.Close()
+
+	c, err := NewClient(WithBaseURL(srv.URL), WithCacheDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	// The batch :query endpoint 404s, forcing the single-shard fallback that
+	// must carry candidates through to keyed matching.
+	results, err := c.QueryDedupShards(t.Context(), []xet.ChunkHash{probe}, candidate)
+	if err != nil {
+		t.Fatalf("QueryDedupShards: %v", err)
+	}
+	if probeResult := results[probe]; probeResult == nil || probeResult.IsNew {
+		t.Fatalf("probe result: got %+v", results[probe])
+	}
+	candidateResult := results[candidate]
+	if candidateResult == nil || candidateResult.IsNew || candidateResult.XorbHash != xorbHash || candidateResult.ChunkIndex != 1 {
+		t.Fatalf("candidate result: got %+v", candidateResult)
 	}
 }

--- a/client/upload.go
+++ b/client/upload.go
@@ -37,8 +37,8 @@ func (a authProviderUploadAdapter) UploadShard(ctx context.Context, shardObj *sh
 	return a.client.UploadShardWithAuthProvider(ctx, a.provider, shardObj)
 }
 
-func (a authProviderUploadAdapter) QueryDedupShards(ctx context.Context, chunkHashes []xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
-	return a.client.QueryDedupShardsWithAuthProvider(ctx, a.provider, chunkHashes)
+func (a authProviderUploadAdapter) QueryDedupShards(ctx context.Context, chunkHashes []xet.ChunkHash, candidates ...xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
+	return a.client.QueryDedupShardsWithAuthProvider(ctx, a.provider, chunkHashes, candidates...)
 }
 
 // UploadFile uploads a single file through the V1 shard API and returns its hash.

--- a/hash.go
+++ b/hash.go
@@ -154,6 +154,21 @@ func ComputeChunkHash(data []byte) ChunkHash {
 	return result
 }
 
+// HMAC returns the keyed form of the chunk hash: a BLAKE3 keyed hash of the
+// raw hash bytes, matching xet-core's MerkleHash::hmac. CAS servers key the
+// chunk hashes in returned global-dedup shards with a per-shard key.
+func (h ChunkHash) HMAC(key [32]byte) ChunkHash {
+	hasher, err := blake3.NewKeyed(key[:])
+	if err != nil {
+		// Unreachable: NewKeyed only fails for keys that are not 32 bytes.
+		panic("blake3.NewKeyed: " + err.Error())
+	}
+	hasher.Write(h[:])
+	var result ChunkHash
+	hasher.Sum(result[:0])
+	return result
+}
+
 // computeInternalNodeHash computes the hash of an internal node using INTERNAL_NODE_KEY
 func computeInternalNodeHash(data []byte) hash {
 	hasher := internalNodeKeyPool.Get().(*blake3.Hasher)

--- a/hash_test.go
+++ b/hash_test.go
@@ -26,6 +26,26 @@ func TestComputeChunkHash(t *testing.T) {
 	}
 }
 
+func TestChunkHashHMAC(t *testing.T) {
+	h := ComputeChunkHash([]byte("Hello World!"))
+	key1 := [32]byte{1}
+	key2 := [32]byte{2}
+
+	keyed := h.HMAC(key1)
+	if keyed == h {
+		t.Error("keyed hash must differ from the raw hash")
+	}
+	if keyed != h.HMAC(key1) {
+		t.Error("HMAC must be deterministic for the same key and hash")
+	}
+	if keyed == h.HMAC(key2) {
+		t.Error("different keys must produce different keyed hashes")
+	}
+	if keyed == ComputeChunkHash([]byte("other")).HMAC(key1) {
+		t.Error("different hashes must produce different keyed hashes")
+	}
+}
+
 /*
 The XET hash string format interprets the 32-byte hash as four
 little-endian 64-bit unsigned values and prints each as 16

--- a/mirror/localcas.go
+++ b/mirror/localcas.go
@@ -44,7 +44,9 @@ func (l *localCAS) UploadShard(ctx context.Context, shardObj *shard.Shard) (*upl
 	return &upload.ShardUploadResponse{Result: result}, nil
 }
 
-func (l *localCAS) QueryDedupShards(ctx context.Context, chunkHashes []xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
+// Local shards are stored with raw chunk hashes, so keyed-shard candidates
+// are unnecessary here.
+func (l *localCAS) QueryDedupShards(ctx context.Context, chunkHashes []xet.ChunkHash, _ ...xet.ChunkHash) (map[xet.ChunkHash]*upload.DeduplicationResult, error) {
 	results := make(map[xet.ChunkHash]*upload.DeduplicationResult, len(chunkHashes))
 	for _, chunkHash := range chunkHashes {
 		if _, ok := results[chunkHash]; ok {

--- a/shard/shard.go
+++ b/shard/shard.go
@@ -132,6 +132,18 @@ type Footer struct {
 	FooterOffset           uint64
 }
 
+// IsKeyed reports whether the chunk hashes in this shard are HMAC-keyed with
+// ChunkHashKey. An all-zero key means the shard stores raw chunk hashes.
+func (f *Footer) IsKeyed() bool {
+	return f.ChunkHashKey != [32]byte{}
+}
+
+// IsExpired reports whether the shard key expiry has passed at now.
+// SetFooter uses ^uint64(0), which never expires.
+func (f *Footer) IsExpired(now time.Time) bool {
+	return f.ShardKeyExpiry <= uint64(now.Unix())
+}
+
 // Shard magic sequence (bytes 15-31 of the tag)
 var shardMagicSequence = [17]byte{
 	0x55, 0x69, 0x67, 0x45, 0x6a, 0x7b, 0x81, 0x57,

--- a/test/conformance/encoding/encoding_test.go
+++ b/test/conformance/encoding/encoding_test.go
@@ -97,6 +97,56 @@ func TestConformance(t *testing.T) {
 	}
 }
 
+// TestHMACConformance verifies ChunkHash.HMAC matches xet-core's
+// MerkleHash::hmac, which keys the chunk hashes in global-dedup shards.
+func TestHMACConformance(t *testing.T) {
+	var sequential, ones [32]byte
+	for i := range sequential {
+		sequential[i] = byte(i)
+		ones[i] = 0xFF
+	}
+
+	hashes := []xet.ChunkHash{
+		{}, // zero hash
+		xet.ChunkHash(sequential),
+		xet.ChunkHash(ones),
+		xet.ComputeChunkHash([]byte("Hello World!")),
+		xet.ComputeChunkHash(utils.MakeRandData(4096)),
+	}
+	keys := [][32]byte{
+		{}, // zero key: the primitive still computes; only the shard layer treats it as unkeyed
+		sequential,
+		ones,
+		[32]byte(xet.ComputeChunkHash([]byte("per-shard hmac key"))),
+	}
+
+	var cases []rustref.HMACCase
+	var native []string
+	for _, chunkHash := range hashes {
+		for _, key := range keys {
+			cases = append(cases, rustref.HMACCase{
+				Hash: chunkHash.String(),
+				Key:  xet.ChunkHash(key).String(),
+			})
+			native = append(native, chunkHash.HMAC(key).String())
+		}
+	}
+
+	reference, err := rustref.HashHMAC(cases)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reference) != len(cases) {
+		t.Fatalf("result count mismatch: got %d want %d", len(reference), len(cases))
+	}
+	for i := range cases {
+		if native[i] != reference[i] {
+			t.Errorf("hmac mismatch for hash=%s key=%s: native=%s reference=%s",
+				cases[i].Hash, cases[i].Key, native[i], reference[i])
+		}
+	}
+}
+
 func TestXorbConformance(t *testing.T) {
 	tests := []struct {
 		name string

--- a/test/conformance/rustref/reference.go
+++ b/test/conformance/rustref/reference.go
@@ -225,6 +225,20 @@ func hashList(command string, chunks []ChunkInfo) (string, error) {
 	return result, err
 }
 
+// HMACCase pairs a chunk hash with an HMAC key, both in XET hex form.
+type HMACCase struct {
+	Hash string `json:"hash"`
+	Key  string `json:"key"`
+}
+
+// HashHMAC computes keyed chunk hashes via xet-core's MerkleHash::hmac, as
+// applied to chunk hashes in HMAC-keyed global-dedup shards.
+func HashHMAC(cases []HMACCase) ([]string, error) {
+	var result []string
+	err := runJSON("hash-hmac", cases, &result)
+	return result, err
+}
+
 func HashFiles(filePaths []string) ([]UploadResult, error) {
 	var result []UploadResult
 	err := runJSON("hash-files", filePaths, &result)

--- a/test/conformance/src/main.rs
+++ b/test/conformance/src/main.rs
@@ -50,6 +50,12 @@ struct ChunkInfo {
     size: u64,
 }
 
+#[derive(Debug, Deserialize)]
+struct HmacCase {
+    hash: String,
+    key: String,
+}
+
 #[derive(Debug, Serialize)]
 struct UploadResult {
     hash: String,
@@ -77,6 +83,7 @@ fn run() -> Result<()> {
         "hash-xorb" => write_json(&hash_list(HashKind::Xorb)?),
         "hash-file" => write_json(&hash_list(HashKind::File)?),
         "hash-range" => write_json(&hash_list(HashKind::Range)?),
+        "hash-hmac" => write_json(&hash_hmac()?),
         "hash-files" => {
             let paths: Vec<String> = read_json()?;
             let context = XetContext::default()?;
@@ -244,6 +251,19 @@ fn hash_list(kind: HashKind) -> Result<String> {
         }
     };
     Ok(hash.hex())
+}
+
+/// Keyed chunk hashes as used for HMAC-keyed global-dedup shards.
+fn hash_hmac() -> Result<Vec<String>> {
+    let cases: Vec<HmacCase> = read_json()?;
+    cases
+        .into_iter()
+        .map(|case| {
+            let hash = MerkleHash::from_hex(&case.hash)?;
+            let key = MerkleHash::from_hex(&case.key)?;
+            Ok(hash.hmac(key).hex())
+        })
+        .collect()
 }
 
 fn sha256_policies(request: &UploadRequest) -> Result<Vec<Sha256Policy>> {

--- a/upload/adapter.go
+++ b/upload/adapter.go
@@ -13,5 +13,9 @@ type ClientAdapter interface {
 	HasXorb(ctx context.Context, xorbHash xet.XorbHash) (bool, error)
 	UploadXorb(ctx context.Context, xorbHash xet.XorbHash, reader io.ReadSeeker) (*XorbUploadResponse, error)
 	UploadShard(ctx context.Context, shardObj *shard.Shard) (*ShardUploadResponse, error)
-	QueryDedupShards(ctx context.Context, chunkHashes []xet.ChunkHash) (map[xet.ChunkHash]*DeduplicationResult, error)
+	// QueryDedupShards resolves chunkHashes against the global dedup index.
+	// candidates are additional raw chunk hashes to match against returned
+	// shards; they are required to find entries in HMAC-keyed shards, whose
+	// stored hashes cannot be reversed to raw hashes.
+	QueryDedupShards(ctx context.Context, chunkHashes []xet.ChunkHash, candidates ...xet.ChunkHash) (map[xet.ChunkHash]*DeduplicationResult, error)
 }

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -296,8 +296,8 @@ func UploadFiles(ctx context.Context, client ClientAdapter, readSeekers []io.Rea
 	return fileHashes, nil
 }
 
-func queryShards(ctx context.Context, client ClientAdapter, cache map[xet.ChunkHash]*DeduplicationResult, probes []xet.ChunkHash) error {
-	m, err := client.QueryDedupShards(ctx, probes)
+func queryShards(ctx context.Context, client ClientAdapter, cache map[xet.ChunkHash]*DeduplicationResult, probes []xet.ChunkHash, candidates []xet.ChunkHash) error {
+	m, err := client.QueryDedupShards(ctx, probes, candidates...)
 	if err != nil {
 		return fmt.Errorf("query dedup shards: %w", err)
 	}
@@ -321,7 +321,9 @@ func deduplicateChunks(ctx context.Context, client ClientAdapter, chunkHashes []
 
 	cache := make(map[xet.ChunkHash]*DeduplicationResult, len(chunkHashes))
 
-	if err := queryShards(ctx, client, cache, globalDedupProbeChunkHashes); err != nil {
+	// Pass every chunk hash as a keyed-shard candidate so entries in
+	// HMAC-keyed shards can be matched back to raw hashes.
+	if err := queryShards(ctx, client, cache, globalDedupProbeChunkHashes, chunkHashes); err != nil {
 		return nil, fmt.Errorf("query shards: %w", err)
 	}
 


### PR DESCRIPTION
Production CAS returns global-dedup shards whose chunk hashes are HMAC-keyed with the per-shard ChunkHashKey (xet-core `MDBShardInfo::keyed_chunk_hash`). `QueryDedupShard` indexed the stored hashes verbatim, so against a keyed shard every lookup missed and global dedup silently degraded to uploading the full payload. The footer's ShardKeyExpiry was ignored the same way.

`QueryDedupShard(s)` now take variadic candidate hashes: for keyed shards each candidate is HMAC'd with the footer key and matched against the stored entries, expired shards are discarded entirely, and unkeyed shards keep the raw-hash indexing (candidates unnecessary). The upload pipeline passes every file chunk hash as a candidate so keyed entries map back to raw hashes. The single-shard fallback merge also stops letting an early IsNew result shadow a location found by a later probe's shard.

`ChunkHash.HMAC` is a BLAKE3 keyed hash of the raw hash bytes. A new `hash-hmac` subcommand in the conformance reference binary checks it against xet-core's `MerkleHash::hmac` on the pinned rev — TestHMACConformance covers 20 hash/key combinations including zero, sequential, and all-FF patterns. New client tests cover keyed matching, key expiry, unkeyed regression, and candidate pass-through on the batch 404 fallback. go build, go vet, and the unit suites pass; the variadic signatures keep existing callers source-compatible.
