### PR TITLE
feat: list stored files grouped by SHA-256 on /internal/files

### DIFF
--- a/cmd/xetd/main.go
+++ b/cmd/xetd/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wzshiming/xet/client"
 	"github.com/wzshiming/xet/mirror"
 	"github.com/wzshiming/xet/server"
+	"github.com/wzshiming/xet/server/internalapi"
 	"github.com/wzshiming/xet/storage"
 	"github.com/wzshiming/xet/token"
 )
@@ -23,6 +24,7 @@ func main() {
 	storageDir := flag.String("storage", "./xet-data", "Storage directory for xorbs and shards")
 	baseURL := flag.String("base-url", "", "Base URL for serving xorb data (optional)")
 	authToken := flag.String("token", "", "Authentication token; also the secret for minted short-lived tokens (optional, if set, clients must provide this token or a minted one)")
+	internalAPI := flag.Bool("internal", false, "Enable unauthenticated internal management endpoints under /internal/ (use only on trusted networks)")
 	upstream := flag.String("upstream", "", "Upstream hub URL to mirror, e.g. https://huggingface.co (enables mirror mode)")
 	upstreamToken := flag.String("upstream-token", "", "Bearer token the mirror uses against the upstream hub")
 	s3Bucket := flag.String("s3-bucket", "", "S3 bucket for xorbs and shards (enables S3 storage; credentials come from the standard AWS config chain)")
@@ -128,6 +130,16 @@ func main() {
 		server.WithAuthFunc(authFn),
 		server.WithNext(next),
 	)
+
+	if *internalAPI {
+		// Internal management endpoints sit in front of the CAS routes and
+		// bypass authentication.
+		next = internalapi.NewHandler(
+			internalapi.WithStorage(stor),
+			internalapi.WithNext(next),
+		)
+		fmt.Println("Internal management endpoints enabled at /internal/")
+	}
 
 	next = handlers.CombinedLoggingHandler(os.Stdout, next)
 

--- a/server/internalapi/internalapi.go
+++ b/server/internalapi/internalapi.go
@@ -1,0 +1,78 @@
+// Package internalapi serves internal management endpoints that are not
+// part of the CAS protocol surface.
+package internalapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/wzshiming/xet/storage"
+)
+
+// Handler serves the internal management endpoints.
+type Handler struct {
+	storage storage.Storage
+	root    *mux.Router
+	next    http.Handler
+}
+
+// Option defines a functional option for configuring the Handler.
+type Option func(*Handler)
+
+// WithStorage sets the storage backend for the internal endpoints.
+func WithStorage(storage storage.Storage) Option {
+	return func(h *Handler) {
+		h.storage = storage
+	}
+}
+
+// WithNext sets the next http.Handler to call if a request does not match any internal route.
+func WithNext(next http.Handler) Option {
+	return func(h *Handler) {
+		h.next = next
+	}
+}
+
+// NewHandler creates a handler for the internal management endpoints.
+func NewHandler(opts ...Option) *Handler {
+	h := &Handler{
+		root: mux.NewRouter(),
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	h.registerRoutes()
+	return h
+}
+
+// registerRoutes sets up all internal HTTP routes.
+func (h *Handler) registerRoutes() {
+	h.root.HandleFunc("/internal/files", h.handleListFiles).Methods(http.MethodGet)
+
+	h.root.NotFoundHandler = h.next
+}
+
+// ServeHTTP implements http.Handler
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.root.ServeHTTP(w, r)
+}
+
+// handleListFiles handles GET /internal/files: all stored files grouped by
+// content SHA-256, each carrying its xet file hashes and original size.
+func (h *Handler) handleListFiles(w http.ResponseWriter, r *http.Request) {
+	ls, ok := h.storage.(storage.ListStore)
+	if !ok {
+		http.Error(w, "Storage does not support file listing", http.StatusNotImplemented)
+		return
+	}
+	entries, err := storage.ListFiles(r.Context(), ls)
+	if err != nil {
+		http.Error(w, "Failed to list files: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(entries)
+}

--- a/server/internalapi/internalapi_test.go
+++ b/server/internalapi/internalapi_test.go
@@ -1,0 +1,104 @@
+package internalapi
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/shard"
+	"github.com/wzshiming/xet/storage"
+	"github.com/wzshiming/xet/xorb"
+)
+
+func TestListFilesEndpoint(t *testing.T) {
+	ctx := context.Background()
+	stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := []byte("internal file listing content")
+	var encoded bytes.Buffer
+	encoder := xorb.NewEncoder(&encoded, true)
+	if _, err := encoder.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatal(err)
+	}
+	xorbHash := encoder.SummoryHash()
+	if _, err := stor.PutXorb(ctx, "default", xorbHash, bytes.NewReader(encoded.Bytes())); err != nil {
+		t.Fatal(err)
+	}
+	chunkHash := xet.ComputeChunkHash(content)
+	fileHash := xet.ComputeFileHash([]xet.ChunkHash{chunkHash}, []uint64{uint64(len(content))})
+	shardObj := shard.NewShard()
+	shardObj.AddCASBlock(shard.CASBlock{
+		CASHash: xorbHash,
+		Chunks:  []shard.CASChunkSequenceEntry{{ChunkHash: chunkHash, UnpackedSegBytes: uint32(len(content))}},
+	})
+	shardObj.AddFile(shard.FileBlock{
+		FileHash: fileHash,
+		Entries: []shard.FileDataSequenceEntry{
+			{CASHash: xorbHash, UnpackedSegBytes: uint32(len(content)), ChunkIndexEnd: 1},
+		},
+	})
+	if _, err := stor.PutShard(ctx, shardObj); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewHandler(WithStorage(stor))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/internal/files", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	var entries []storage.FileListEntry
+	if err := json.NewDecoder(rec.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	digest := sha256.Sum256(content)
+	want := []storage.FileListEntry{{
+		SHA256:       hex.EncodeToString(digest[:]),
+		FileHashes:   []string{fileHash.String()},
+		OriginalSize: uint64(len(content)),
+	}}
+	if len(entries) != 1 || entries[0].SHA256 != want[0].SHA256 ||
+		len(entries[0].FileHashes) != 1 || entries[0].FileHashes[0] != want[0].FileHashes[0] ||
+		entries[0].OriginalSize != want[0].OriginalSize || entries[0].Missing {
+		t.Fatalf("entries = %+v, want %+v", entries, want)
+	}
+}
+
+// listlessStorage implements storage.Storage but not storage.ListStore.
+type listlessStorage struct{ storage.Storage }
+
+func TestListFilesEndpointNotImplemented(t *testing.T) {
+	handler := NewHandler(WithStorage(listlessStorage{}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/internal/files", nil))
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotImplemented)
+	}
+}
+
+func TestHandlerFallsThroughToNext(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	handler := NewHandler(WithNext(next))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/shards", nil))
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusTeapot)
+	}
+}

--- a/storage/list_files.go
+++ b/storage/list_files.go
@@ -1,0 +1,323 @@
+package storage
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	iofs "io/fs"
+	"slices"
+	"sync"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/shard"
+	"github.com/wzshiming/xet/xorb"
+	"golang.org/x/sync/errgroup"
+)
+
+// FileListEntry describes one stored content: every xet file hash that
+// reconstructs the same bytes, keyed by the SHA-256 recorded at ingest.
+type FileListEntry struct {
+	// SHA256 is the hex content digest; empty for empty files (stored with
+	// an all-zero marker) and for entries whose owning shard is missing.
+	SHA256 string `json:"sha256,omitempty"`
+	// FileHashes are the xet file hashes resolving to this content; one
+	// SHA-256 can map to several since the xet hash depends on chunking.
+	FileHashes []string `json:"file_hashes"`
+	// OriginalSize is the original file size in bytes, counted once per entry.
+	OriginalSize uint64 `json:"original_size"`
+	// UniqueSize is the stored (compressed) bytes referenced only by this
+	// entry, i.e. what deleting it would free: exact per-chunk packed sizes
+	// including chunk headers. Per-xorb footer bytes are not attributed and
+	// chunks whose xorb has vanished contribute nothing.
+	UniqueSize uint64 `json:"unique_size"`
+	// SharedSize is the stored bytes this entry shares with other entries;
+	// overlapping bytes are attributed to every sharing entry.
+	SharedSize uint64 `json:"shared_size"`
+	// Missing marks entries that no longer resolve to stored data: the
+	// owning shard is gone or its chunk metadata is invalid.
+	Missing bool `json:"missing,omitempty"`
+}
+
+// ListStore is the thin per-backend surface needed to enumerate stored
+// files; the aggregation lives in ListFiles.
+type ListStore interface {
+	// WalkFileIndex calls fn for every index/files entry, passing the hex
+	// file hash and the owning shard hash.
+	WalkFileIndex(ctx context.Context, fn func(fileHash, shardHash string) error) error
+
+	// GetShardByHash loads a stored shard by the hash of its serialized
+	// bytes; the error wraps fs.ErrNotExist when the shard is absent.
+	GetShardByHash(ctx context.Context, shardHash string) (*shard.Shard, error)
+
+	// GetXorbChunkOffsets returns the xorb's chunk offset table: the
+	// cumulative packed end-offset of every chunk in the stored xorb.
+	GetXorbChunkOffsets(ctx context.Context, xorbHash xet.XorbHash) ([]uint64, error)
+}
+
+// listFilesConcurrency bounds parallel shard and xorb offset-table reads
+// while building the listing.
+const listFilesConcurrency = 4
+
+// chunkRange is one reconstruction term: chunks [start, end) of one xorb.
+type chunkRange struct {
+	hash       xet.XorbHash
+	start, end uint32
+}
+
+// ListFiles enumerates every file recorded in the file index, grouped by
+// content: one entry per SHA-256 carrying all file hashes that map to it.
+// The result is deterministically sorted and never nil.
+func ListFiles(ctx context.Context, st ListStore) ([]FileListEntry, error) {
+	// Group by shard first so each shard is loaded exactly once and can be
+	// released after its group; only the flattened terms are retained.
+	byShard := map[string][]string{} // shard hash -> file hashes
+	err := st.WalkFileIndex(ctx, func(fileHash, shardHash string) error {
+		byShard[shardHash] = append(byShard[shardHash], fileHash)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve shard groups in parallel; the SHA-256 grouping below stays
+	// sequential so it needs no locks.
+	shardHashes := make([]string, 0, len(byShard))
+	for shardHash := range byShard {
+		shardHashes = append(shardHashes, shardHash)
+	}
+	resolved := make([][]resolvedFile, len(shardHashes))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(listFilesConcurrency)
+	for i, shardHash := range shardHashes {
+		g.Go(func() error {
+			files, err := resolveShardFiles(gctx, st, shardHash, byShard[shardHash])
+			if err != nil {
+				return err
+			}
+			resolved[i] = files
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	entries := []FileListEntry{}
+	var entryTerms [][]chunkRange // parallel to entries
+	bySHA256 := map[string]int{}  // sha256 -> index in entries
+	for _, files := range resolved {
+		for _, rf := range files {
+			if rf.missing {
+				entries = append(entries, FileListEntry{FileHashes: []string{rf.fileHash}, Missing: true})
+				entryTerms = append(entryTerms, nil)
+				continue
+			}
+			if rf.sha == "" {
+				entries = append(entries, FileListEntry{FileHashes: []string{rf.fileHash}, OriginalSize: rf.size})
+				entryTerms = append(entryTerms, rf.terms)
+				continue
+			}
+			if i, ok := bySHA256[rf.sha]; ok {
+				entries[i].FileHashes = append(entries[i].FileHashes, rf.fileHash)
+				entryTerms[i] = append(entryTerms[i], rf.terms...)
+				continue
+			}
+			bySHA256[rf.sha] = len(entries)
+			entries = append(entries, FileListEntry{SHA256: rf.sha, FileHashes: []string{rf.fileHash}, OriginalSize: rf.size})
+			entryTerms = append(entryTerms, rf.terms)
+		}
+	}
+
+	if err := computeStoredSizes(ctx, st, entries, entryTerms); err != nil {
+		return nil, err
+	}
+
+	for i := range entries {
+		slices.Sort(entries[i].FileHashes)
+	}
+	slices.SortFunc(entries, func(a, b FileListEntry) int {
+		if c := cmp.Compare(b.OriginalSize, a.OriginalSize); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.SHA256, b.SHA256); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.FileHashes[0], b.FileHashes[0])
+	})
+	return entries, nil
+}
+
+// resolvedFile is one file-index entry resolved against its owning shard:
+// the flattened reconstruction terms plus the grouping metadata.
+type resolvedFile struct {
+	fileHash string
+	sha      string
+	size     uint64
+	terms    []chunkRange
+	missing  bool
+}
+
+// resolveShardFiles loads one shard and resolves its file-index entries; a
+// missing shard is not an error, its files come back marked missing, as do
+// files whose chunk metadata is out of bounds.
+func resolveShardFiles(ctx context.Context, st ListStore, shardHash string, fileHashes []string) ([]resolvedFile, error) {
+	sh, err := st.GetShardByHash(ctx, shardHash)
+	if err != nil {
+		if !errors.Is(err, iofs.ErrNotExist) {
+			return nil, err
+		}
+		sh = nil
+	}
+	var blocks map[xet.FileHash]*shard.FileBlock
+	if sh != nil {
+		blocks = make(map[xet.FileHash]*shard.FileBlock, len(sh.Files))
+		for i := range sh.Files {
+			blocks[sh.Files[i].FileHash] = &sh.Files[i]
+		}
+	}
+	files := make([]resolvedFile, 0, len(fileHashes))
+	for _, fileHash := range fileHashes {
+		var file *shard.FileBlock
+		if want, err := xet.ParseFileHash(fileHash); err == nil {
+			file = blocks[want]
+		}
+		if file == nil {
+			files = append(files, resolvedFile{fileHash: fileHash, missing: true})
+			continue
+		}
+		rf := resolvedFile{fileHash: fileHash, terms: make([]chunkRange, 0, len(file.Entries))}
+		valid := true
+		for _, entry := range file.Entries {
+			// Dedup terms escape shard-ingest validation, so bound the chunk
+			// index here before it sizes per-chunk usage arrays.
+			if entry.ChunkIndexEnd > xet.MaxChunksPerXorb {
+				valid = false
+				break
+			}
+			rf.size += uint64(entry.UnpackedSegBytes)
+			if entry.ChunkIndexEnd > entry.ChunkIndexStart {
+				rf.terms = append(rf.terms, chunkRange{hash: entry.CASHash, start: entry.ChunkIndexStart, end: entry.ChunkIndexEnd})
+			}
+		}
+		if !valid {
+			files = append(files, resolvedFile{fileHash: fileHash, missing: true})
+			continue
+		}
+		// The all-zero digest is the empty-file marker, not a real SHA-256,
+		// so those entries stay ungrouped.
+		if file.MetadataExt != nil && file.MetadataExt.SHA256Hash != (shard.SHA256Hash{}) {
+			rf.sha = file.MetadataExt.SHA256Hash.String()
+		}
+		files = append(files, rf)
+	}
+	return files, nil
+}
+
+// xorbUsage tracks, per chunk of one xorb, how many entries reference it and
+// the last entry counted (for per-entry dedup).
+type xorbUsage struct {
+	distinct []uint32
+	last     []int32
+}
+
+func (u *xorbUsage) grow(n int) {
+	for len(u.last) < n {
+		u.distinct = append(u.distinct, 0)
+		u.last = append(u.last, -1)
+	}
+}
+
+// computeStoredSizes fills UniqueSize and SharedSize on every entry with the
+// exact stored bytes of each referenced chunk. Every referenced xorb's chunk
+// offset table is fetched once, in parallel (the same cached table
+// reconstruction uses; footer-less xorbs cost a one-time header scan), then
+// all range math is local. Chunk reference counts across entries decide
+// unique vs shared; consecutive chunks with the same classification are
+// coalesced into one range. Chunks whose xorb is gone or inconsistent with
+// the shard contribute nothing.
+func computeStoredSizes(ctx context.Context, st ListStore, entries []FileListEntry, entryTerms [][]chunkRange) error {
+	usage := map[xet.XorbHash]*xorbUsage{}
+	for e := range entries {
+		for _, term := range entryTerms[e] {
+			u := usage[term.hash]
+			if u == nil {
+				u = &xorbUsage{}
+				usage[term.hash] = u
+			}
+			u.grow(int(term.end))
+			for k := term.start; k < term.end; k++ {
+				if u.last[k] != int32(e) {
+					u.last[k] = int32(e)
+					u.distinct[k]++
+				}
+			}
+		}
+	}
+	// Fetch every referenced xorb's offset table once, in parallel.
+	offsets := make(map[xet.XorbHash][]uint64, len(usage))
+	var offsetsMut sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(listFilesConcurrency)
+	for hash := range usage {
+		g.Go(func() error {
+			offs, err := st.GetXorbChunkOffsets(gctx, hash)
+			if err != nil {
+				// A vanished xorb has no stored bytes to attribute.
+				if errors.Is(err, iofs.ErrNotExist) {
+					return nil
+				}
+				return fmt.Errorf("chunk offsets of xorb %s: %w", hash.String(), err)
+			}
+			offsetsMut.Lock()
+			offsets[hash] = offs
+			offsetsMut.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	for _, u := range usage {
+		for k := range u.last {
+			u.last[k] = -1
+		}
+	}
+	for e := range entries {
+		var unique, shared uint64
+		for _, term := range entryTerms[e] {
+			// Skip terms the stored xorb cannot satisfy (vanished or shorter
+			// than the shard claims); their stored bytes are unknown.
+			if uint64(term.end) > uint64(len(offsets[term.hash])) {
+				continue
+			}
+			u := usage[term.hash]
+			for k := term.start; k < term.end; {
+				if u.last[k] == int32(e) {
+					k++
+					continue
+				}
+				sharedRun := u.distinct[k] > 1
+				runEnd := k
+				for runEnd < term.end && u.last[runEnd] != int32(e) && (u.distinct[runEnd] > 1) == sharedRun {
+					u.last[runEnd] = int32(e)
+					runEnd++
+				}
+				start, end, err := xorb.ChunkDataRangeFromOffsets(offsets[term.hash], k, runEnd)
+				if err != nil {
+					return fmt.Errorf("stored size of xorb %s chunks [%d,%d): %w", term.hash.String(), k, runEnd, err)
+				}
+				if sharedRun {
+					shared += uint64(end - start + 1)
+				} else {
+					unique += uint64(end - start + 1)
+				}
+				k = runEnd
+			}
+		}
+		entries[e].UniqueSize = unique
+		entries[e].SharedSize = shared
+	}
+	return nil
+}

--- a/storage/list_files_test.go
+++ b/storage/list_files_test.go
@@ -1,0 +1,368 @@
+package storage
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	iofs "io/fs"
+	"math"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/shard"
+	"github.com/wzshiming/xet/xorb"
+)
+
+// sortEntries orders expectations the way ListFiles sorts its result:
+// original size descending, then SHA-256, then first file hash.
+func sortEntries(entries []FileListEntry) {
+	slices.SortFunc(entries, func(a, b FileListEntry) int {
+		if c := cmp.Compare(b.OriginalSize, a.OriginalSize); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.SHA256, b.SHA256); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.FileHashes[0], b.FileHashes[0])
+	})
+}
+
+type listBackend struct {
+	name          string
+	newStore      func(t *testing.T) Storage
+	writeDangling func(t *testing.T, st Storage, fileHash, shardHash string)
+}
+
+func listBackends() []listBackend {
+	return []listBackend{
+		{
+			name: "file",
+			newStore: func(t *testing.T) Storage {
+				st, err := NewFileStorage(WithBasePath(t.TempDir()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return st
+			},
+			writeDangling: func(t *testing.T, st Storage, fileHash, shardHash string) {
+				fs := st.(*FileStorage)
+				if err := writeIndexFile(fs.objectPath("index/files", fileHash), []byte(shardHash)); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "s3",
+			newStore: func(t *testing.T) Storage {
+				return newTestS3Storage(t)
+			},
+			writeDangling: func(t *testing.T, st Storage, fileHash, shardHash string) {
+				ss := st.(*S3Storage)
+				if err := ss.putIndexObject(context.Background(), ss.objectKey("index/files", fileHash), []byte(shardHash)); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+}
+
+// putListedFile stores one file chunked as parts (one single-chunk xorb per
+// part) and returns its hex file hash together with the exact stored size of
+// its chunks (a footer-less encode of each part is exactly the packed chunk
+// bytes the listing attributes).
+func putListedFile(t *testing.T, ctx context.Context, st Storage, parts [][]byte) (string, uint64) {
+	t.Helper()
+	shardObj := shard.NewShard()
+	fileBlock := shard.FileBlock{}
+	var chunkHashes []xet.ChunkHash
+	var chunkSizes []uint64
+	var storedSize uint64
+	for _, part := range parts {
+		var encoded bytes.Buffer
+		encoder := xorb.NewEncoder(&encoded, true)
+		if _, err := encoder.Write(part); err != nil {
+			t.Fatal(err)
+		}
+		if err := encoder.Close(); err != nil {
+			t.Fatal(err)
+		}
+		xorbHash := encoder.SummoryHash()
+		if _, err := st.PutXorb(ctx, "default", xorbHash, bytes.NewReader(encoded.Bytes())); err != nil {
+			t.Fatal(err)
+		}
+		var chunkOnly bytes.Buffer
+		bare := xorb.NewEncoder(&chunkOnly, false)
+		if _, err := bare.Write(part); err != nil {
+			t.Fatal(err)
+		}
+		if err := bare.Close(); err != nil {
+			t.Fatal(err)
+		}
+		storedSize += uint64(chunkOnly.Len())
+		chunkHash := xet.ComputeChunkHash(part)
+		chunkHashes = append(chunkHashes, chunkHash)
+		chunkSizes = append(chunkSizes, uint64(len(part)))
+		fileBlock.Entries = append(fileBlock.Entries, shard.FileDataSequenceEntry{
+			CASHash: xorbHash, UnpackedSegBytes: uint32(len(part)), ChunkIndexEnd: 1,
+		})
+		shardObj.AddCASBlock(shard.CASBlock{
+			CASHash: xorbHash,
+			Chunks:  []shard.CASChunkSequenceEntry{{ChunkHash: chunkHash, UnpackedSegBytes: uint32(len(part))}},
+		})
+	}
+	fileHash := xet.ComputeFileHash(chunkHashes, chunkSizes)
+	fileBlock.FileHash = fileHash
+	shardObj.AddFile(fileBlock)
+	if _, err := st.PutShard(ctx, shardObj); err != nil {
+		t.Fatal(err)
+	}
+	return fileHash.String(), storedSize
+}
+
+// TestListFilesGroupsBySHA256 proves that identical content chunked two
+// different ways (two xet file hashes) collapses into one entry whose size is
+// counted once, while empty files stay ungrouped with no SHA-256.
+func TestListFilesGroupsBySHA256(t *testing.T) {
+	for _, backend := range listBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := backend.newStore(t)
+
+			content := []byte("same content, two different chunkings")
+			other := []byte("a different file")
+
+			oneChunk, oneStored := putListedFile(t, ctx, st, [][]byte{content})
+			twoChunks, twoStored := putListedFile(t, ctx, st, [][]byte{content[:11], content[11:]})
+			otherHash, otherStored := putListedFile(t, ctx, st, [][]byte{other})
+
+			emptyHash := xet.FileHash{42}
+			emptyShard := shard.NewShard()
+			emptyShard.AddFile(shard.FileBlock{FileHash: emptyHash})
+			if _, err := st.PutShard(ctx, emptyShard); err != nil {
+				t.Fatalf("PutShard(empty file): %v", err)
+			}
+
+			got, err := ListFiles(ctx, st.(ListStore))
+			if err != nil {
+				t.Fatalf("ListFiles: %v", err)
+			}
+
+			contentSHA := sha256.Sum256(content)
+			otherSHA := sha256.Sum256(other)
+			grouped := []string{oneChunk, twoChunks}
+			slices.Sort(grouped)
+			// Both chunkings are stored, so the group's unique bytes count the
+			// stored chunks of both.
+			want := []FileListEntry{
+				{FileHashes: []string{emptyHash.String()}},
+				{SHA256: hex.EncodeToString(contentSHA[:]), FileHashes: grouped, OriginalSize: uint64(len(content)), UniqueSize: oneStored + twoStored},
+				{SHA256: hex.EncodeToString(otherSHA[:]), FileHashes: []string{otherHash}, OriginalSize: uint64(len(other)), UniqueSize: otherStored},
+			}
+			sortEntries(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("ListFiles() = %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+// TestListFilesMarksDanglingEntries covers file-index entries whose shard is
+// gone: they stay listed, flagged missing, with no SHA-256 or size.
+func TestListFilesMarksDanglingEntries(t *testing.T) {
+	for _, backend := range listBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := backend.newStore(t)
+
+			content := []byte("still resolvable")
+			realHash, realStored := putListedFile(t, ctx, st, [][]byte{content})
+
+			danglingHash := strings.Repeat("ab", 32)
+			backend.writeDangling(t, st, danglingHash, strings.Repeat("cd", 32))
+
+			got, err := ListFiles(ctx, st.(ListStore))
+			if err != nil {
+				t.Fatalf("ListFiles: %v", err)
+			}
+
+			digest := sha256.Sum256(content)
+			want := []FileListEntry{
+				{FileHashes: []string{danglingHash}, Missing: true},
+				{SHA256: hex.EncodeToString(digest[:]), FileHashes: []string{realHash}, OriginalSize: uint64(len(content)), UniqueSize: realStored},
+			}
+			sortEntries(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("ListFiles() = %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+// fakeListStore serves hand-built shards and per-xorb chunk packed sizes,
+// letting the accounting tests control stored bytes without real encoding.
+type fakeListStore struct {
+	refs       [][2]string // fileHash, shardHash
+	shards     map[string]*shard.Shard
+	chunkSizes map[xet.XorbHash][]uint64 // per-chunk stored (packed) sizes
+}
+
+func (f *fakeListStore) WalkFileIndex(_ context.Context, fn func(fileHash, shardHash string) error) error {
+	for _, r := range f.refs {
+		if err := fn(r[0], r[1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeListStore) GetShardByHash(_ context.Context, shardHash string) (*shard.Shard, error) {
+	sh, ok := f.shards[shardHash]
+	if !ok {
+		return nil, iofs.ErrNotExist
+	}
+	return sh, nil
+}
+
+func (f *fakeListStore) GetXorbChunkOffsets(_ context.Context, xorbHash xet.XorbHash) ([]uint64, error) {
+	sizes, ok := f.chunkSizes[xorbHash]
+	if !ok {
+		return nil, iofs.ErrNotExist
+	}
+	offsets := make([]uint64, len(sizes))
+	var total uint64
+	for i, size := range sizes {
+		total += size
+		offsets[i] = total
+	}
+	return offsets, nil
+}
+
+// TestListFilesComputesUniqueAndShared covers the stored-size accounting: a
+// chunk referenced by two entries counts as shared for both, per-chunk sizes
+// are the exact packed bytes from the xorb offset table, and dedup'd terms
+// resolve against the xorb regardless of which shard uploaded it.
+func TestListFilesComputesUniqueAndShared(t *testing.T) {
+	xorbA := xet.XorbHash{1}
+	xorbB := xet.XorbHash{2}
+	file1 := xet.FileHash{11}
+	file2 := xet.FileHash{12}
+	sha1 := shard.NewSHA256Hash([32]byte{101})
+	sha2 := shard.NewSHA256Hash([32]byte{102})
+
+	shard1 := shard.NewShard()
+	shard1.AddFile(shard.FileBlock{
+		FileHash:    file1,
+		Entries:     []shard.FileDataSequenceEntry{{CASHash: xorbA, UnpackedSegBytes: 100, ChunkIndexEnd: 1}},
+		MetadataExt: &shard.FileMetadataExt{SHA256Hash: sha1},
+	})
+	shard1.AddCASBlock(shard.CASBlock{
+		CASHash:        xorbA,
+		Chunks:         []shard.CASChunkSequenceEntry{{UnpackedSegBytes: 100}},
+		NumBytesInCAS:  100,
+		NumBytesOnDisk: 50,
+	})
+
+	// file2 dedups its first chunk against xorbA, whose CAS block lives in shard1.
+	shard2 := shard.NewShard()
+	shard2.AddFile(shard.FileBlock{
+		FileHash: file2,
+		Entries: []shard.FileDataSequenceEntry{
+			{CASHash: xorbA, UnpackedSegBytes: 100, ChunkIndexEnd: 1},
+			{CASHash: xorbB, UnpackedSegBytes: 200, ChunkIndexEnd: 1},
+		},
+		MetadataExt: &shard.FileMetadataExt{SHA256Hash: sha2},
+	})
+	shard2.AddCASBlock(shard.CASBlock{
+		CASHash:        xorbB,
+		Chunks:         []shard.CASChunkSequenceEntry{{UnpackedSegBytes: 200}},
+		NumBytesInCAS:  200,
+		NumBytesOnDisk: 100,
+	})
+
+	st := &fakeListStore{
+		refs:   [][2]string{{file1.String(), "s1"}, {file2.String(), "s2"}},
+		shards: map[string]*shard.Shard{"s1": shard1, "s2": shard2},
+		chunkSizes: map[xet.XorbHash][]uint64{
+			xorbA: {50},
+			xorbB: {100},
+		},
+	}
+
+	got, err := ListFiles(context.Background(), st)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	want := []FileListEntry{
+		{SHA256: sha1.String(), FileHashes: []string{file1.String()}, OriginalSize: 100, UniqueSize: 0, SharedSize: 50},
+		{SHA256: sha2.String(), FileHashes: []string{file2.String()}, OriginalSize: 300, UniqueSize: 100, SharedSize: 50},
+	}
+	sortEntries(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListFiles() = %+v, want %+v", got, want)
+	}
+}
+
+// TestListFilesMarksInvalidChunkMetadata covers a dedup term whose chunk
+// index escaped shard-ingest validation: the entry is flagged missing
+// instead of sizing per-chunk usage arrays off the bogus index.
+func TestListFilesMarksInvalidChunkMetadata(t *testing.T) {
+	file1 := xet.FileHash{11}
+	sh := shard.NewShard()
+	sh.AddFile(shard.FileBlock{
+		FileHash: file1,
+		Entries: []shard.FileDataSequenceEntry{
+			{CASHash: xet.XorbHash{1}, UnpackedSegBytes: 100, ChunkIndexStart: math.MaxUint32 - 1, ChunkIndexEnd: math.MaxUint32},
+		},
+	})
+	st := &fakeListStore{
+		refs:   [][2]string{{file1.String(), "s1"}},
+		shards: map[string]*shard.Shard{"s1": sh},
+	}
+
+	got, err := ListFiles(context.Background(), st)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	want := []FileListEntry{{FileHashes: []string{file1.String()}, Missing: true}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListFiles() = %+v, want %+v", got, want)
+	}
+}
+
+// TestListFilesToleratesVanishedXorb covers a reconstruction term whose xorb
+// is gone: the entry stays listed and the vanished chunks contribute no
+// stored bytes.
+func TestListFilesToleratesVanishedXorb(t *testing.T) {
+	xorbA := xet.XorbHash{1}
+	xorbGone := xet.XorbHash{9}
+	file1 := xet.FileHash{11}
+	sha1 := shard.NewSHA256Hash([32]byte{101})
+	sh := shard.NewShard()
+	sh.AddFile(shard.FileBlock{
+		FileHash: file1,
+		Entries: []shard.FileDataSequenceEntry{
+			{CASHash: xorbA, UnpackedSegBytes: 100, ChunkIndexEnd: 1},
+			{CASHash: xorbGone, UnpackedSegBytes: 200, ChunkIndexEnd: 1},
+		},
+		MetadataExt: &shard.FileMetadataExt{SHA256Hash: sha1},
+	})
+	st := &fakeListStore{
+		refs:       [][2]string{{file1.String(), "s1"}},
+		shards:     map[string]*shard.Shard{"s1": sh},
+		chunkSizes: map[xet.XorbHash][]uint64{xorbA: {50}},
+	}
+
+	got, err := ListFiles(context.Background(), st)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	want := []FileListEntry{{SHA256: sha1.String(), FileHashes: []string{file1.String()}, OriginalSize: 300, UniqueSize: 50}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListFiles() = %+v, want %+v", got, want)
+	}
+}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	iofs "io/fs"
 	"net/http"
 	"os"
 	"strings"
@@ -23,6 +24,7 @@ import (
 	"github.com/wzshiming/xet"
 	"github.com/wzshiming/xet/shard"
 	"github.com/wzshiming/xet/xorb"
+	"golang.org/x/sync/errgroup"
 )
 
 // defaultPresignExpiry keeps presigned xorb URLs valid long enough for
@@ -392,6 +394,12 @@ func (ss *S3Storage) GetXorbDataRange(ctx context.Context, _ string, xorbHash xe
 	return xorb.ChunkDataRangeFromOffsets(offsets, chunkStart, chunkEnd)
 }
 
+// GetXorbChunkOffsets returns the xorb's chunk offset table; cached after
+// the first read.
+func (ss *S3Storage) GetXorbChunkOffsets(ctx context.Context, xorbHash xet.XorbHash) ([]uint64, error) {
+	return ss.xorbChunkOffsets(ctx, xorbHash)
+}
+
 // hasFile checks whether a file hash already has a shard mapping.
 func (ss *S3Storage) hasFile(ctx context.Context, fileHash xet.FileHash) (bool, error) {
 	ss.fileMut.Lock()
@@ -565,6 +573,80 @@ func (ss *S3Storage) getShardByHash(ctx context.Context, shardHash string) (*sha
 		ss.fileMut.Unlock()
 	}
 	return s, nil
+}
+
+// GetShardByHash loads a stored shard by the hash of its serialized bytes.
+// The returned error wraps fs.ErrNotExist when the shard is absent.
+func (ss *S3Storage) GetShardByHash(ctx context.Context, shardHash string) (*shard.Shard, error) {
+	s, err := ss.getShardByHash(ctx, shardHash)
+	if err != nil && isS3NotFound(err) {
+		return nil, fmt.Errorf("shard %s: %w", shardHash, iofs.ErrNotExist)
+	}
+	return s, err
+}
+
+// fileIndexWalkConcurrency bounds parallel index-object reads during walks.
+const fileIndexWalkConcurrency = 4
+
+// WalkFileIndex calls fn for every committed index/files entry.
+func (ss *S3Storage) WalkFileIndex(ctx context.Context, fn func(fileHash, shardHash string) error) error {
+	base := "index/files/"
+	if ss.prefix != "" {
+		base = ss.prefix + "/" + base
+	}
+	paginator := s3.NewListObjectsV2Paginator(ss.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(ss.bucket),
+		Prefix: aws.String(base),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("list file index: %w", err)
+		}
+		var keys, hashes []string
+		for _, obj := range page.Contents {
+			key := aws.ToString(obj.Key)
+			fileHash := strings.ReplaceAll(strings.TrimPrefix(key, base), "/", "")
+			if len(fileHash) != 64 {
+				continue
+			}
+			if _, err := hex.DecodeString(fileHash); err != nil {
+				continue
+			}
+			keys = append(keys, key)
+			hashes = append(hashes, fileHash)
+		}
+		// Read the page's index objects in parallel; fn stays sequential.
+		bodies := make([][]byte, len(keys))
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(fileIndexWalkConcurrency)
+		for i, key := range keys {
+			g.Go(func() error {
+				data, err := ss.getObject(gctx, key)
+				if err != nil {
+					// Deleted between list and read: leave the slot nil.
+					if isS3NotFound(err) {
+						return nil
+					}
+					return fmt.Errorf("read file index %s: %w", key, err)
+				}
+				bodies[i] = data
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return err
+		}
+		for i, fileHash := range hashes {
+			if bodies[i] == nil {
+				continue
+			}
+			if err := fn(fileHash, strings.TrimSpace(string(bodies[i]))); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // GetShard retrieves a shard by file hash

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	iofs "io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -293,6 +294,52 @@ func (fs *FileStorage) getShardByHash(shardHash string) (*shard.Shard, error) {
 		fs.fileMut.Unlock()
 	}
 	return s, nil
+}
+
+// GetShardByHash loads a stored shard by the hash of its serialized bytes.
+// The returned error wraps fs.ErrNotExist when the shard is absent.
+func (fs *FileStorage) GetShardByHash(ctx context.Context, shardHash string) (*shard.Shard, error) {
+	return fs.getShardByHash(shardHash)
+}
+
+// WalkFileIndex calls fn for every committed index/files entry.
+func (fs *FileStorage) WalkFileIndex(ctx context.Context, fn func(fileHash, shardHash string) error) error {
+	root := filepath.Join(fs.basePath, "index", "files")
+	return filepath.WalkDir(root, func(path string, d iofs.DirEntry, err error) error {
+		if err != nil {
+			// Tolerate concurrent deletion anywhere under the index.
+			if errors.Is(err, iofs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		fileHash := strings.ReplaceAll(filepath.ToSlash(rel), "/", "")
+		// Skip in-flight .tmp files and anything that is not a hash name.
+		if len(fileHash) != 64 {
+			return nil
+		}
+		if _, err := hex.DecodeString(fileHash); err != nil {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, iofs.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		return fn(fileHash, strings.TrimSpace(string(data)))
+	})
 }
 
 // PutXorb stores an xorb
@@ -708,4 +755,10 @@ func (fs *FileStorage) GetXorbDataRange(ctx context.Context, _ string, xorbHash 
 		return 0, 0, fmt.Errorf("failed to get chunk data range: %w", err)
 	}
 	return xorb.ChunkDataRangeFromOffsets(offsets, chunkStart, chunkEnd)
+}
+
+// GetXorbChunkOffsets returns the xorb's chunk offset table; cached after
+// the first read.
+func (fs *FileStorage) GetXorbChunkOffsets(_ context.Context, xorbHash xet.XorbHash) ([]uint64, error) {
+	return fs.xorbChunkOffsets(xorbHash)
 }


### PR DESCRIPTION
One stored content can be reachable through several xet file hashes: the file hash depends on chunk boundaries, so differently chunked uploads of identical bytes get distinct hashes while the SHA-256 stays the same. `GET /internal/files` therefore groups by SHA-256 — one entry per content, carrying every file hash that maps to it, with the original size counted once:

```json
[{"sha256":"…","file_hashes":["…","…"],"original_size":38,"unique_size":25,"shared_size":0,"unique_size":76,"shared_size":0}]
```

The aggregation is a single `storage.ListFiles` function over a thin `ListStore` surface (`WalkFileIndex` + `GetShardByHash`) implemented by both backends: the file backend walks the `index/files/` fanout and skips anything that is not a 64-hex name, so in-flight `.tmp` files are ignored; the S3 backend pages through ListObjectsV2 and reads each entry object. `index/files/` is the source of truth — it is the commit marker `PutShard` writes last — so partially stored shards never surface. Entries whose shard is gone stay listed with `missing:true`, and the all-zero SHA-256 marker of empty files is reported as no digest rather than grouped.

`unique_size` and `shared_size` estimate stored bytes by reference-counting chunks across entries: bytes only this entry references are what deleting it would free; bytes referenced by several entries count as shared for each. Exact accounting would need the chunk offset table from every xorb footer — too heavy across the whole store — so per-chunk unpacked sizes come from the CAS blocks of the shards the listing already loads, scaled by each xorb's `NumBytesOnDisk`/`NumBytesInCAS`. Dedup'd terms find their CAS block in the other entry's shard via the whole-store walk; a xorb with no CAS block anywhere falls back to spreading the term's unpacked bytes evenly at ratio 1.

The endpoint sits on a standalone `server.InternalHandler` mounted in front of the CAS routes in xetd, keeping management endpoints off the CAS protocol handler; unmatched paths fall through to the next handler like the rest of the chain. No auth on it, matching the other read endpoints.

`TestListFilesGroupsBySHA256` stores the same bytes chunked two different ways and expects one entry with both file hashes; `TestListFilesMarksDanglingEntries` covers dangling index entries — both run against the file and gofakes3 backends. `TestListFilesEstimatesUniqueAndShared` checks the shared/unique split, the ratio scaling, and the dedup'd-CAS-block lookup on hand-built shards.

