### PR TITLE
fix: wait for in-flight ingest tasks before mirror test teardown

### DIFF
--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -140,6 +140,30 @@ func newMirrorFixture(t *testing.T, upstream string, storageDir, cacheDir string
 		server.WithAuthFunc(func(tok string) bool { return issuer.Validate(tok, time.Now()) }),
 		server.WithNext(h),
 	)))
+	// Ingest tasks keep writing to storage and cache after clients disconnect;
+	// wait for them so the t.TempDir removals running after this cleanup do
+	// not race those writes.
+	t.Cleanup(func() {
+		timeout := time.After(30 * time.Second)
+		for {
+			h.mu.Lock()
+			var done chan struct{}
+			for _, tk := range h.tasks {
+				done = tk.done
+				break
+			}
+			h.mu.Unlock()
+			if done == nil {
+				return
+			}
+			select {
+			case <-done:
+			case <-timeout:
+				t.Error("mirror fixture: in-flight ingest tasks did not finish")
+				return
+			}
+		}
+	})
 	return &mirrorFixture{srv: srv, handler: h, stor: stor, issuer: issuer}
 }
 


### PR DESCRIPTION
CI hit a flake in `TestMirrorClientDisconnectThenRangeResume` ([run](https://github.com/wzshiming/xet/actions/runs/31786416451/attempts/1)):

```
testing.go:1369: TempDir RemoveAll cleanup: unlinkat /tmp/TestMirrorClientDisconnectThenRangeResume1558421630/001: directory not empty
```

The test returns once client 2 drains the body, but `runTask` is still committing the file to storage in the background — `ingestSpool` → `upload.UploadFile` keeps creating xorb/shard files in the storage temp dir while `t.TempDir` cleanup runs `RemoveAll`, which fails when a file appears between its readdir and rmdir. `TestMirrorRangeWhileIngesting` has the same latent race; the other resume tests only avoid it because they happen to end with `waitReady`.

Fixed in the fixture rather than per test: `newMirrorFixture` registers a cleanup that waits on each in-flight task's `done` channel, which closes only after the storage, index, and spool writes finished. Cleanups run LIFO, so the wait runs before the callers' `t.TempDir` removals, and any future fixture user is covered too. All gated tests close their gates, so the wait terminates; a 30s guard reports if one ever doesn't.

Verified with `go test ./mirror/ -run 'TestMirrorClientDisconnect|TestMirrorRangeWhileIngesting|TestIngest' -count=20 -race` and a full `go test ./mirror/ -race`, both pass.
