### PR TITLE
refactor: point the sha256 index at the shard hash

### DIFF
--- a/storage/reconstructed_file.go
+++ b/storage/reconstructed_file.go
@@ -39,14 +39,20 @@ type reconstructedFile struct {
 	closed     bool
 }
 
-func newReconstructedFile(ctx context.Context, stor xorbRangeReader, namespace string, sh *shard.Shard, digest [32]byte) (io.ReadSeekCloser, error) {
-	var file *shard.FileBlock
+// findFileBySHA256 returns the shard file whose recorded SHA-256 matches
+// digest, or nil when the shard does not carry it.
+func findFileBySHA256(sh *shard.Shard, digest [32]byte) *shard.FileBlock {
+	want := shard.NewSHA256Hash(digest)
 	for i := range sh.Files {
-		if sh.Files[i].MetadataExt != nil && sh.Files[i].MetadataExt.SHA256Hash == shard.NewSHA256Hash(digest) {
-			file = &sh.Files[i]
-			break
+		if sh.Files[i].MetadataExt != nil && sh.Files[i].MetadataExt.SHA256Hash == want {
+			return &sh.Files[i]
 		}
 	}
+	return nil
+}
+
+func newReconstructedFile(ctx context.Context, stor xorbRangeReader, namespace string, sh *shard.Shard, digest [32]byte) (io.ReadSeekCloser, error) {
+	file := findFileBySHA256(sh, digest)
 	if file == nil {
 		return nil, fmt.Errorf("SHA-256 is not present in shard")
 	}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -46,7 +46,7 @@ type S3Storage struct {
 	fileIndex    *lru.Cache // bounded file hash -> shard hash
 	shardIndex   *lru.Cache // bounded shard hash -> shard cache
 	chunkIndex   *lru.Cache // bounded chunk hash -> shard hash
-	sha256Index  *lru.Cache // bounded SHA-256 -> file hash
+	sha256Index  *lru.Cache // bounded SHA-256 -> shard hash
 	offsetsIndex *lru.Cache // bounded xorb hash -> []uint64 packed chunk end-offsets
 
 	fileMut    sync.Mutex // guards fileIndex
@@ -510,7 +510,7 @@ func (ss *S3Storage) PutShard(ctx context.Context, s *shard.Shard) (bool, error)
 		}
 	}
 	for _, file := range s.Files {
-		if err := ss.putIndexObject(ctx, ss.objectKey("index/sha256", file.MetadataExt.SHA256Hash.String()), []byte(file.FileHash.String())); err != nil {
+		if err := ss.putIndexObject(ctx, ss.objectKey("index/sha256", file.MetadataExt.SHA256Hash.String()), shardHashData); err != nil {
 			return wasInserted, fmt.Errorf("write SHA-256 index for file %s: %w", file.FileHash.String(), err)
 		}
 	}
@@ -607,38 +607,46 @@ func (ss *S3Storage) GetShardByChunkHash(ctx context.Context, _ string, chunkHas
 }
 
 // GetFileHashBySHA256 resolves a SHA-256 digest to the xet file hash recorded
-// at ingest.
+// at ingest, loading the owning shard and matching its file metadata.
 func (ss *S3Storage) GetFileHashBySHA256(ctx context.Context, _ string, digest [32]byte) (xet.FileHash, error) {
+	sh, err := ss.getShardBySHA256(ctx, digest)
+	if err != nil {
+		return xet.FileHash{}, err
+	}
+	file := findFileBySHA256(sh, digest)
+	if file == nil {
+		return xet.FileHash{}, fmt.Errorf("SHA-256 is not present in shard")
+	}
+	return file.FileHash, nil
+}
+
+// getShardBySHA256 resolves a SHA-256 digest through index/sha256/<digest>,
+// whose contents are the hash of the owning shard, reading the index through
+// the bounded cache.
+func (ss *S3Storage) getShardBySHA256(ctx context.Context, digest [32]byte) (*shard.Shard, error) {
 	ss.sha256Mut.Lock()
 	value, exists := ss.sha256Index.Get(digest)
 	ss.sha256Mut.Unlock()
 	if exists {
-		return value.(xet.FileHash), nil
+		return ss.getShardByHash(ctx, value.(string))
 	}
 
 	data, err := ss.getObject(ctx, ss.objectKey("index/sha256", hex.EncodeToString(digest[:])))
 	if err != nil {
 		if isS3NotFound(err) {
-			return xet.FileHash{}, fmt.Errorf("SHA-256 not found")
+			return nil, fmt.Errorf("SHA-256 not found")
 		}
-		return xet.FileHash{}, fmt.Errorf("read SHA-256 index: %w", err)
+		return nil, fmt.Errorf("read SHA-256 index: %w", err)
 	}
-	fileHash, err := xet.ParseFileHash(strings.TrimSpace(string(data)))
-	if err != nil {
-		return xet.FileHash{}, fmt.Errorf("invalid SHA-256 index: %w", err)
-	}
+	shardHash := strings.TrimSpace(string(data))
 	ss.sha256Mut.Lock()
-	ss.sha256Index.Add(digest, fileHash)
+	ss.sha256Index.Add(digest, shardHash)
 	ss.sha256Mut.Unlock()
-	return fileHash, nil
+	return ss.getShardByHash(ctx, shardHash)
 }
 
 func (ss *S3Storage) GetReconstructedFile(ctx context.Context, namespace string, sha256 [32]byte) (io.ReadSeekCloser, error) {
-	fileHash, err := ss.GetFileHashBySHA256(ctx, namespace, sha256)
-	if err != nil {
-		return nil, fmt.Errorf("get file hash by sha256: %w", err)
-	}
-	sh, err := ss.GetShard(ctx, fileHash)
+	sh, err := ss.getShardBySHA256(ctx, sha256)
 	if err != nil {
 		return nil, fmt.Errorf("get shard by sha256: %w", err)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -58,7 +58,7 @@ type FileStorage struct {
 	fileIndex    *lru.Cache // bounded file hash -> shard hash
 	shardIndex   *lru.Cache // bounded shard hash -> shard cache
 	chunkIndex   *lru.Cache // bounded chunk hash -> shard hash
-	sha256Index  *lru.Cache // bounded SHA-256 -> file hash
+	sha256Index  *lru.Cache // bounded SHA-256 -> shard hash
 	xorbIndex    *lru.Cache // bounded xorb hash -> *xorbFile
 	offsetsIndex *lru.Cache // bounded xorb hash -> []uint64 packed chunk end-offsets
 
@@ -454,7 +454,7 @@ func (fs *FileStorage) PutShard(ctx context.Context, s *shard.Shard) (bool, erro
 	}
 	for _, file := range s.Files {
 		sha256Path := fs.objectPath("index/sha256", file.MetadataExt.SHA256Hash.String())
-		if err := writeIndexFile(sha256Path, []byte(file.FileHash.String())); err != nil {
+		if err := writeIndexFile(sha256Path, shardHashData); err != nil {
 			return wasInserted, fmt.Errorf("write SHA-256 index for file %s: %w", file.FileHash.String(), err)
 		}
 	}
@@ -568,43 +568,47 @@ func (fs *FileStorage) GetShard(ctx context.Context, fileHash xet.FileHash) (*sh
 }
 
 // GetFileHashBySHA256 resolves a SHA-256 digest to the xet file hash recorded
-// at ingest, reading the sha256 index file through the bounded cache.
+// at ingest, loading the owning shard and matching its file metadata.
 func (fs *FileStorage) GetFileHashBySHA256(ctx context.Context, _ string, digest [32]byte) (xet.FileHash, error) {
+	sh, err := fs.getShardBySHA256(digest)
+	if err != nil {
+		return xet.FileHash{}, err
+	}
+	file := findFileBySHA256(sh, digest)
+	if file == nil {
+		return xet.FileHash{}, fmt.Errorf("SHA-256 is not present in shard")
+	}
+	return file.FileHash, nil
+}
+
+// getShardBySHA256 resolves a SHA-256 digest through index/sha256/<digest>,
+// whose contents are the hash of the owning shard, reading the index through
+// the bounded cache.
+func (fs *FileStorage) getShardBySHA256(digest [32]byte) (*shard.Shard, error) {
 	fs.sha256Mut.Lock()
 	value, exists := fs.sha256Index.Get(digest)
 	fs.sha256Mut.Unlock()
 	if exists {
-		return value.(xet.FileHash), nil
+		return fs.getShardByHash(value.(string))
 	}
 
 	indexPath := fs.objectPath("index/sha256", hex.EncodeToString(digest[:]))
 	b, err := os.ReadFile(indexPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return xet.FileHash{}, fmt.Errorf("SHA-256 not found")
+			return nil, fmt.Errorf("SHA-256 not found")
 		}
-		return xet.FileHash{}, fmt.Errorf("read SHA-256 index: %w", err)
+		return nil, fmt.Errorf("read SHA-256 index: %w", err)
 	}
-	fileHash, err := xet.ParseFileHash(strings.TrimSpace(string(b)))
-	if err != nil {
-		return xet.FileHash{}, fmt.Errorf("invalid SHA-256 index: %w", err)
-	}
+	shardHash := strings.TrimSpace(string(b))
 	fs.sha256Mut.Lock()
-	fs.sha256Index.Add(digest, fileHash)
+	fs.sha256Index.Add(digest, shardHash)
 	fs.sha256Mut.Unlock()
-	return fileHash, nil
-}
-
-func (fs *FileStorage) getShardBySHA256(ctx context.Context, namespace string, digest [32]byte) (*shard.Shard, error) {
-	fileHash, err := fs.GetFileHashBySHA256(ctx, namespace, digest)
-	if err != nil {
-		return nil, err
-	}
-	return fs.GetShard(ctx, fileHash)
+	return fs.getShardByHash(shardHash)
 }
 
 func (fs *FileStorage) GetReconstructedFile(ctx context.Context, namespace string, sha256 [32]byte) (io.ReadSeekCloser, error) {
-	sh, err := fs.getShardBySHA256(ctx, namespace, sha256)
+	sh, err := fs.getShardBySHA256(sha256)
 	if err != nil {
 		return nil, fmt.Errorf("get shard by sha256: %w", err)
 	}


### PR DESCRIPTION
Resolving a SHA-256 went digest -> file hash -> index/files -> shard, costing an extra index read even though the shard is what every caller loads next. The index/sha256 entries now store the shard hash directly, the bounded cache follows, and GetFileHashBySHA256 recovers the file hash from the loaded shard's metadata through the same lookup newReconstructedFile uses.