### PR TITLE
perf: merge touching cache entries of one xorb in the background

### DIFF
--- a/download/cache_manager.go
+++ b/download/cache_manager.go
@@ -28,6 +28,11 @@ const reconcileInterval = time.Minute
 // lifts the pause immediately.
 const evictBackoff = time.Second
 
+// mergeDebounce is how long a hash directory must stay quiet after its last
+// merge hint before the background merger compacts it; hints from ranges
+// still being written keep pushing the work back.
+const mergeDebounce = 2 * time.Second
+
 // cacheEntry is the LRU bookkeeping for one published cache file.
 type cacheEntry struct {
 	size int64
@@ -80,6 +85,16 @@ type CacheManager struct {
 	// keyed by final path, so each entry is verified at most once per
 	// manager.
 	verified sync.Map
+
+	// mergeQuiet is the per-hash quiet period before compaction runs.
+	mergeQuiet time.Duration
+
+	// pendingMerge maps a xorb hash to its last merge hint time; drained by
+	// mergeWorker once the hash has been quiet for mergeQuiet.
+	pendingMerge map[string]time.Time
+
+	// mergeRunning reports whether a mergeWorker goroutine is active.
+	mergeRunning bool
 }
 
 // NewCacheManager creates a manager for the chunk cache at cacheDir (empty
@@ -88,9 +103,10 @@ type CacheManager struct {
 // cache directory and pass it to every reader sharing that directory.
 func NewCacheManager(cacheDir string, capacity int64) *CacheManager {
 	m := &CacheManager{
-		dir:      defaultCacheDir(cacheDir),
-		capacity: capacity,
-		lru:      lru.New(0),
+		dir:        defaultCacheDir(cacheDir),
+		capacity:   capacity,
+		lru:        lru.New(0),
+		mergeQuiet: mergeDebounce,
 	}
 	m.lru.OnEvicted = func(key lru.Key, value any) {
 		k, _ := key.(string)
@@ -142,6 +158,89 @@ func (m *CacheManager) release(path string) {
 			}
 		}
 	}
+}
+
+// noteMergeCandidate schedules a background compaction of hash's cache
+// directory once it has been quiet for mergeQuiet.
+func (m *CacheManager) noteMergeCandidate(hash string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(hash) < 2 {
+		return
+	}
+	if m.pendingMerge == nil {
+		m.pendingMerge = make(map[string]time.Time)
+	}
+	m.pendingMerge[hash] = time.Now()
+	if !m.mergeRunning {
+		m.mergeRunning = true
+		go m.mergeWorker()
+	}
+}
+
+// mergeWorker drains pendingMerge, compacting each hash directory after it
+// has been quiet for mergeQuiet, and exits once nothing is pending.
+func (m *CacheManager) mergeWorker() {
+	for {
+		m.mu.Lock()
+		var hash string
+		var oldest time.Time
+		for h, t := range m.pendingMerge {
+			if hash == "" || t.Before(oldest) {
+				hash, oldest = h, t
+			}
+		}
+		if hash == "" {
+			m.mergeRunning = false
+			m.mu.Unlock()
+			return
+		}
+		wait := m.mergeQuiet - time.Since(oldest)
+		if wait <= 0 {
+			delete(m.pendingMerge, hash)
+		}
+		m.mu.Unlock()
+		if wait > 0 {
+			time.Sleep(wait)
+			continue
+		}
+		mergeHashDir(m, hash) //nolint:errcheck
+	}
+}
+
+// forgetIfIdle unlinks the sealed entry at path and drops it from tracking,
+// but only when no in-process user holds a reference; in-use or flocked
+// entries are kept for normal eviction. Returns true when the name is gone.
+func (m *CacheManager) forgetIfIdle(path string) bool {
+	m.mu.Lock()
+	if v, ok := m.lru.Get(path); ok {
+		if e := v.(*cacheEntry); e.refs > 0 {
+			m.mu.Unlock()
+			return false
+		}
+	}
+	m.mu.Unlock()
+	if !removeCacheEntry(path) {
+		return false
+	}
+	m.mu.Lock()
+	if v, ok := m.lru.Get(path); ok {
+		e := v.(*cacheEntry)
+		m.total -= e.size
+		m.lru.Remove(path)
+		// Remove fires OnEvicted; drop the bookkeeping entry it queued so
+		// the next eviction pass does not double-count this file.
+		kept := m.evicted[:0]
+		for _, ev := range m.evicted {
+			if ev.key != path {
+				kept = append(kept, ev)
+			}
+		}
+		m.evicted = kept
+	}
+	m.verified.Delete(path)
+	m.mu.Unlock()
+	return true
 }
 
 // wasVerified reports whether path already passed checksum verification.

--- a/download/cache_merge.go
+++ b/download/cache_merge.go
@@ -1,0 +1,180 @@
+package download
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/wzshiming/xet/internal/flock"
+)
+
+// mergeCandidate is one sealed cache entry considered for compaction.
+type mergeCandidate struct {
+	path       string
+	start, end uint32
+	bytesStart int64
+	bytesEnd   int64
+}
+
+// cachedChunkReader feeds already-cached chunks to a chunkCache writer, one
+// chunk per Read call, matching the decoder contract of load.
+type cachedChunkReader struct {
+	src   *chunkCache
+	idx   uint32
+	count uint32
+}
+
+func (r *cachedChunkReader) Read(p []byte) (int, error) {
+	if r.idx >= r.count {
+		return 0, io.EOF
+	}
+	n, err := r.src.Chunk(r.idx, p)
+	if err != nil {
+		return 0, err
+	}
+	r.idx++
+	return int(n), nil
+}
+
+// mergeHashDir compacts the cache directory of one xorb hash: runs of sealed
+// entries whose chunk ranges touch or overlap are rewritten as one covering
+// entry and the now-redundant sources are unlinked. Best-effort: entries in
+// use, locked elsewhere, or vanishing mid-pass are left to normal eviction.
+func mergeHashDir(m *CacheManager, hash string) error {
+	if len(hash) < 2 {
+		return nil
+	}
+	hashDir := filepath.Join(m.dir, hash[:2], hash[2:])
+	files, err := os.ReadDir(hashDir)
+	if err != nil {
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			return nil
+		}
+		return err
+	}
+
+	var cands []mergeCandidate
+	for _, de := range files {
+		if de.IsDir() || strings.HasPrefix(de.Name(), ".") {
+			continue
+		}
+		cs, ce, bs, be, ok := parseCacheFileName(de.Name())
+		if !ok {
+			continue
+		}
+		info, err := de.Info()
+		if err != nil {
+			continue
+		}
+		path := filepath.Join(hashDir, de.Name())
+		if !isCompleteCacheFile(path, cs, ce, info.Size()) {
+			continue
+		}
+		cands = append(cands, mergeCandidate{path: path, start: cs, end: ce, bytesStart: bs, bytesEnd: be})
+	}
+	if len(cands) < 2 {
+		return nil
+	}
+
+	sort.Slice(cands, func(i, j int) bool {
+		if cands[i].start != cands[j].start {
+			return cands[i].start < cands[j].start
+		}
+		return cands[i].end > cands[j].end
+	})
+
+	// Walk maximal runs of touching or overlapping chunk ranges.
+	var firstErr error
+	for i := 0; i < len(cands); {
+		j := i + 1
+		end := cands[i].end
+		for j < len(cands) && cands[j].start <= end {
+			end = max(end, cands[j].end)
+			j++
+		}
+		if j-i >= 2 {
+			if err := mergeRun(m, hash, cands[i:j], cands[i].start, end); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		i = j
+	}
+	return firstErr
+}
+
+// mergeRun replaces the entries in run with one entry covering
+// [chunkStart, chunkEnd), reusing an existing covering entry when present.
+func mergeRun(m *CacheManager, hash string, run []mergeCandidate, chunkStart, chunkEnd uint32) error {
+	bytesStart := run[0].bytesStart
+	bytesEnd := run[0].bytesEnd
+	covering := ""
+	for _, c := range run {
+		bytesStart = min(bytesStart, c.bytesStart)
+		bytesEnd = max(bytesEnd, c.bytesEnd)
+		if covering == "" && c.start == chunkStart && c.end == chunkEnd {
+			covering = c.path
+		}
+	}
+	if covering == "" {
+		var err error
+		covering, err = writeMergedEntry(m, hash, chunkStart, chunkEnd, bytesStart, bytesEnd)
+		if err != nil || covering == "" {
+			return err
+		}
+	}
+	for _, c := range run {
+		if c.path == covering {
+			continue
+		}
+		m.forgetIfIdle(c.path)
+	}
+	return nil
+}
+
+// writeMergedEntry rewrites the already-cached chunks [chunkStart, chunkEnd)
+// as one sealed entry and returns its path, or "" when the range can no
+// longer be assembled because a source was evicted mid-pass.
+func writeMergedEntry(m *CacheManager, hash string, chunkStart, chunkEnd uint32, bytesStart, bytesEnd int64) (string, error) {
+	lockFile, err := lockChunkCache(m.dir, hash, chunkStart, chunkEnd, bytesStart, bytesEnd)
+	if err != nil {
+		return "", err
+	}
+	path := cacheFilePath(m.dir, hash, chunkStart, chunkEnd, bytesStart, bytesEnd)
+
+	// A contender may have sealed the same merged entry while this one
+	// waited on the lock.
+	if info, statErr := os.Stat(path); statErr == nil && isCompleteCacheFile(path, chunkStart, chunkEnd, info.Size()) {
+		flock.Unlock(lockFile) //nolint:errcheck
+		lockFile.Close()
+		return path, nil
+	}
+
+	source, err := openCachedRange(m, hash, chunkStart, chunkEnd)
+	if err != nil || source == nil {
+		// Discard the placeholder created by lockChunkCache; the held flock
+		// keeps eviction and other writers away during removal.
+		os.Remove(path) //nolint:errcheck
+		removeEmptyCacheDirs(path)
+		flock.Unlock(lockFile) //nolint:errcheck
+		lockFile.Close()
+		return "", err
+	}
+
+	dec := &cachedChunkReader{src: source, count: chunkEnd - chunkStart}
+	merged, err := newLockedChunkCache(dec, m, hash, chunkStart, chunkEnd, bytesStart, bytesEnd, lockFile)
+	if err != nil {
+		source.Done()
+		flock.Unlock(lockFile) //nolint:errcheck
+		lockFile.Close()
+		return "", err
+	}
+	err = merged.LoadAll()
+	merged.Done()
+	source.Done()
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/download/cache_merge_test.go
+++ b/download/cache_merge_test.go
@@ -1,0 +1,369 @@
+package download
+
+import (
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// chunksReader returns one chunk per Read call, matching the decoder
+// contract expected by chunkCache.load.
+type chunksReader struct {
+	chunks []string
+	idx    int
+}
+
+func (r *chunksReader) Read(p []byte) (int, error) {
+	if r.idx >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.chunks[r.idx])
+	r.idx++
+	return n, nil
+}
+
+// writeRangeEntry publishes one sealed multi-chunk entry and returns its path.
+func writeRangeEntry(t *testing.T, m *CacheManager, hash string, cs, ce uint32, bs, be int64, chunks []string) string {
+	t.Helper()
+	if int(ce-cs) != len(chunks) {
+		t.Fatalf("chunk count %d does not match range [%d,%d)", len(chunks), cs, ce)
+	}
+	cache, err := newChunkCache(&chunksReader{chunks: chunks}, m, hash, cs, ce, bs, be)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cache.readonly {
+		cache.Done()
+		t.Fatalf("range [%d,%d) was already cached", cs, ce)
+	}
+	if err := cache.LoadAll(); err != nil {
+		t.Fatal(err)
+	}
+	cache.Done()
+	return cacheFilePath(m.dir, hash, cs, ce, bs, be)
+}
+
+// listEntryNames returns the names of all files in hash's cache directory.
+func listEntryNames(t *testing.T, dir, hash string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(dir, hash[:2], hash[2:]))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, de := range entries {
+		names = append(names, de.Name())
+	}
+	return names
+}
+
+// verifyChunks opens [0, len(want)) with a fresh manager and checks contents.
+func verifyChunks(t *testing.T, dir, hash string, want []string) {
+	t.Helper()
+	cached, err := openCachedRange(NewCacheManager(dir, 0), hash, 0, uint32(len(want)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached == nil {
+		t.Fatal("merged range was not found in cache")
+	}
+	defer cached.Done()
+	if len(cached.files) != 0 {
+		t.Fatalf("range served from %d files, want a single file", len(cached.files)+1)
+	}
+	buf := make([]byte, 64)
+	for i, w := range want {
+		n, err := cached.Chunk(uint32(i), buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := string(buf[:n]); got != w {
+			t.Fatalf("chunk %d: got %q, want %q", i, got, w)
+		}
+	}
+}
+
+func TestMergeAdjacentEntries(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	// Park the background merger so manual passes stay deterministic.
+	m.mergeQuiet = time.Hour
+
+	writeRangeEntry(t, m, testCacheHash, 0, 2, 0, 100, []string{"aaa", "bbb"})
+	writeRangeEntry(t, m, testCacheHash, 2, 4, 100, 200, []string{"ccc", "ddd"})
+
+	if err := mergeHashDir(m, testCacheHash); err != nil {
+		t.Fatal(err)
+	}
+
+	names := listEntryNames(t, dir, testCacheHash)
+	if len(names) != 1 || names[0] != cacheFileName(0, 4, 0, 200) {
+		t.Fatalf("got entries %v, want single %q", names, cacheFileName(0, 4, 0, 200))
+	}
+	verifyChunks(t, dir, testCacheHash, []string{"aaa", "bbb", "ccc", "ddd"})
+
+	info, err := os.Stat(cacheFilePath(dir, testCacheHash, 0, 4, 0, 200))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := trackedTotal(m); got != info.Size() {
+		t.Fatalf("tracked total %d, want merged file size %d", got, info.Size())
+	}
+}
+
+func TestMergeOverlappingEntries(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	m.mergeQuiet = time.Hour
+
+	writeRangeEntry(t, m, testCacheHash, 0, 3, 0, 150, []string{"c0", "c1", "c2"})
+	writeRangeEntry(t, m, testCacheHash, 2, 5, 100, 250, []string{"c2", "c3", "c4"})
+
+	if err := mergeHashDir(m, testCacheHash); err != nil {
+		t.Fatal(err)
+	}
+
+	names := listEntryNames(t, dir, testCacheHash)
+	if len(names) != 1 || names[0] != cacheFileName(0, 5, 0, 250) {
+		t.Fatalf("got entries %v, want single %q", names, cacheFileName(0, 5, 0, 250))
+	}
+	verifyChunks(t, dir, testCacheHash, []string{"c0", "c1", "c2", "c3", "c4"})
+}
+
+func TestMergeRemovesRedundantSubset(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	m.mergeQuiet = time.Hour
+
+	// The subset must be written first; a covering entry would satisfy it.
+	writeRangeEntry(t, m, testCacheHash, 2, 4, 100, 200, []string{"c2", "c3"})
+	covering := writeRangeEntry(t, m, testCacheHash, 0, 6, 0, 300, []string{"c0", "c1", "c2", "c3", "c4", "c5"})
+
+	if err := mergeHashDir(m, testCacheHash); err != nil {
+		t.Fatal(err)
+	}
+
+	names := listEntryNames(t, dir, testCacheHash)
+	if len(names) != 1 || names[0] != filepath.Base(covering) {
+		t.Fatalf("got entries %v, want only the covering entry %q", names, filepath.Base(covering))
+	}
+	verifyChunks(t, dir, testCacheHash, []string{"c0", "c1", "c2", "c3", "c4", "c5"})
+
+	info, err := os.Stat(covering)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := trackedTotal(m); got != info.Size() {
+		t.Fatalf("tracked total %d, want covering file size %d", got, info.Size())
+	}
+}
+
+func TestMergeKeepsInUseSource(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	m.mergeQuiet = time.Hour
+
+	first := writeRangeEntry(t, m, testCacheHash, 0, 2, 0, 100, []string{"aaa", "bbb"})
+	writeRangeEntry(t, m, testCacheHash, 2, 4, 100, 200, []string{"ccc", "ddd"})
+
+	pinned, err := openCachedRange(m, testCacheHash, 0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pinned == nil {
+		t.Fatal("first entry was not found in cache")
+	}
+
+	if err := mergeHashDir(m, testCacheHash); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(first); err != nil {
+		t.Fatalf("in-use source was removed: %v", err)
+	}
+	if _, err := os.Stat(cacheFilePath(dir, testCacheHash, 0, 4, 0, 200)); err != nil {
+		t.Fatalf("merged entry was not written: %v", err)
+	}
+	buf := make([]byte, 64)
+	n, err := pinned.Chunk(0, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf[:n]); got != "aaa" {
+		t.Fatalf("pinned reader got %q, want %q", got, "aaa")
+	}
+	pinned.Done()
+
+	// With the reference gone, the next pass removes the now-redundant source.
+	if err := mergeHashDir(m, testCacheHash); err != nil {
+		t.Fatal(err)
+	}
+	names := listEntryNames(t, dir, testCacheHash)
+	if len(names) != 1 || names[0] != cacheFileName(0, 4, 0, 200) {
+		t.Fatalf("got entries %v, want single %q", names, cacheFileName(0, 4, 0, 200))
+	}
+	verifyChunks(t, dir, testCacheHash, []string{"aaa", "bbb", "ccc", "ddd"})
+}
+
+func TestMergeIgnoresIncompleteNeighbor(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	m.mergeQuiet = time.Hour
+
+	sealed := writeRangeEntry(t, m, testCacheHash, 0, 2, 0, 100, []string{"aaa", "bbb"})
+	incomplete := cacheFilePath(dir, testCacheHash, 2, 4, 100, 200)
+	if err := os.WriteFile(incomplete, []byte("garbage"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeHashDir(m, testCacheHash); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(sealed); err != nil {
+		t.Fatalf("sealed entry was disturbed: %v", err)
+	}
+	if _, err := os.Stat(incomplete); err != nil {
+		t.Fatalf("incomplete entry was disturbed: %v", err)
+	}
+	if names := listEntryNames(t, dir, testCacheHash); len(names) != 2 {
+		t.Fatalf("got entries %v, want the two originals", names)
+	}
+}
+
+func TestMergeRecoversFromCrashedMerge(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	m.mergeQuiet = time.Hour
+
+	writeRangeEntry(t, m, testCacheHash, 0, 2, 0, 100, []string{"aaa", "bbb"})
+	writeRangeEntry(t, m, testCacheHash, 2, 4, 100, 200, []string{"ccc", "ddd"})
+
+	// A merge that died mid-write: placeholder header plus partial data,
+	// never sealed, flock released with the process.
+	crashed := cacheFilePath(dir, testCacheHash, 0, 4, 0, 200)
+	leftover := make([]byte, 4+4*5+7)
+	binary.LittleEndian.PutUint32(leftover, 5)
+	copy(leftover[24:], "aaabbbc")
+	if err := os.WriteFile(crashed, leftover, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restart: a fresh manager still serves the range from the sources.
+	restarted := NewCacheManager(dir, 0)
+	restarted.mergeQuiet = time.Hour
+	cached, err := openCachedRange(restarted, testCacheHash, 0, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached == nil {
+		t.Fatal("sources no longer serve the range after crashed merge")
+	}
+	cached.Done()
+
+	// The first prepare after restart sweeps the crashed leftover.
+	restarted.prepare()
+	if _, err := os.Stat(crashed); !os.IsNotExist(err) {
+		t.Fatalf("crashed merge leftover was not cleaned up: %v", err)
+	}
+	if names := listEntryNames(t, dir, testCacheHash); len(names) != 2 {
+		t.Fatalf("got entries %v, want the two intact sources", names)
+	}
+
+	// The next pass completes the interrupted merge.
+	if err := mergeHashDir(restarted, testCacheHash); err != nil {
+		t.Fatal(err)
+	}
+	names := listEntryNames(t, dir, testCacheHash)
+	if len(names) != 1 || names[0] != cacheFileName(0, 4, 0, 200) {
+		t.Fatalf("got entries %v, want single %q", names, cacheFileName(0, 4, 0, 200))
+	}
+	verifyChunks(t, dir, testCacheHash, []string{"aaa", "bbb", "ccc", "ddd"})
+}
+
+func TestMergeWorkerCompactsAfterQuietPeriod(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	m.mergeQuiet = 10 * time.Millisecond
+
+	// Publishing hints the merger; no manual mergeHashDir call.
+	writeRangeEntry(t, m, testCacheHash, 0, 2, 0, 100, []string{"aaa", "bbb"})
+	writeRangeEntry(t, m, testCacheHash, 2, 4, 100, 200, []string{"ccc", "ddd"})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		names := listEntryNames(t, dir, testCacheHash)
+		if len(names) == 1 && names[0] == cacheFileName(0, 4, 0, 200) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("worker did not compact entries, still have %v", names)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	verifyChunks(t, dir, testCacheHash, []string{"aaa", "bbb", "ccc", "ddd"})
+}
+
+func TestMergeConcurrentReaders(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheManager(dir, 0)
+	m.mergeQuiet = time.Hour
+
+	want := []string{"aaa", "bbb", "ccc", "ddd"}
+	writeRangeEntry(t, m, testCacheHash, 0, 2, 0, 100, want[:2])
+	writeRangeEntry(t, m, testCacheHash, 2, 4, 100, 200, want[2:])
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, 64)
+			for range 25 {
+				cached, err := openCachedRange(m, testCacheHash, 0, 4)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				if cached == nil {
+					// Transient miss while sources are being unlinked.
+					continue
+				}
+				for i, w := range want {
+					n, err := cached.Chunk(uint32(i), buf)
+					if err != nil {
+						t.Error(err)
+						break
+					}
+					if got := string(buf[:n]); got != w {
+						t.Errorf("chunk %d: got %q, want %q", i, got, w)
+						break
+					}
+				}
+				cached.Done()
+			}
+		}()
+	}
+	if err := mergeHashDir(m, testCacheHash); err != nil {
+		t.Error(err)
+	}
+	wg.Wait()
+
+	// Readers may have pinned sources during the first pass; a final pass
+	// leaves only the merged entry.
+	if err := mergeHashDir(m, testCacheHash); err != nil {
+		t.Fatal(err)
+	}
+	names := listEntryNames(t, dir, testCacheHash)
+	if len(names) != 1 || names[0] != cacheFileName(0, 4, 0, 200) {
+		t.Fatalf("got entries %v, want single %q", names, cacheFileName(0, 4, 0, 200))
+	}
+	verifyChunks(t, dir, testCacheHash, want)
+}

--- a/download/chunk_cache.go
+++ b/download/chunk_cache.go
@@ -94,6 +94,7 @@ type chunkCache struct {
 	files          []*os.File // additional files for multi-file read path (fileIdx > 0)
 	lockFile       *os.File   // same handle as file while the write lock is held
 	path           string     // entry file path
+	hash           string     // xorb hash, set for writers to hint the merger
 	expectedChunks uint32
 	crc            uint32 // incremental crc32 of the data region while writing
 	published      bool
@@ -245,6 +246,7 @@ func newLockedChunkCache(dec io.Reader, m *CacheManager, hash string, chunkStart
 		writePos:       int64(headerSize), // data starts after the header
 		lockFile:       lockFile,
 		path:           r.path(),
+		hash:           hash,
 		expectedChunks: numChunks,
 		manager:        m,
 	}, nil
@@ -405,6 +407,10 @@ func openCachedRange(m *CacheManager, hash string, chunkStart, chunkEnd uint32) 
 	extraFiles := make([]*os.File, len(segments)-1)
 	for i := 1; i < len(segments); i++ {
 		extraFiles[i-1] = segments[i].file
+	}
+	if len(segments) > 1 {
+		// Several files served one range; schedule their compaction.
+		m.noteMergeCandidate(hash)
 	}
 	return &chunkCache{
 		metas:    allMetas,
@@ -693,6 +699,7 @@ func (c *chunkCache) finalize() error {
 	if c.manager != nil {
 		// Evict any overage now that the cache grew.
 		c.manager.evaluate()
+		c.manager.noteMergeCandidate(c.hash)
 	}
 	return nil
 }

--- a/test/e2e/client_cache_verify_test.go
+++ b/test/e2e/client_cache_verify_test.go
@@ -1,0 +1,156 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/client"
+	"github.com/wzshiming/xet/server"
+	"github.com/wzshiming/xet/storage"
+)
+
+// TestClientCacheEndToEnd verifies the client disk cache end to end:
+// correctness, warm-download cache hits, and background compaction of
+// overlapping same-xorb entries created by dedup'd downloads.
+func TestClientCacheEndToEnd(t *testing.T) {
+	uploadStorage, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var xorbGets atomic.Int64
+	handler := server.NewHandler(server.WithStorage(uploadStorage))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/xorbs/") {
+			xorbGets.Add(1)
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	cacheDir := t.TempDir()
+	c1, err := client.NewClient(client.WithBaseURL(srv.URL), client.WithCacheDir(cacheDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// file2 shares file1's prefix so chunk boundaries align from byte 0 and
+	// its upload dedups against file1's xorb; downloading file2 then file1
+	// caches overlapping ranges of that xorb.
+	file1 := deterministicData(10 * 1024 * 1024)
+	file2 := append(append([]byte{}, file1[:5*1024*1024]...), bytes.Repeat([]byte{0xC7}, 3*1024*1024)...)
+
+	ctx := context.Background()
+	hash1, err := c1.UploadFile(ctx, bytes.NewReader(file1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash2, err := c1.UploadFile(ctx, bytes.NewReader(file2))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	download := func(t *testing.T, c *client.Client, hash xet.FileHash, want []byte) {
+		t.Helper()
+		f, err := os.CreateTemp(t.TempDir(), "out")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		if err := c.DownloadFile(ctx, hash, f); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("downloaded %d bytes, mismatch with original %d bytes", len(got), len(want))
+		}
+	}
+
+	// Cold downloads: file2 first caches a sub-range of the shared xorb,
+	// file1 then caches the covering range.
+	download(t, c1, hash2, file2)
+	download(t, c1, hash1, file1)
+	coldGets := xorbGets.Load()
+	if coldGets == 0 {
+		t.Fatal("cold downloads issued no xorb fetches")
+	}
+
+	multiObserved := countMultiEntryXorbDirs(t, cacheDir)
+	t.Logf("cold xorb GETs: %d, xorb dirs with multiple entries before merge: %d", coldGets, multiObserved)
+	if multiObserved == 0 {
+		t.Fatal("dedup downloads did not produce overlapping entries of one xorb")
+	}
+
+	// Warm downloads on the same client must be fully cache-served.
+	download(t, c1, hash1, file1)
+	download(t, c1, hash2, file2)
+	if got := xorbGets.Load(); got != coldGets {
+		t.Fatalf("warm downloads issued %d extra xorb fetches", got-coldGets)
+	}
+
+	// Background merge (2s quiet period) compacts each xorb to one entry.
+	deadline := time.Now().Add(15 * time.Second)
+	for countMultiEntryXorbDirs(t, cacheDir) > 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("cache entries were not merged within the deadline")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Log("overlapping entries were merged to one entry per xorb")
+
+	// A fresh client on the same directory re-verifies checksums and must
+	// serve both files from the merged entries without any fetch.
+	c2, err := client.NewClient(client.WithBaseURL(srv.URL), client.WithCacheDir(cacheDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	download(t, c2, hash1, file1)
+	download(t, c2, hash2, file2)
+	if got := xorbGets.Load(); got != coldGets {
+		t.Fatalf("fresh client issued %d xorb fetches, want all cache hits", got-coldGets)
+	}
+}
+
+// countMultiEntryXorbDirs counts xorb hash directories holding more than one
+// cache entry file.
+func countMultiEntryXorbDirs(t *testing.T, cacheDir string) int {
+	t.Helper()
+	count := 0
+	prefixes, err := os.ReadDir(cacheDir)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range prefixes {
+		if !p.IsDir() {
+			continue
+		}
+		hashDirs, err := os.ReadDir(filepath.Join(cacheDir, p.Name()))
+		if err != nil {
+			continue
+		}
+		for _, hd := range hashDirs {
+			entries, err := os.ReadDir(filepath.Join(cacheDir, p.Name(), hd.Name()))
+			if err != nil {
+				continue
+			}
+			if len(entries) > 1 {
+				count++
+			}
+		}
+	}
+	return count
+}


### PR DESCRIPTION
Ranges of one xorb fetched at different times seal separate cache entries: a dedup'd file pulls a sub-range that a later download of the full file widens, or adjacent terms land as neighboring files. openCachedRange already assembles touching entries into one hit, but every spanning read then opens one handle per fragment and verifies each file separately, and eviction treats the fragments independently, so dropping a middle piece turns later spanning reads into misses that refetch bytes already on disk.

finalize and the multi-file read path now hint a per-manager merger that compacts a hash directory once it has been quiet for two seconds. Runs of touching or overlapping sealed entries are rewritten as one covering entry through the existing locked write path, entries fully covered by another are unlinked, and sources are only removed after the merged file seals, so complete files are still never rewritten. Entries pinned by readers or flocked by another process are kept and left to normal eviction; a merge that dies mid-write leaves an incomplete file that readers never adopt and the next reconcile sweeps.

New tests cover adjacent and overlapping merges, subset cleanup, pinned sources, crashed-merge recovery, and concurrent readers; an e2e test uploads two files sharing a 5 MiB prefix so dedup caches overlapping ranges of one xorb, then asserts downloads stay fully cache-served before and after compaction. go vet and go test -race over download, client, and test/e2e pass, as does the conformance client suite.