### PR TITLE
feat: expose an Ingest API on the mirror Handler

### DIFF
--- a/mirror/branch.go
+++ b/mirror/branch.go
@@ -48,7 +48,7 @@ func (h *Handler) branchStale(b *branchEntry) bool {
 // ingest task can reuse it instead of probing again.
 type branchProbe struct {
 	b   *branchEntry
-	key string
+	key resolveKey
 	pr  *probeResult
 }
 
@@ -59,8 +59,8 @@ type branchProbe struct {
 // probe failures fall back to the last known commit so cached content stays
 // served while the upstream is unreachable. The returned probe result is
 // non-nil when this call probed the upstream for exactly this key.
-func (h *Handler) branchCommit(key string, m []string) (string, *probeResult, bool) {
-	name := m[1] + "\x00" + m[2]
+func (h *Handler) branchCommit(key resolveKey) (string, *probeResult, bool) {
+	name := key.repo + "\x00" + key.rev
 	h.mu.Lock()
 	b := h.branches[name]
 	h.mu.Unlock()
@@ -77,11 +77,11 @@ func (h *Handler) branchCommit(key string, m []string) (string, *probeResult, bo
 		}
 		// Background context: the probe result is shared by every request of
 		// the repo branch, so one disconnecting client must not fail it.
-		pr, err := h.probe(context.Background(), key)
+		pr, err := h.probe(context.Background(), key.String())
 		if err != nil {
 			return &branchProbe{b: b}, nil // unreachable upstream: serve the last known commit
 		}
-		nb := &branchEntry{Repo: m[1], Rev: m[2], CheckedAt: time.Now()}
+		nb := &branchEntry{Repo: key.repo, Rev: key.rev, CheckedAt: time.Now()}
 		if pr.realCommit && commitRevRe.MatchString(pr.commit) {
 			nb.Commit = pr.commit
 		}

--- a/mirror/index.go
+++ b/mirror/index.go
@@ -87,8 +87,8 @@ func readEntry(path string) *fileEntry {
 // loadIndex reads all persisted entries from dir: entries grouped under
 // per-commit directories plus legacy flat files, which are moved under their
 // commit directory as they are seen.
-func loadIndex(dir string) (map[string]*fileEntry, error) {
-	files := make(map[string]*fileEntry)
+func loadIndex(dir string) (map[resolveKey]*fileEntry, error) {
+	files := make(map[resolveKey]*fileEntry)
 	dirEntries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -111,7 +111,9 @@ func loadIndex(dir string) (map[string]*fileEntry, error) {
 					continue
 				}
 				if e := readEntry(filepath.Join(dir, de.Name(), se.Name())); e != nil {
-					files[e.Key] = e
+					if k, ok := parseResolveKey(e.Key); ok {
+						files[k] = e
+					}
 				}
 			}
 			continue
@@ -124,7 +126,9 @@ func loadIndex(dir string) (map[string]*fileEntry, error) {
 		if e == nil {
 			continue
 		}
-		files[e.Key] = e
+		if k, ok := parseResolveKey(e.Key); ok {
+			files[k] = e
+		}
 		// Legacy flat entry: move it under its commit directory.
 		if indexEntryPath(dir, e.Commit, e.Key) != path && persistEntry(dir, e) == nil {
 			_ = os.Remove(path)

--- a/mirror/ingest.go
+++ b/mirror/ingest.go
@@ -1,0 +1,128 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Entry describes a fully ingested file, exporting what the index persists.
+type Entry struct {
+	// SHA256 is the hex digest of the file bytes, also the key of the plain
+	// download bridge (/xet-bridge/{sha256}).
+	SHA256 string
+	// FileHash is the xet file hash in local storage; empty for empty files.
+	FileHash string
+	// Size is the file length in bytes.
+	Size int64
+	// ETag is the upstream entity tag the cached bytes were validated against.
+	ETag string
+	// Commit is the upstream revision the file was resolved at.
+	Commit string
+}
+
+// exportEntry copies the persisted fields of a ready entry into the exported
+// form.
+func exportEntry(e *fileEntry) *Entry {
+	return &Entry{
+		SHA256:   e.SHA256,
+		FileHash: e.FileHash,
+		Size:     e.Size,
+		ETag:     e.ETag,
+		Commit:   e.Commit,
+	}
+}
+
+// entryErr maps a failed entry to the error Ingest reports; not-found
+// failures match ErrUpstreamNotFound.
+func entryErr(e *fileEntry) error {
+	if e.lastErr != nil {
+		return e.lastErr
+	}
+	if e.notFound {
+		return ErrUpstreamNotFound
+	}
+	return errors.New("upstream fetch failed")
+}
+
+// Ingestion is a started or joined ingest. Wait on Done, then read Entry;
+// abandoning an Ingestion never cancels the ingest itself, the same contract
+// as a client disconnect on the HTTP path.
+type Ingestion struct {
+	done  chan struct{}
+	entry *Entry // set before done closes
+	err   error  // set before done closes
+}
+
+// Done is closed once the ingest finished: the entry is ready or failed.
+func (in *Ingestion) Done() <-chan struct{} { return in.done }
+
+// Entry reports the outcome: the ready entry, or the ingest failure with
+// not-found matching ErrUpstreamNotFound. Before Done is closed it returns
+// nil, nil.
+func (in *Ingestion) Entry() (*Entry, error) {
+	select {
+	case <-in.done:
+		return in.entry, in.err
+	default:
+		return nil, nil
+	}
+}
+
+// Ingest starts ingesting the file at /{repo}/resolve/{rev}/{path} into local
+// storage — bytes fetched, xorbs and shards landed, index entry persisted —
+// or joins the in-flight ingest, and returns immediately: wait on Done, then
+// read Entry. The components must be given in the escaped URL path form
+// ServeHTTP sees, so Ingest and the HTTP path share tasks, entries, and
+// spools.
+//
+// The whole resolution (branch pinning, upstream probes, task wait) runs off
+// the calling goroutine, deduplicated per key: concurrent Ingests of one file
+// share a single flight. Ready entries resolve quickly (revalidated on the
+// usual cadence), as do failed ingests still inside their retry backoff.
+func (h *Handler) Ingest(repo, rev, path string) (*Ingestion, error) {
+	if repo == "" || rev == "" || path == "" || strings.Contains(rev, "/") {
+		return nil, fmt.Errorf("mirror: invalid resolve components repo=%q rev=%q path=%q", repo, rev, path)
+	}
+	key := resolveKey{repo: repo, rev: rev, path: path}
+
+	in := &Ingestion{done: make(chan struct{})}
+	ch := h.flight.DoChan("ingest\x00"+key.String(), func() (any, error) {
+		return h.ingest(key)
+	})
+	go func() {
+		res := <-ch
+		if e, ok := res.Val.(*Entry); ok {
+			in.entry = e
+		}
+		in.err = res.Err
+		close(in.done)
+	}()
+	return in, nil
+}
+
+// ingest resolves one Ingest flight through the shared acquire flow and
+// blocks until the entry is ready or failed.
+func (h *Handler) ingest(key resolveKey) (*Entry, error) {
+	key, t, e, err := h.acquire(context.Background(), key)
+	if err != nil {
+		return nil, err
+	}
+	if t != nil {
+		<-t.done
+		h.mu.Lock()
+		e = h.entries[key]
+		h.mu.Unlock()
+		if e == nil {
+			// Only possible when a concurrent revalidation found the fresh
+			// entry already stale; the same window the HTTP path answers
+			// with 404.
+			return nil, fmt.Errorf("mirror: %q changed upstream during ingest", key)
+		}
+	}
+	if e.State == stateReady {
+		return exportEntry(e), nil
+	}
+	return nil, entryErr(e)
+}

--- a/mirror/ingest_test.go
+++ b/mirror/ingest_test.go
@@ -1,0 +1,171 @@
+package mirror
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIngest(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	data := make([]byte, 128*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	const resolvePath = "/org/repo/resolve/main/model.bin"
+	upstream.set(resolvePath, data)
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+
+	t.Run("rejects invalid components", func(t *testing.T) {
+		if _, err := fx.handler.Ingest("org/repo", "main/extra", "model.bin"); err == nil {
+			t.Fatal("expected an error for a rev containing a slash")
+		}
+		if _, err := fx.handler.Ingest("org/repo", "main", ""); err == nil {
+			t.Fatal("expected an error for an empty path")
+		}
+	})
+
+	t.Run("resolves once done", func(t *testing.T) {
+		in, err := fx.handler.Ingest("org/repo", "main", "model.bin")
+		if err != nil {
+			t.Fatalf("Ingest: %v", err)
+		}
+		<-in.Done()
+		entry, err := in.Entry()
+		if err != nil {
+			t.Fatalf("Entry: %v", err)
+		}
+		sum := sha256.Sum256(data)
+		if entry.SHA256 != hex.EncodeToString(sum[:]) {
+			t.Fatalf("SHA256 = %q, want %q", entry.SHA256, hex.EncodeToString(sum[:]))
+		}
+		if entry.Size != int64(len(data)) {
+			t.Fatalf("Size = %d, want %d", entry.Size, len(data))
+		}
+		if entry.FileHash == "" {
+			t.Fatal("FileHash is empty")
+		}
+		if entry.Commit != "commit-1" {
+			t.Fatalf("Commit = %q, want %q", entry.Commit, "commit-1")
+		}
+		if entry.ETag == "" {
+			t.Fatal("ETag is empty")
+		}
+
+		// Readiness must hold the moment Done closes: the resolve answers
+		// with the ready-state redirect and the xet path serves the bytes.
+		resp, err := noRedirect().Get(fx.srv.URL + resolvePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 302 {
+			t.Fatalf("resolve status = %d, want 302 immediately after Done", resp.StatusCode)
+		}
+		if got := downloadViaXet(t, fx.srv.URL+resolvePath); !bytes.Equal(got, data) {
+			t.Fatalf("xet download mismatch: got %d bytes, want %d", len(got), len(data))
+		}
+	})
+
+	t.Run("ready entry resolves without new downloads", func(t *testing.T) {
+		before := upstream.dataGETs.Load()
+		in, err := fx.handler.Ingest("org/repo", "main", "model.bin")
+		if err != nil {
+			t.Fatalf("Ingest: %v", err)
+		}
+		<-in.Done()
+		entry, err := in.Entry()
+		if err != nil {
+			t.Fatalf("Entry: %v", err)
+		}
+		if entry.Size != int64(len(data)) {
+			t.Fatalf("Size = %d, want %d", entry.Size, len(data))
+		}
+		if got := upstream.dataGETs.Load(); got != before {
+			t.Fatalf("upstream GETs went %d -> %d, want no new downloads", before, got)
+		}
+	})
+
+	t.Run("not found matches ErrUpstreamNotFound", func(t *testing.T) {
+		in, err := fx.handler.Ingest("org/repo", "main", "missing.bin")
+		if err != nil {
+			t.Fatalf("Ingest: %v", err)
+		}
+		<-in.Done()
+		if _, err := in.Entry(); !errors.Is(err, ErrUpstreamNotFound) {
+			t.Fatalf("err = %v, want ErrUpstreamNotFound", err)
+		}
+		// The failure is cached with backoff and resolves without re-probing.
+		in, err = fx.handler.Ingest("org/repo", "main", "missing.bin")
+		if err != nil {
+			t.Fatalf("Ingest: %v", err)
+		}
+		<-in.Done()
+		if _, err := in.Entry(); !errors.Is(err, ErrUpstreamNotFound) {
+			t.Fatalf("cached err = %v, want ErrUpstreamNotFound", err)
+		}
+	})
+}
+
+// TestIngestInFlight verifies Ingest returns while the download runs, a
+// second Ingest joins the same task, and abandoning an Ingestion never
+// cancels the ingest.
+func TestIngestInFlight(t *testing.T) {
+	upstream := newPlainUpstream()
+	upstream.gate = make(chan struct{})
+	upstream.gateHit = make(chan struct{})
+	upstreamSrv := httptest.NewServer(upstream)
+	defer upstreamSrv.Close()
+
+	data := make([]byte, 128*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	const resolvePath = "/org/repo/resolve/main/model.bin"
+	upstream.set(resolvePath, data)
+
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir())
+
+	in, err := fx.handler.Ingest("org/repo", "main", "model.bin")
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	<-upstream.gateHit // Ingest already returned while the transfer is held open
+	select {
+	case <-in.Done():
+		t.Fatal("Done closed while the upstream transfer is still gated")
+	default:
+	}
+	if e, err := in.Entry(); e != nil || err != nil {
+		t.Fatalf("Entry before Done = %v, %v; want nil, nil", e, err)
+	}
+
+	joined, err := fx.handler.Ingest("org/repo", "main", "model.bin")
+	if err != nil {
+		t.Fatalf("joining Ingest: %v", err)
+	}
+	// The first handle is abandoned from here on; the ingest must not care.
+
+	close(upstream.gate) // let the transfer finish
+	<-joined.Done()
+	entry, err := joined.Entry()
+	if err != nil {
+		t.Fatalf("Entry: %v", err)
+	}
+	sum := sha256.Sum256(data)
+	if entry.SHA256 != hex.EncodeToString(sum[:]) {
+		t.Fatalf("SHA256 = %q, want %q", entry.SHA256, hex.EncodeToString(sum[:]))
+	}
+	if got := upstream.dataGETs.Load(); got != 1 {
+		t.Fatalf("upstream GETs = %d, want 1 (joins must share one download)", got)
+	}
+}

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -62,11 +62,37 @@ const (
 )
 
 var (
-	errUpstreamNotFound = errors.New("upstream file not found")
+	// ErrUpstreamNotFound reports that the upstream hub has no file at the
+	// requested key. Errors returned by Ingest match it with errors.Is.
+	ErrUpstreamNotFound = errors.New("upstream file not found")
 	// errSpoolCorrupt marks spooled bytes that failed verification; the spool
 	// must be discarded rather than kept for resume.
 	errSpoolCorrupt = errors.New("spool corrupt")
 )
+
+// resolveKey identifies one (repo, rev, path) file and keys the in-memory
+// entry and task maps. Fields hold escaped URL path segments exactly as they
+// appear in the hub-style resolve path.
+type resolveKey struct {
+	repo string
+	rev  string
+	path string
+}
+
+// parseResolveKey splits a hub-style download path into its key.
+func parseResolveKey(p string) (resolveKey, bool) {
+	m := resolveRe.FindStringSubmatch(p)
+	if m == nil {
+		return resolveKey{}, false
+	}
+	return resolveKey{repo: m[1], rev: m[2], path: m[3]}, true
+}
+
+// String renders the hub-style resolve path, the form used for upstream
+// URLs, spool names, and the persisted index.
+func (k resolveKey) String() string {
+	return "/" + k.repo + "/resolve/" + k.rev + "/" + k.path
+}
 
 // Handler is the mirror HTTP front end: resolve requests are served from the
 // local cache (ingesting on miss) and the token endpoint hands downstream
@@ -95,9 +121,9 @@ type Handler struct {
 
 	mu       sync.Mutex
 	flight   singleflight.Group
-	entries  map[string]*fileEntry
+	entries  map[resolveKey]*fileEntry
 	branches map[string]*branchEntry
-	tasks    map[string]*task
+	tasks    map[resolveKey]*task
 }
 
 // Option configures the Handler.
@@ -165,8 +191,8 @@ func NewHandler(opts ...Option) (*Handler, error) {
 	h := &Handler{
 		cacheDir:           "./xet-mirror",
 		revalidateInterval: 5 * time.Minute,
-		entries:            map[string]*fileEntry{},
-		tasks:              map[string]*task{},
+		entries:            map[resolveKey]*fileEntry{},
+		tasks:              map[resolveKey]*task{},
 	}
 	for _, opt := range opts {
 		opt(h)

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -1180,7 +1180,8 @@ func TestMirrorIndexMigration(t *testing.T) {
 	}
 
 	fx.handler.mu.Lock()
-	loadedEntry := fx.handler.entries[key]
+	k, _ := parseResolveKey(key)
+	loadedEntry := fx.handler.entries[k]
 	loadedBranch := fx.handler.branches["org/repo\x00main"]
 	fx.handler.mu.Unlock()
 	if loadedEntry == nil {

--- a/mirror/resolve.go
+++ b/mirror/resolve.go
@@ -10,64 +10,25 @@ import (
 	"time"
 )
 
-// handleResolve serves GET/HEAD for hub-style download paths.
-func (h *Handler) handleResolve(w http.ResponseWriter, r *http.Request, key string) {
-	m := resolveRe.FindStringSubmatch(key)
-	rev := m[2]
-
-	// Branch revisions are pinned to the upstream commit they point at, so
-	// entries, tasks, and spools are all keyed by immutable content. The
-	// branch mapping is re-checked on the revalidation cadence; one probe
-	// covers every file of the repo branch and is reused by the ingest task.
-	var preProbe *probeResult
-	if !commitRevRe.MatchString(rev) {
-		commit, pr, ok := h.branchCommit(key, m)
-		preProbe = pr
-		if ok {
-			rev = commit
-			key = "/" + m[1] + "/resolve/" + rev + "/" + m[3]
-		}
-	}
-
-	h.mu.Lock()
-	t := h.tasks[key]
-	e := h.entries[key]
-	h.mu.Unlock()
-
-	if t != nil {
-		h.serveTaskOrEntry(w, r, key, t)
+// handleResolve serves GET/HEAD for hub-style download paths. The shared
+// acquire flow pins branch revisions, so entries, tasks, and spools are all
+// keyed by immutable content and reused by Ingest.
+func (h *Handler) handleResolve(w http.ResponseWriter, r *http.Request, p string) {
+	key, ok := parseResolveKey(p)
+	if !ok {
+		http.NotFound(w, r)
 		return
 	}
-	if e != nil {
-		switch e.State {
-		case stateReady:
-			if h.needsRevalidate(e, rev) {
-				e = h.revalidate(r.Context(), key, e)
-			}
-			if e != nil {
-				h.serveReady(w, r, e)
-				return
-			}
-			// stale: fall through and re-ingest
-		case stateFailed:
-			if time.Now().Before(e.nextRetry) {
-				h.serveFailed(w, e)
-				return
-			}
-		}
-	}
-
-	t, e, err := h.startTask(key, preProbe)
+	key, t, e, err := h.acquire(r.Context(), key)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if e != nil {
-		// Lost the race: another request finished (or failed) the ingest first.
-		h.serveEntry(w, r, e)
+	if t != nil {
+		h.serveTaskOrEntry(w, r, key, t)
 		return
 	}
-	h.serveTaskOrEntry(w, r, key, t)
+	h.serveEntry(w, r, e)
 }
 
 // serveEntry answers from a completed entry, ready or failed.
@@ -82,7 +43,7 @@ func (h *Handler) serveEntry(w http.ResponseWriter, r *http.Request, e *fileEntr
 // serveTaskOrEntry streams from the in-flight task, falling back to the entry
 // published by a completed ingest when the spool was drained and removed
 // before this request could attach.
-func (h *Handler) serveTaskOrEntry(w http.ResponseWriter, r *http.Request, key string, t *task) {
+func (h *Handler) serveTaskOrEntry(w http.ResponseWriter, r *http.Request, key resolveKey, t *task) {
 	if h.serveFromTask(w, r, t) {
 		return
 	}
@@ -107,8 +68,8 @@ func (h *Handler) needsRevalidate(e *fileEntry, rev string) bool {
 // revalidate re-probes the upstream. It returns the entry to serve, or nil
 // when the entry went stale and must be re-ingested. Upstream errors keep
 // serving the cached copy.
-func (h *Handler) revalidate(ctx context.Context, key string, e *fileEntry) *fileEntry {
-	pr, err := h.probe(ctx, key)
+func (h *Handler) revalidate(ctx context.Context, key resolveKey, e *fileEntry) *fileEntry {
+	pr, err := h.probe(ctx, key.String())
 	if err != nil || pr.status < 200 || pr.status >= 300 {
 		return e
 	}

--- a/mirror/resume_test.go
+++ b/mirror/resume_test.go
@@ -347,8 +347,9 @@ func (u *flakyUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // clearBackoff lets the next request start a fresh task immediately.
 func clearBackoff(h *Handler, key string) {
+	k, _ := parseResolveKey(key)
 	h.mu.Lock()
-	if e := h.entries[key]; e != nil && e.State == stateFailed {
+	if e := h.entries[k]; e != nil && e.State == stateFailed {
 		e.nextRetry = time.Time{}
 	}
 	h.mu.Unlock()
@@ -527,11 +528,12 @@ func TestMirrorStalePartialDiscarded(t *testing.T) {
 // waitFailed polls until the entry for key is in the failed state.
 func waitFailed(t *testing.T, h *Handler, key string) {
 	t.Helper()
+	k, _ := parseResolveKey(key)
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		h.mu.Lock()
-		e := h.entries[key]
-		_, running := h.tasks[key]
+		e := h.entries[k]
+		_, running := h.tasks[k]
 		h.mu.Unlock()
 		if !running && e != nil && e.State == stateFailed {
 			return

--- a/mirror/task.go
+++ b/mirror/task.go
@@ -22,6 +22,7 @@ type task struct {
 	spool    *spool        // set by runTask before probed closes (when the probe succeeded)
 	probed   chan struct{} // closed once probe metadata (or probeErr) is set
 	sized    chan struct{} // closed once size is known or no early source remains
+	done     chan struct{} // closed once the task finished and its entry is published
 	sizeOnce sync.Once
 	probeErr error
 	notFound bool
@@ -43,8 +44,8 @@ func (t *task) setSize(n int64) {
 // startup itself runs inside the singleflight, so the task is registered
 // exactly once per key. A pre-probe result from the branch mapping refresh is
 // handed to the task so the upstream is not probed twice.
-func (h *Handler) startTask(key string, pre *probeResult) (*task, *fileEntry, error) {
-	v, err, _ := h.flight.Do(key, func() (any, error) {
+func (h *Handler) startTask(key resolveKey, pre *probeResult) (*task, *fileEntry, error) {
+	v, err, _ := h.flight.Do(key.String(), func() (any, error) {
 		// A previous flight may have registered a task, or finished the whole
 		// ingest, between the caller's check and this one.
 		h.mu.Lock()
@@ -62,7 +63,7 @@ func (h *Handler) startTask(key string, pre *probeResult) (*task, *fileEntry, er
 				return e, nil
 			}
 		}
-		nt := &task{probed: make(chan struct{}), sized: make(chan struct{})}
+		nt := &task{probed: make(chan struct{}), sized: make(chan struct{}), done: make(chan struct{})}
 		nt.size.Store(-1)
 		h.mu.Lock()
 		h.tasks[key] = nt
@@ -79,34 +80,82 @@ func (h *Handler) startTask(key string, pre *probeResult) (*task, *fileEntry, er
 	return nil, v.(*fileEntry), nil
 }
 
+// acquire is the shared resolution flow behind both the HTTP resolve path and
+// Ingest: it pins branch revisions to their upstream commit and returns what
+// the request attaches to — the in-flight task, or the terminal entry (ready,
+// revalidated on the usual cadence, or failed and still inside its retry
+// backoff) — starting a new ingest task when neither exists. Exactly one of
+// the returned task and entry is non-nil; the returned key carries the branch
+// pin. ctx bounds only the revalidation probe.
+func (h *Handler) acquire(ctx context.Context, key resolveKey) (resolveKey, *task, *fileEntry, error) {
+	var preProbe *probeResult
+	if !commitRevRe.MatchString(key.rev) {
+		commit, pr, ok := h.branchCommit(key)
+		preProbe = pr
+		if ok {
+			key.rev = commit
+		}
+	}
+
+	h.mu.Lock()
+	t := h.tasks[key]
+	e := h.entries[key]
+	h.mu.Unlock()
+
+	if t != nil {
+		return key, t, nil, nil
+	}
+	if e != nil {
+		switch e.State {
+		case stateReady:
+			if h.needsRevalidate(e, key.rev) {
+				e = h.revalidate(ctx, key, e)
+			}
+			if e != nil {
+				return key, nil, e, nil
+			}
+			// stale: fall through and re-ingest
+		case stateFailed:
+			if time.Now().Before(e.nextRetry) {
+				return key, nil, e, nil
+			}
+		}
+	}
+
+	t, e, err := h.startTask(key, preProbe)
+	return key, t, e, err
+}
+
 // runTask executes one ingestion end to end on a background context; client
 // disconnects never cancel it. The spool opens after the probe so partial
 // bytes from a previous failed task (or a previous process) are resumed when
 // the upstream etag still matches. A non-nil pre stands in for the probe.
-func (h *Handler) runTask(key string, t *task, pre *probeResult) {
+func (h *Handler) runTask(key resolveKey, t *task, pre *probeResult) {
 	ctx := context.Background()
+	upath := key.String()
+	defer close(t.done) // the entry is published by then, on every path
 
 	pr, err := pre, error(nil)
 	if pr == nil {
-		pr, err = h.probe(ctx, key)
+		pr, err = h.probe(ctx, upath)
 	}
 	if err == nil {
 		switch {
 		case pr.status == http.StatusNotFound:
-			err = errUpstreamNotFound
+			err = ErrUpstreamNotFound
 		case pr.status < 200 || pr.status >= 300:
 			err = fmt.Errorf("upstream status %d", pr.status)
 		}
 	}
 	if err != nil {
 		t.probeErr = err
-		t.notFound = errors.Is(err, errUpstreamNotFound)
+		t.notFound = errors.Is(err, ErrUpstreamNotFound)
 		close(t.probed)
 		h.failTask(key, t, err)
 		return
 	}
 
-	sp, err := openSpool(h.spoolDir, key, pr.etag, pr.size)
+	sp, err := openSpool(h.spoolDir, upath, pr.etag, pr.size)
 	if err != nil {
 		t.probeErr = err
 		close(t.probed)
@@ -132,9 +181,9 @@ func (h *Handler) runTask(key string, t *task, pre *probeResult) {
 		// The xet ingest reports no size before completion; when the probe
 		// found none there is no early source, so stop replies waiting for one.
 		t.setSize(-1)
-		err = h.fetchXet(ctx, t, key)
+		err = h.fetchXet(ctx, t, upath)
 	default:
-		err = h.fetchPlain(ctx, t, key)
+		err = h.fetchPlain(ctx, t, upath)
 	}
 	if err == nil {
 		if want := t.size.Load(); want >= 0 && t.spool.size() != want {
@@ -170,7 +219,7 @@ func (h *Handler) runTask(key string, t *task, pre *probeResult) {
 }
 
 // failTask records a failure with exponential backoff and clears the task.
-func (h *Handler) failTask(key string, t *task, err error) {
+func (h *Handler) failTask(key resolveKey, t *task, err error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	failures := 1
@@ -180,7 +229,7 @@ func (h *Handler) failTask(key string, t *task, err error) {
 	shift := min(failures-1, maxFailureShift)
 	backoff := min(failureBackoffBase<<shift, failureBackoffCap)
 	h.entries[key] = &fileEntry{
-		Key:       key,
+		Key:       key.String(),
 		State:     stateFailed,
 		failures:  failures,
 		nextRetry: time.Now().Add(backoff),
@@ -192,7 +241,7 @@ func (h *Handler) failTask(key string, t *task, err error) {
 
 // ingestSpool verifies the spooled bytes and runs the standard upload pipeline
 // against local storage, then returns the ready index entry.
-func (h *Handler) ingestSpool(ctx context.Context, t *task, key string) (*fileEntry, error) {
+func (h *Handler) ingestSpool(ctx context.Context, t *task, key resolveKey) (*fileEntry, error) {
 	f, err := os.Open(t.spool.f.Name())
 	if err != nil {
 		return nil, fmt.Errorf("open spool: %w", err)
@@ -212,7 +261,7 @@ func (h *Handler) ingestSpool(ctx context.Context, t *task, key string) (*fileEn
 	}
 
 	entry := &fileEntry{
-		Key:       key,
+		Key:       key.String(),
 		State:     stateReady,
 		SHA256:    digest,
 		Size:      size,


### PR DESCRIPTION
Fixes #165

Embedding the mirror leaves ServeHTTP as the only way to trigger an ingest: a synthesized in-process GET drained through a discarding ResponseWriter, where the body ending only proves the spool completed — the xorbs and shards land afterwards in ingestSpool, so readiness still has to be polled.

This adds Handler.Ingest(repo, rev, path). Unlike the blocking method proposed in the issue, it returns an Ingestion handle immediately: Done() closes once the entry is ready or failed (after xorbs, shards, and the index entry landed), and Entry() then reports the persisted fields (SHA256, FileHash, Size, ETag, Commit) or the failure, with upstream 404s matching the exported ErrUpstreamNotFound. The whole resolution runs behind a singleflight DoChan, so Ingest never blocks on branch probes and concurrent calls for one file share a flight. Abandoning the handle never cancels the ingest — the same contract as a client disconnect on the HTTP path.

To avoid duplicating handleResolve, the entry/task maps are now keyed by a resolveKey{repo, rev, path} struct and both paths share one acquire flow (branch pin → revalidate/backoff → start or join the task). On-disk formats are unchanged: fileEntry.Key, spool names, and upstream URLs still use the rendered path string.

go test ./mirror -race -count=1 passes; ingest_test.go covers the handle lifecycle, joining an in-flight ingest, cached failures, and sentinel matching.
