### PR TITLE
perf: keep the open entry across no-op and in-chunk seeks

### DIFF
--- a/storage/reconstructed_file.go
+++ b/storage/reconstructed_file.go
@@ -121,6 +121,17 @@ func (r *reconstructedFile) Seek(offset int64, whence int) (int64, error) {
 	if next < 0 {
 		return 0, fmt.Errorf("negative seek position %d", next)
 	}
+	if next == r.position {
+		return next, nil
+	}
+	// Reposition within the buffered chunk to avoid reopening the entry.
+	if r.chunk != nil {
+		if pos := int64(r.chunkPos) + next - r.position; pos >= 0 && pos <= int64(len(r.chunk)) {
+			r.chunkPos = int(pos)
+			r.position = next
+			return next, nil
+		}
+	}
 	r.closeEntry()
 	r.position = next
 	return next, nil


### PR DESCRIPTION
`reconstructedFile.Seek` closed the current entry unconditionally, so even a `Seek(0, io.SeekCurrent)` position query or a small reposition inside the already-decoded chunk dropped the xorb reader and decoder; the next Read then reopened the xorb from storage and decode-skipped from the entry start.

Now a seek that resolves to the current position returns immediately, and one that lands inside the buffered chunk (including its end boundary) just moves `chunkPos` — Read's existing entry/boundary handling covers the rest. Anything else still goes through `closeEntry` as before.
