### PR TITLE
refactor: wire the upstream proxy explicitly via NewUpstreamProxy

### DIFF
--- a/cmd/xetd/main.go
+++ b/cmd/xetd/main.go
@@ -98,6 +98,12 @@ func main() {
 			os.Exit(1)
 		}
 
+		proxy, err := mirror.NewUpstreamProxy(*upstream, *upstreamToken)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create upstream proxy: %v\n", err)
+			os.Exit(1)
+		}
+
 		next, err = mirror.NewHandler(
 			mirror.WithStorage(stor),
 			mirror.WithUpstream(*upstream),
@@ -106,6 +112,7 @@ func main() {
 			mirror.WithCacheDir(filepath.Join(*storageDir, "mirror")),
 			mirror.WithClient(xetClient),
 			mirror.WithMintToken(issuer.Mint),
+			mirror.WithNext(proxy),
 		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to create mirror: %v\n", err)

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -96,11 +95,11 @@ func (k resolveKey) String() string {
 
 // Handler is the mirror HTTP front end: resolve requests are served from the
 // local cache (ingesting on miss) and the token endpoint hands downstream
-// clients their CAS credential. Everything else falls through to next, which
-// defaults to a reverse proxy that forwards to the upstream with the mirror's
-// credentials injected (control plane only, never file bytes). Mount the
-// Handler as the CAS server's next; token minting and validation are wired by
-// the caller through WithMintToken and the server's AuthFunc.
+// clients their CAS credential. Everything else falls through to next
+// (404 when unset); wire NewUpstreamProxy there to forward the control plane
+// to the upstream. Mount the Handler as the CAS server's next; token minting
+// and validation are wired by the caller through WithMintToken and the
+// server's AuthFunc.
 type Handler struct {
 	storage            storage.Storage
 	upstreamRaw        string
@@ -173,8 +172,8 @@ func WithMintToken(mint func(now time.Time) (token string, exp int64)) Option {
 }
 
 // WithNext sets the handler for requests that are neither resolve nor token
-// requests. When unset it defaults to a reverse proxy that forwards to the
-// upstream with the mirror's credentials injected.
+// requests. When unset such requests are answered with 404; pass
+// NewUpstreamProxy to forward them to the upstream instead.
 func WithNext(next http.Handler) Option {
 	return func(h *Handler) { h.next = next }
 }
@@ -256,43 +255,14 @@ func NewHandler(opts ...Option) (*Handler, error) {
 	h.localAdapter = &localCAS{storage: h.storage, namespace: "default"}
 
 	if h.next == nil {
-		h.next = h.newUpstreamProxy()
+		h.next = http.NotFoundHandler()
 	}
 
 	return h, nil
 }
 
-// newUpstreamProxy builds the default next handler: a reverse proxy that
-// forwards control-plane requests to the upstream with the mirror's
-// credentials injected.
-func (h *Handler) newUpstreamProxy() http.Handler {
-	return &httputil.ReverseProxy{
-		Rewrite: func(pr *httputil.ProxyRequest) {
-			pr.SetURL(h.upstream)
-			pr.Out.Host = h.upstream.Host
-			pr.Out.Header.Del("Authorization")
-			if h.upstreamToken != "" {
-				pr.Out.Header.Set("Authorization", "Bearer "+h.upstreamToken)
-			}
-		},
-		// Upstream response headers are dropped except the entity headers
-		// describing the relayed body and the redirect target without which
-		// 3xx cannot work.
-		ModifyResponse: func(resp *http.Response) error {
-			kept := http.Header{}
-			for _, k := range []string{"Content-Type", "Content-Length", "Content-Encoding", "Etag", "Date", "Location"} {
-				if v := resp.Header.Get(k); v != "" {
-					kept.Set(k, v)
-				}
-			}
-			resp.Header = kept
-			return nil
-		},
-	}
-}
-
 // ServeHTTP handles resolve and token requests; everything else falls through
-// to next (the upstream proxy by default).
+// to next.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p := r.URL.EscapedPath()
 	if p == tokenEndpointPath && r.Method == http.MethodGet {

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -122,12 +122,18 @@ func newMirrorFixture(t *testing.T, upstream string, storageDir, cacheDir string
 		t.Fatal(err)
 	}
 
+	proxy, err := NewUpstreamProxy(upstream, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	h, err := NewHandler(append([]Option{
 		WithStorage(stor),
 		WithUpstream(upstream),
 		WithExternalURL(srv.URL),
 		WithCacheDir(cacheDir),
 		WithMintToken(issuer.Mint),
+		WithNext(proxy),
 	}, opts...)...)
 	if err != nil {
 		t.Fatal(err)
@@ -782,7 +788,11 @@ func TestMirrorControlPlaneProxy(t *testing.T) {
 	}))
 	defer upstreamSrv.Close()
 
-	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir(), WithUpstreamToken("up-secret"))
+	proxy, err := NewUpstreamProxy(upstreamSrv.URL, "up-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fx := newMirrorFixture(t, upstreamSrv.URL, t.TempDir(), t.TempDir(), WithUpstreamToken("up-secret"), WithNext(proxy))
 
 	req, _ := http.NewRequest(http.MethodGet, fx.srv.URL+"/api/models/org/repo", nil)
 	req.Header.Set("Authorization", "Bearer downstream-junk")

--- a/mirror/proxy.go
+++ b/mirror/proxy.go
@@ -1,0 +1,42 @@
+package mirror
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+// NewUpstreamProxy builds a reverse proxy that forwards control-plane
+// requests to the upstream hub with the given credential injected, intended
+// as the Handler's next (WithNext). Downstream Authorization headers are
+// never forwarded upstream.
+func NewUpstreamProxy(upstream, upstreamToken string) (http.Handler, error) {
+	u, err := url.Parse(upstream)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("mirror: invalid upstream URL %q", upstream)
+	}
+	return &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(u)
+			pr.Out.Host = u.Host
+			pr.Out.Header.Del("Authorization")
+			if upstreamToken != "" {
+				pr.Out.Header.Set("Authorization", "Bearer "+upstreamToken)
+			}
+		},
+		// Upstream response headers are dropped except the entity headers
+		// describing the relayed body and the redirect target without which
+		// 3xx cannot work.
+		ModifyResponse: func(resp *http.Response) error {
+			kept := http.Header{}
+			for _, k := range []string{"Content-Type", "Content-Length", "Content-Encoding", "Etag", "Date", "Location"} {
+				if v := resp.Header.Get(k); v != "" {
+					kept.Set(k, v)
+				}
+			}
+			resp.Header = kept
+			return nil
+		},
+	}, nil
+}

--- a/test/conformance/mirror/mirror_compat_test.go
+++ b/test/conformance/mirror/mirror_compat_test.go
@@ -147,6 +147,10 @@ func startMirror(t *testing.T, upstream, storageDir, cacheDir string, opts ...mi
 	if err != nil {
 		t.Fatal(err)
 	}
+	proxy, err := mirror.NewUpstreamProxy(upstream, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h, err := mirror.NewHandler(
 		append([]mirror.Option{
 			mirror.WithStorage(stor),
@@ -154,6 +158,7 @@ func startMirror(t *testing.T, upstream, storageDir, cacheDir string, opts ...mi
 			mirror.WithExternalURL(srv.URL),
 			mirror.WithCacheDir(cacheDir),
 			mirror.WithMintToken(issuer.Mint),
+			mirror.WithNext(proxy),
 		}, opts...)...,
 	)
 	if err != nil {

--- a/test/e2e/mirror_test.go
+++ b/test/e2e/mirror_test.go
@@ -163,6 +163,10 @@ func newMirrorServer(t *testing.T, upstreamURL, storageDir, cacheDir string, opt
 	if err != nil {
 		t.Fatal(err)
 	}
+	proxy, err := mirror.NewUpstreamProxy(upstreamURL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h, err := mirror.NewHandler(
 		append([]mirror.Option{
 			mirror.WithStorage(stor),
@@ -170,6 +174,7 @@ func newMirrorServer(t *testing.T, upstreamURL, storageDir, cacheDir string, opt
 			mirror.WithExternalURL(srv.URL),
 			mirror.WithCacheDir(cacheDir),
 			mirror.WithMintToken(issuer.Mint),
+			mirror.WithNext(proxy),
 		}, opts...)...,
 	)
 	if err != nil {


### PR DESCRIPTION
`NewHandler` defaulted `next` to a reverse proxy that forwards control-plane requests to the upstream with the mirror's credentials injected. The fallback was invisible: embedders got upstream forwarding whether they wanted it or not, and the proxy could not be built or configured on its own.

The proxy is now exported as `NewUpstreamProxy(upstream, token)` in mirror/proxy.go and is wired explicitly through `WithNext`; cmd/xetd and the mirror/conformance/e2e fixtures do so. When `next` is unset the handler answers 404 for unmatched routes instead of silently proxying.

Behavior change for embedders that relied on the implicit default: they now need `mirror.WithNext(mirror.NewUpstreamProxy(...))`.
