### PR TITLE
refactor: store shard objects footerless for deterministic naming

### DIFF
--- a/client/shard_test.go
+++ b/client/shard_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/wzshiming/xet"
 	"github.com/wzshiming/xet/shard"
@@ -220,7 +221,7 @@ func buildDedupShardBytes(t *testing.T, key [32]byte, keyExpiry uint64, xorbHash
 		NumBytesInCAS:  offset,
 		NumBytesOnDisk: offset,
 	})
-	s.SetFooter()
+	s.SetFooter(time.Now())
 	s.Footer.ChunkHashKey = key
 	if keyExpiry != 0 {
 		s.Footer.ShardKeyExpiry = keyExpiry

--- a/shard/encode.go
+++ b/shard/encode.go
@@ -4,19 +4,26 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"time"
 )
 
-// Encode returns a streaming reader for the shard serialization.
+// Encode returns a streaming reader for the shard serialization. It does not
+// modify the shard, so a cached shard can be served concurrently.
 func (s *Shard) Encode(withFooter bool) (io.Reader, error) {
-	if withFooter {
-		if s.Footer == nil {
-			s.SetFooter()
-		}
-	}
-	return &shardReader{
+	r := &shardReader{
 		shard:      s,
 		withFooter: withFooter,
-	}, nil
+	}
+	if withFooter {
+		r.footerSize = 200
+		footer := s.Footer
+		if footer == nil {
+			footer = s.newFooter(time.Now())
+		}
+		local := *footer
+		r.footer = &local
+	}
+	return r, nil
 }
 
 // shardReader implements io.Reader for shard serialization.
@@ -26,6 +33,8 @@ func (s *Shard) Encode(withFooter bool) (io.Reader, error) {
 type shardReader struct {
 	shard         *Shard
 	withFooter    bool
+	footer        *Footer // private copy: encoding fills in its offsets
+	footerSize    uint64
 	sectionIdx    int
 	buffer        []byte
 	bufOffset     int
@@ -105,11 +114,6 @@ func (r *shardReader) loadSection(idx, numFiles, numCAS int) error {
 	switch {
 	case idx == 0:
 		// Header (48 bytes).
-		if r.withFooter {
-			r.shard.FooterSize = 200
-		} else {
-			r.shard.FooterSize = 0
-		}
 		r.buildHeader()
 
 	case idx >= 1 && idx <= numFiles:
@@ -136,7 +140,7 @@ func (r *shardReader) loadSection(idx, numFiles, numCAS int) error {
 }
 
 func (r *shardReader) buildFooterBuffer() {
-	f := r.shard.Footer
+	f := r.footer
 	f.FileInfoOffset = r.fileInfoOffset
 	f.CASInfoOffset = r.casInfoOffset
 	f.FooterOffset = r.footerOffset
@@ -180,7 +184,7 @@ func (r *shardReader) buildHeader() {
 	r.buffer = append(r.buffer, 0)
 	r.buffer = append(r.buffer, shardMagicSequence[:]...)
 	r.buffer = binary.LittleEndian.AppendUint64(r.buffer, version)
-	r.buffer = binary.LittleEndian.AppendUint64(r.buffer, r.shard.FooterSize)
+	r.buffer = binary.LittleEndian.AppendUint64(r.buffer, r.footerSize)
 }
 
 func (r *shardReader) buildFileBlock(fb FileBlock) {

--- a/shard/encode_test.go
+++ b/shard/encode_test.go
@@ -1,0 +1,97 @@
+package shard
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+func encodeTestShard() *Shard {
+	s := NewShard()
+	s.AddFile(FileBlock{
+		FileHash: [32]byte{1},
+		Entries:  []FileDataSequenceEntry{{CASHash: [32]byte{2}, UnpackedSegBytes: 10, ChunkIndexEnd: 1}},
+	})
+	s.AddCASBlock(CASBlock{
+		CASHash:       [32]byte{2},
+		Chunks:        []CASChunkSequenceEntry{{ChunkHash: [32]byte{3}, UnpackedSegBytes: 10}},
+		NumBytesInCAS: 10,
+	})
+	return s
+}
+
+func TestEncodeLeavesShardUnmodified(t *testing.T) {
+	s := encodeTestShard()
+	r, err := s.Encode(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(r); err != nil {
+		t.Fatal(err)
+	}
+	if s.Footer != nil {
+		t.Fatal("Encode() created a footer on the shard")
+	}
+	if s.FooterSize != 0 {
+		t.Fatalf("Encode() set FooterSize = %d", s.FooterSize)
+	}
+
+	// An existing footer keeps its offsets: encoding fills in a private copy.
+	s.SetFooter(time.Now())
+	before := *s.Footer
+	r, err = s.Encode(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(r); err != nil {
+		t.Fatal(err)
+	}
+	if *s.Footer != before {
+		t.Fatalf("Encode() modified the footer: %+v -> %+v", before, *s.Footer)
+	}
+}
+
+// TestEncodeIsConcurrencySafe serves one shard from several goroutines, as the
+// dedup endpoints do with a cached shard. Run with -race.
+func TestEncodeIsConcurrencySafe(t *testing.T) {
+	s := encodeTestShard()
+	s.SetFooter(time.Now())
+
+	want, err := s.Encode(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, err := io.ReadAll(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	results := make([][]byte, 8)
+	for i := range results {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := s.Encode(true)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			data, err := io.ReadAll(r)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			results[i] = data
+		}()
+	}
+	wg.Wait()
+
+	for i, got := range results {
+		if !bytes.Equal(got, expected) {
+			t.Fatalf("concurrent encode %d produced different bytes", i)
+		}
+	}
+}

--- a/shard/shard.go
+++ b/shard/shard.go
@@ -226,11 +226,16 @@ func (s *Shard) EncodedSize(withFooter bool) int64 {
 	return size
 }
 
-// SetFooter creates a Footer for this shard, computing StoredBytesOnDisk,
-// StoredBytes, and MaterializedBytes from the current CAS and file data.
-// Offset fields (FileInfoOffset, CASInfoOffset, FooterOffset) are set
-// automatically during Encode and do not need to be supplied here.
-func (s *Shard) SetFooter() {
+// SetFooter creates a Footer for this shard, stamped with creationTime and
+// computing StoredBytesOnDisk, StoredBytes, and MaterializedBytes from the
+// current CAS and file data. Offset fields (FileInfoOffset, CASInfoOffset,
+// FooterOffset) are set automatically during Encode and do not need to be
+// supplied here.
+func (s *Shard) SetFooter(creationTime time.Time) {
+	s.Footer = s.newFooter(creationTime)
+}
+
+func (s *Shard) newFooter(creationTime time.Time) *Footer {
 	var storedBytesOnDisk, storedBytes, materializedBytes uint64
 	for _, cas := range s.CASInfos {
 		storedBytesOnDisk += uint64(cas.NumBytesOnDisk)
@@ -241,12 +246,12 @@ func (s *Shard) SetFooter() {
 			materializedBytes += uint64(entry.UnpackedSegBytes)
 		}
 	}
-	s.Footer = &Footer{
+	return &Footer{
 		Version:                1,
 		StoredBytesOnDisk:      storedBytesOnDisk,
 		StoredBytes:            storedBytes,
 		MaterializedBytes:      materializedBytes,
-		ShardCreationTimestamp: uint64(time.Now().Unix()),
+		ShardCreationTimestamp: uint64(creationTime.Unix()),
 		ShardKeyExpiry:         ^uint64(0),
 	}
 }

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -473,9 +473,10 @@ func (ss *S3Storage) PutShard(ctx context.Context, s *shard.Shard) (bool, error)
 		s.Files[i].Flags |= shard.FileWithMetadataExt
 	}
 
-	// Serialize the shard first, then hash those exact persisted bytes. The
-	// shard object is addressed by this hash rather than by any contained file.
-	r, err := s.Encode(true)
+	// Serialize without the footer (it embeds a creation timestamp), so the
+	// stored bytes — and the sha256 hash addressing them — are deterministic
+	// for identical shard content.
+	r, err := s.Encode(false)
 	if err != nil {
 		return false, fmt.Errorf("serialize shard: %w", err)
 	}
@@ -500,7 +501,9 @@ func (ss *S3Storage) PutShard(ctx context.Context, s *shard.Shard) (bool, error)
 
 	// The index/files/ index is written last: hasFile treats it as the commit
 	// marker, so a partial failure leaves a retryable shard instead of one
-	// that reports "already exists" with missing chunk/sha256 indexes.
+	// that reports "already exists" with missing chunk/sha256 indexes. Nothing
+	// is cached here; the read path populates the caches from the stored
+	// objects, so a warm process serves exactly what a restarted one would.
 	shardHashData := []byte(shardHash)
 	for _, casBlock := range s.CASInfos {
 		for _, chunk := range casBlock.Chunks {
@@ -520,17 +523,6 @@ func (ss *S3Storage) PutShard(ctx context.Context, s *shard.Shard) (bool, error)
 		}
 	}
 
-	// Populate caches only after everything is persisted; caching earlier
-	// would make a retry skip the objects that failed to write.
-	ss.shardMut.Lock()
-	ss.shardIndex.Add(shardHash, s)
-	ss.shardMut.Unlock()
-	for _, file := range s.Files {
-		ss.fileMut.Lock()
-		ss.fileIndex.Add(file.FileHash, shardHash)
-		ss.fileMut.Unlock()
-	}
-
 	return wasInserted, nil
 }
 
@@ -542,14 +534,26 @@ func (ss *S3Storage) getShardByHash(ctx context.Context, shardHash string) (*sha
 		return value.(*shard.Shard), nil
 	}
 
-	body, err := ss.getObjectReader(ctx, ss.objectKey("shards", shardHash))
+	out, err := ss.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(ss.bucket),
+		Key:    aws.String(ss.objectKey("shards", shardHash)),
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer body.Close()
-	s := shard.NewShard()
-	if err := s.Decode(body, true); err != nil {
+	defer out.Body.Close()
+	s, err := decodeStoredShard(out.Body)
+	if err != nil {
 		return nil, err
+	}
+	if s.Footer == nil {
+		// xet-core prunes cached dedup shards oldest-first by the footer creation
+		// time, so pin it to the ingest time instead of the first-serve time.
+		creationTime := time.Now()
+		if out.LastModified != nil {
+			creationTime = *out.LastModified
+		}
+		s.SetFooter(creationTime)
 	}
 
 	ss.shardMut.Lock()

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -178,6 +181,100 @@ func putTestShard(t *testing.T, ctx context.Context, ss *S3Storage, parts [][]by
 	fileBlock.FileHash = fileHash
 	shardObj.AddFile(fileBlock)
 	return shardObj, fileHash
+}
+
+// newIndexedShard returns a shard with one file and one CAS block.
+func newIndexedShard(fileHash xet.FileHash) *shard.Shard {
+	s := shard.NewShard()
+	s.AddFile(shard.FileBlock{FileHash: fileHash})
+	s.AddCASBlock(shard.CASBlock{
+		CASHash: xet.XorbHash{2},
+		Chunks:  []shard.CASChunkSequenceEntry{{ChunkHash: xet.ChunkHash{3}}},
+	})
+	return s
+}
+
+// shardObjectKey returns the single stored shard key.
+func shardObjectKey(t *testing.T, ss *S3Storage) string {
+	t.Helper()
+	var found string
+	for key := range listObjectKeys(t, ss) {
+		if !strings.Contains(key, "shards/") {
+			continue
+		}
+		if found != "" {
+			t.Fatalf("more than one shard object: %q and %q", found, key)
+		}
+		found = key
+	}
+	if found == "" {
+		t.Fatal("no shard object stored")
+	}
+	return found
+}
+
+// TestS3ShardNameIsDeterministicContentHash mirrors the FileStorage assertion:
+// the object name is the SHA-256 of the stored bytes and does not vary with the
+// creation time embedded in the (unstored) footer.
+func TestS3ShardNameIsDeterministicContentHash(t *testing.T) {
+	ctx := context.Background()
+
+	var names []string
+	for _, creationTime := range []uint64{1, 1 << 30} {
+		ss := newTestS3Storage(t)
+		s := newIndexedShard(xet.FileHash{1})
+		s.SetFooter(time.Unix(int64(creationTime), 0))
+		if inserted, err := ss.PutShard(ctx, s); err != nil || !inserted {
+			t.Fatalf("PutShard() = %v, %v", inserted, err)
+		}
+
+		key := shardObjectKey(t, ss)
+		data, err := ss.getObject(ctx, key)
+		if err != nil {
+			t.Fatalf("read stored shard: %v", err)
+		}
+		if footerSize := binary.LittleEndian.Uint64(data[40:48]); footerSize != 0 {
+			t.Fatalf("stored FooterSize = %d, want 0", footerSize)
+		}
+		name := strings.ReplaceAll(strings.TrimPrefix(key, "shards/"), "/", "")
+		sum := sha256.Sum256(data)
+		if want := hex.EncodeToString(sum[:]); name != want {
+			t.Fatalf("shard name %q != sha256 of stored bytes %q", name, want)
+		}
+		names = append(names, name)
+	}
+	if names[0] != names[1] {
+		t.Fatalf("identical content produced different names: %q vs %q", names[0], names[1])
+	}
+}
+
+// TestS3FooteredShardObjectStaysReadable covers objects written before shards
+// went footerless.
+func TestS3FooteredShardObjectStaysReadable(t *testing.T) {
+	ctx := context.Background()
+	ss := newTestS3Storage(t)
+
+	fileHash := xet.FileHash{7}
+	const creationTime = 1700000000
+	data, name := legacyShardBytes(t, newIndexedShard(fileHash), creationTime)
+
+	if err := ss.putObject(ctx, ss.objectKey("shards", name), bytes.NewReader(data)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ss.putIndexObject(ctx, ss.objectKey("index/files", fileHash.String()), []byte(name)); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := ss.GetShard(ctx, fileHash)
+	if err != nil {
+		t.Fatalf("GetShard on a footered object: %v", err)
+	}
+	if loaded.Files[0].FileHash != fileHash {
+		t.Fatal("loaded the wrong shard")
+	}
+	if loaded.Footer == nil || loaded.Footer.ShardCreationTimestamp != creationTime {
+		t.Fatalf("stored footer was not preserved: %+v", loaded.Footer)
+	}
 }
 
 func TestS3StorageShardRoundTrip(t *testing.T) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,8 +1,10 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -35,7 +37,7 @@ type Storage interface {
 	// GetXorbDataRange returns the byte range within the stored xorb for the given chunk range
 	GetXorbDataRange(ctx context.Context, namespace string, xorbHash xet.XorbHash, chunkStart, chunkEnd uint32) (startByte, endByte int64, err error)
 
-	// PutShard stores a shard by its hash
+	// PutShard stores a shard, named by the SHA-256 of its stored bytes
 	PutShard(ctx context.Context, shard *shard.Shard) (bool, error)
 
 	// GetShard retrieves a shard by file hash
@@ -236,6 +238,24 @@ func (fs *FileStorage) getShard(fileHash xet.FileHash) (*shard.Shard, error) {
 	return fs.getShardByHash(shardHash)
 }
 
+// shardHeaderSize is the fixed shard header; its last 8 bytes carry FooterSize.
+const shardHeaderSize = 48
+
+// decodeStoredShard decodes a stored shard object, following the FooterSize its
+// header declares so objects written before shards went footerless still load.
+func decodeStoredShard(r io.Reader) (*shard.Shard, error) {
+	var header [shardHeaderSize]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, fmt.Errorf("read shard header: %w", err)
+	}
+	s := shard.NewShard()
+	withFooter := binary.LittleEndian.Uint64(header[40:]) != 0
+	if err := s.Decode(io.MultiReader(bytes.NewReader(header[:]), r), withFooter); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
 func (fs *FileStorage) getShardByHash(shardHash string) (*shard.Shard, error) {
 	fs.shardMut.Lock()
 	value, exists := fs.shardIndex.Get(shardHash)
@@ -250,9 +270,18 @@ func (fs *FileStorage) getShardByHash(shardHash string) (*shard.Shard, error) {
 		return nil, err
 	}
 	defer f.Close()
-	s := shard.NewShard()
-	if err := s.Decode(f, true); err != nil {
+	s, err := decodeStoredShard(f)
+	if err != nil {
 		return nil, err
+	}
+	if s.Footer == nil {
+		info, err := f.Stat()
+		if err != nil {
+			return nil, fmt.Errorf("stat shard file: %w", err)
+		}
+		// xet-core prunes cached dedup shards oldest-first by the footer creation
+		// time, so pin it to the ingest time instead of the first-serve time.
+		s.SetFooter(info.ModTime())
 	}
 
 	fs.shardMut.Lock()
@@ -373,9 +402,10 @@ func (fs *FileStorage) PutShard(ctx context.Context, s *shard.Shard) (bool, erro
 		s.Files[i].Flags |= shard.FileWithMetadataExt
 	}
 
-	// Serialize the shard first, then hash those exact persisted bytes. The
-	// shard object is addressed by this hash rather than by any contained file.
-	r, err := s.Encode(true)
+	// Serialize without the footer (it embeds a creation timestamp), so the
+	// stored bytes — and the sha256 hash addressing them — are deterministic
+	// for identical shard content.
+	r, err := s.Encode(false)
 	if err != nil {
 		return false, fmt.Errorf("serialize shard: %w", err)
 	}
@@ -429,14 +459,11 @@ func (fs *FileStorage) PutShard(ctx context.Context, s *shard.Shard) (bool, erro
 		removeTemp = false
 	}
 
+	// Nothing is cached here: the read path populates the caches from the
+	// stored objects, so a warm process serves exactly what a restarted one
+	// would.
 	shardHashData := []byte(shardHash)
-	fs.shardMut.Lock()
-	fs.shardIndex.Add(shardHash, s)
-	fs.shardMut.Unlock()
 	for _, file := range s.Files {
-		fs.fileMut.Lock()
-		fs.fileIndex.Add(file.FileHash, shardHash)
-		fs.fileMut.Unlock()
 		indexPath := fs.objectPath("index/files", file.FileHash.String())
 		if err := writeIndexFile(indexPath, shardHashData); err != nil {
 			return wasInserted, fmt.Errorf("write file index for file %s: %w", file.FileHash.String(), err)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -3,15 +3,130 @@ package storage
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/wzshiming/xet"
 	"github.com/wzshiming/xet/shard"
 	"github.com/wzshiming/xet/xorb"
 )
+
+// TestShardNameIsDeterministicContentHash proves the stored object name is the
+// SHA-256 of the exact stored bytes and does not vary with the creation time
+// embedded in the (unstored) footer.
+func TestShardNameIsDeterministicContentHash(t *testing.T) {
+	newIdenticalShard := func(creationTime uint64) *shard.Shard {
+		s := shard.NewShard()
+		s.AddFile(shard.FileBlock{FileHash: xet.FileHash{1}})
+		s.AddCASBlock(shard.CASBlock{
+			CASHash: xet.XorbHash{2},
+			Chunks:  []shard.CASChunkSequenceEntry{{ChunkHash: xet.ChunkHash{3}}},
+		})
+		s.SetFooter(time.Unix(int64(creationTime), 0))
+		return s
+	}
+
+	var names []string
+	for _, creationTime := range []uint64{1, 1 << 30} {
+		basePath := t.TempDir()
+		st, err := NewFileStorage(WithBasePath(basePath))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if inserted, err := st.PutShard(context.Background(), newIdenticalShard(creationTime)); err != nil || !inserted {
+			t.Fatalf("PutShard() = %v, %v", inserted, err)
+		}
+		entries, err := fanoutEntries(filepath.Join(basePath, "shards"))
+		if err != nil {
+			t.Fatalf("read shards directory: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("shards directory contains %d entries, want 1", len(entries))
+		}
+		name := entries[0]
+		data, err := os.ReadFile(st.objectPath("shards", name))
+		if err != nil {
+			t.Fatalf("read stored shard: %v", err)
+		}
+		if footerSize := binary.LittleEndian.Uint64(data[40:48]); footerSize != 0 {
+			t.Fatalf("stored FooterSize = %d, want 0", footerSize)
+		}
+		sum := sha256.Sum256(data)
+		if want := hex.EncodeToString(sum[:]); name != want {
+			t.Fatalf("shard name %q != sha256 of stored bytes %q", name, want)
+		}
+		names = append(names, name)
+	}
+	if names[0] != names[1] {
+		t.Fatalf("identical content produced different names: %q vs %q", names[0], names[1])
+	}
+}
+
+// legacyShardBytes serializes a shard the way it was stored before shard
+// objects went footerless, and returns the bytes with their object name.
+func legacyShardBytes(t *testing.T, s *shard.Shard, creationTime uint64) ([]byte, string) {
+	t.Helper()
+	s.SetFooter(time.Unix(int64(creationTime), 0))
+	r, err := s.Encode(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(data)
+	return data, hex.EncodeToString(sum[:])
+}
+
+// TestFooteredShardObjectStaysReadable covers objects written before shards
+// went footerless: they must keep resolving, with their stored footer intact.
+func TestFooteredShardObjectStaysReadable(t *testing.T) {
+	basePath := t.TempDir()
+	fs, err := NewFileStorage(WithBasePath(basePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fileHash := xet.FileHash{7}
+	s := shard.NewShard()
+	s.AddFile(shard.FileBlock{FileHash: fileHash})
+	s.AddCASBlock(shard.CASBlock{
+		CASHash: xet.XorbHash{8},
+		Chunks:  []shard.CASChunkSequenceEntry{{ChunkHash: xet.ChunkHash{9}}},
+	})
+	const creationTime = 1700000000
+	data, name := legacyShardBytes(t, s, creationTime)
+
+	shardPath := fs.objectPath("shards", name)
+	if err := os.MkdirAll(filepath.Dir(shardPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shardPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeIndexFile(fs.objectPath("index/files", fileHash.String()), []byte(name)); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := fs.GetShard(context.Background(), fileHash)
+	if err != nil {
+		t.Fatalf("GetShard on a footered object: %v", err)
+	}
+	if loaded.Files[0].FileHash != fileHash {
+		t.Fatal("loaded the wrong shard")
+	}
+	if loaded.Footer == nil || loaded.Footer.ShardCreationTimestamp != creationTime {
+		t.Fatalf("stored footer was not preserved: %+v", loaded.Footer)
+	}
+}
 
 func TestChunkIndexPersistsAndShardReloadsAfterEviction(t *testing.T) {
 	basePath := t.TempDir()
@@ -30,7 +145,7 @@ func TestChunkIndexPersistsAndShardReloadsAfterEviction(t *testing.T) {
 		CASHash: xet.XorbHash{10},
 		Chunks:  []shard.CASChunkSequenceEntry{{ChunkHash: chunkHash}},
 	})
-	s.SetFooter()
+	s.SetFooter(time.Now())
 
 	inserted, err := fs.PutShard(context.Background(), s)
 	if err != nil || !inserted {
@@ -44,14 +159,13 @@ func TestChunkIndexPersistsAndShardReloadsAfterEviction(t *testing.T) {
 		t.Fatalf("shards directory contains %d entries, want 1", len(shardHashes))
 	}
 	shardHash := shardHashes[0]
-	if cached, ok := fs.shardIndex.Get(shardHash); !ok || cached.(*shard.Shard) != s {
-		t.Fatal("shard was not added to the shard cache")
+	// Put warms no cache: the first read is what caches the shard, with the
+	// footer rebuilt from the stored object.
+	if _, ok := fs.shardIndex.Get(shardHash); ok {
+		t.Fatal("shard was added to the shard cache on put")
 	}
-	if cached, ok := fs.fileIndex.Get(secondFileHash); !ok || cached.(string) != shardHash {
-		t.Fatal("file mapping was not added to the file cache")
-	}
-	if _, ok := fs.shardIndex.Get(secondFileHash); ok {
-		t.Fatal("file hash was added to the shard cache")
+	if _, ok := fs.fileIndex.Get(secondFileHash); ok {
+		t.Fatal("file mapping was added to the file cache on put")
 	}
 
 	for _, hash := range []xet.FileHash{fileHash, secondFileHash} {
@@ -91,6 +205,13 @@ func TestChunkIndexPersistsAndShardReloadsAfterEviction(t *testing.T) {
 	}
 	if got.Files[0].FileHash != fileHash {
 		t.Fatalf("loaded wrong shard: %s", got.Files[0].FileHash.String())
+	}
+	info, err := os.Stat(fs.objectPath("shards", shardHash))
+	if err != nil {
+		t.Fatalf("stat stored shard: %v", err)
+	}
+	if got.Footer == nil || got.Footer.ShardCreationTimestamp != uint64(info.ModTime().Unix()) {
+		t.Fatalf("reloaded footer creation time not pinned to mod time: %+v", got.Footer)
 	}
 	if cached, ok := fs.chunkIndex.Get(chunkHash); !ok || cached.(string) != shardHash {
 		t.Fatal("chunk index was not added to the LRU cache")


### PR DESCRIPTION
Shard objects were named by the SHA-256 of their encoded bytes with the footer included. `SetFooter` embeds `time.Now()`, so identical shard content stored at different times produced different object names — the store was not content-addressed, and a re-upload after an unlink left an orphaned duplicate under a second name.

## Changes

- `PutShard` (FileStorage and S3) serializes with `Encode(false)`: the stored bytes carry no footer, and the object name is the SHA-256 of exactly those bytes — deterministic for identical content, and `sha256sum <object>` now equals the name.
- Dedup responses still carry a footer: the read path rebuilds it when loading a shard, pinning the creation time to the stored object's mod time (`LastModified` on S3). xet-core prunes its local dedup-shard cache oldest-first by that timestamp, so it tracks ingest time rather than the server's cache-load time. `SetFooter` now takes that time as an argument instead of stamping `time.Now()` and having callers patch it afterwards.
- `PutShard` warms no in-memory cache. Caching a shard it never read back would serve a footer stamped with the upload time rather than the object's, and the same reasoning applies to the file mapping, so both are left to the read path — a warm process then serves exactly what a restarted one would.
- `Encode` no longer writes through to the shard. It used to set `FooterSize` and the footer offsets on the receiver, so two dedup queries serving the same cached shard raced on shared fields; both now live in the reader.
- `index/sha256` and the bridge lookups are unchanged.

## Compatibility

No migration. The shard header carries `FooterSize`, so the read path decodes each stored object according to what it declares and only rebuilds a footer for objects that have none. Shards written before this keep resolving, byte-identical, with their original creation timestamp. The shard package's `Decode(r, withFooter)` keeps its strict xet-core semantics; the adaptation lives in the storage read path.

## Verification

- `TestShardNameIsDeterministicContentHash` (FileStorage) and `TestS3ShardNameIsDeterministicContentHash`: stored bytes have `FooterSize == 0`, the name equals the SHA-256 of the stored bytes, and different footer creation timestamps yield the same name.
- `TestFooteredShardObjectStaysReadable` and its S3 twin: an object written the old way still resolves through `GetShard` and keeps its stored footer.
- Reload assertion: a shard loaded from disk carries a footer creation time equal to the stored object's mod time, and `PutShard` leaves both caches empty.
- `TestEncodeLeavesShardUnmodified` and `TestEncodeIsConcurrencySafe` cover the serve path.
- Full `go test ./...` passes, and `-race` over `./shard/... ./storage/...`.
