### PR TITLE
feat: redirect xorb uploads directly to S3 and verify at shard time

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,17 +21,18 @@ type AuthProvider interface {
 
 // Client represents an HTTP client for the XET protocol
 type Client struct {
-	baseURL       string
-	token         string
-	httpClient    *http.Client
-	getHttpClient *http.Client
-	namespace     string
-	concurrency   int
-	retries       int
-	progressFunc  progress.ProgressFunc
-	cacheDir      string
-	cacheSize     int64
-	cacheManager  *download.CacheManager
+	baseURL          string
+	token            string
+	httpClient       *http.Client
+	getHttpClient    *http.Client
+	noRedirectClient *http.Client
+	namespace        string
+	concurrency      int
+	retries          int
+	progressFunc     progress.ProgressFunc
+	cacheDir         string
+	cacheSize        int64
+	cacheManager     *download.CacheManager
 }
 
 type Options func(*Client)
@@ -143,6 +144,16 @@ func NewClient(opts ...Options) (*Client, error) {
 			}),
 	}
 
+	// The xorb upload POST must observe direct-upload redirects itself: an
+	// auto-followed 307 would re-POST the body while the redirect target
+	// (a presigned S3 URL) only accepts PUT.
+	c.noRedirectClient = &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Jar:           c.httpClient.Jar,
+		Timeout:       c.httpClient.Timeout,
+		Transport:     c.httpClient.Transport,
+	}
+
 	return c, nil
 }
 
@@ -240,6 +251,10 @@ func resetRequestBody(req *http.Request) error {
 }
 
 func (c *Client) doWithNetworkRetry(req *http.Request) (*http.Response, error) {
+	return c.doWithNetworkRetryClient(c.httpClient, req)
+}
+
+func (c *Client) doWithNetworkRetryClient(client *http.Client, req *http.Request) (*http.Response, error) {
 	attempts := c.retryAttempts()
 
 	var lastErr error
@@ -250,7 +265,7 @@ func (c *Client) doWithNetworkRetry(req *http.Request) (*http.Response, error) {
 			}
 		}
 
-		resp, err := c.httpClient.Do(req)
+		resp, err := client.Do(req)
 		if err == nil {
 			if isServerError(resp.StatusCode) {
 				lastErr = fmt.Errorf("server error status %s", resp.Status)

--- a/client/xorb.go
+++ b/client/xorb.go
@@ -108,17 +108,36 @@ func (c *Client) UploadXorbWithAuthProvider(ctx context.Context, provider AuthPr
 	req.GetBody = makeBody
 	req.ContentLength = contentLength - startOffset
 	req.Header.Set("Content-Type", "application/octet-stream")
+	// Advertise redirect support; servers only send 307 to clients that opt in.
+	req.Header.Set(upload.HeaderDirectUpload, upload.DirectUploadAccept)
+	// Wait for the server's verdict before transmitting the body: direct-upload
+	// servers answer with a redirect to the object store instead of reading it.
+	req.Header.Set("Expect", "100-continue")
 	if token, err := c.getToken(ctx, provider); err != nil {
 		return nil, fmt.Errorf("get token: %w", err)
 	} else if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	resp, err := c.doWithNetworkRetry(req)
+	// The redirect must not be auto-followed: Go would re-POST while the
+	// presigned target URL only accepts PUT.
+	resp, err := c.doWithNetworkRetryClient(c.noRedirectClient, req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTemporaryRedirect {
+		location, err := resp.Location()
+		if err != nil {
+			return nil, fmt.Errorf("xorb upload redirect: %w", err)
+		}
+		inserted, err := c.uploadXorbDirect(ctx, location.String(), makeBody, contentLength-startOffset)
+		if err != nil {
+			return nil, err
+		}
+		return &upload.XorbUploadResponse{WasInserted: inserted}, nil
+	}
 
 	if err := reqError(req, resp); err != nil {
 		return nil, err
@@ -130,6 +149,46 @@ func (c *Client) UploadXorbWithAuthProvider(ctx context.Context, provider AuthPr
 	}
 
 	return &uploadResp, nil
+}
+
+// uploadXorbDirect PUTs the raw xorb bytes to a direct upload URL handed out
+// by the server. The URL embeds its own authorization (e.g. a presigned S3
+// PUT URL), so no Authorization header is sent. It reports whether the PUT
+// created the object: a 412 means another uploader stored the same
+// content-addressed xorb first, which is equivalent to success.
+func (c *Client) uploadXorbDirect(ctx context.Context, url string, makeBody func() (io.ReadCloser, error), contentLength int64) (bool, error) {
+	body, err := makeBody()
+	if err != nil {
+		return false, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, body)
+	if err != nil {
+		return false, fmt.Errorf("create request: %w", err)
+	}
+	req.GetBody = makeBody
+	req.ContentLength = contentLength
+	// Create-only: matches the presigned signature and keeps a replayed URL
+	// from overwriting an already stored xorb.
+	req.Header.Set("If-None-Match", "*")
+
+	resp, err := c.doWithNetworkRetry(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		return false, nil
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		respBody, _ := io.ReadAll(resp.Body)
+		// Strip the query: presigned URLs carry credential-equivalent signatures.
+		bare := *req.URL
+		bare.RawQuery = ""
+		return false, fmt.Errorf("url %s: direct xorb upload error (status %s): %s", bare.String(), resp.Status, string(respBody))
+	}
+	return true, nil
 }
 
 // DownloadXorb fetches the raw xorb bytes for the given hash directly

--- a/client/xorb_test.go
+++ b/client/xorb_test.go
@@ -1,12 +1,133 @@
 package client
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/upload"
 )
+
+func TestUploadXorbFollowsDirectUploadRedirect(t *testing.T) {
+	xorbData := []byte("raw xorb bytes")
+
+	var putMethod, putAuth, putCond atomic.Value
+	var putBody atomic.Pointer[[]byte]
+	objectStore := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		putMethod.Store(r.Method)
+		putAuth.Store(r.Header.Get("Authorization"))
+		putCond.Store(r.Header.Get("If-None-Match"))
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read direct upload body: %v", err)
+		}
+		putBody.Store(&body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer objectStore.Close()
+
+	uploadURL := objectStore.URL + "/bucket/xorbs/ab/cdef?X-Amz-Signature=sig"
+	var postExpect, postAuth, postOptIn atomic.Value
+	casServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		postExpect.Store(r.Header.Get("Expect"))
+		postAuth.Store(r.Header.Get("Authorization"))
+		postOptIn.Store(r.Header.Get(upload.HeaderDirectUpload))
+		w.Header().Set("Location", uploadURL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer casServer.Close()
+
+	c, err := NewClient(WithBaseURL(casServer.URL), WithToken("secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.UploadXorb(t.Context(), xet.XorbHash{1}, bytes.NewReader(xorbData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.WasInserted {
+		t.Fatal("WasInserted = false, want true after direct upload")
+	}
+
+	if got := postExpect.Load(); got != "100-continue" {
+		t.Errorf("xorb POST Expect header = %q, want 100-continue", got)
+	}
+	if got := postOptIn.Load(); got != upload.DirectUploadAccept {
+		t.Errorf("xorb POST %s header = %q, want %q", upload.HeaderDirectUpload, got, upload.DirectUploadAccept)
+	}
+	if got := postAuth.Load(); got != "Bearer secret" {
+		t.Errorf("xorb POST Authorization = %q, want Bearer secret", got)
+	}
+	if got := putMethod.Load(); got != http.MethodPut {
+		t.Errorf("direct upload method = %q, want PUT", got)
+	}
+	if got := putCond.Load(); got != "*" {
+		t.Errorf("direct upload If-None-Match = %q, want *", got)
+	}
+	if got := putAuth.Load(); got != "" {
+		t.Errorf("Authorization forwarded to direct upload URL: %q", got)
+	}
+	if got := putBody.Load(); got == nil || !bytes.Equal(*got, xorbData) {
+		t.Errorf("direct upload body does not match xorb bytes")
+	}
+}
+
+func TestUploadXorbReportsDirectUploadFailure(t *testing.T) {
+	objectStore := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "access denied", http.StatusForbidden)
+	}))
+	defer objectStore.Close()
+
+	casServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", objectStore.URL+"/bucket/xorbs/ab/cdef?X-Amz-Signature=topsecret")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer casServer.Close()
+
+	c, err := NewClient(WithBaseURL(casServer.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.UploadXorb(t.Context(), xet.XorbHash{1}, bytes.NewReader([]byte("data")))
+	if err == nil || !strings.Contains(err.Error(), "direct xorb upload error") {
+		t.Fatalf("expected direct upload error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "topsecret") {
+		t.Fatalf("error leaks the presigned query: %v", err)
+	}
+}
+
+// A 412 means another uploader stored the same content-addressed xorb
+// between the redirect and the PUT; that is success, not an error.
+func TestUploadXorbDirectTreatsPreconditionFailedAsExisting(t *testing.T) {
+	objectStore := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusPreconditionFailed)
+	}))
+	defer objectStore.Close()
+
+	casServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", objectStore.URL+"/bucket/xorbs/ab/cdef")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer casServer.Close()
+
+	c, err := NewClient(WithBaseURL(casServer.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.UploadXorb(t.Context(), xet.XorbHash{1}, bytes.NewReader([]byte("data")))
+	if err != nil {
+		t.Fatalf("UploadXorb: %v", err)
+	}
+	if resp.WasInserted {
+		t.Fatal("WasInserted = true for a 412 (already stored) direct upload")
+	}
+}
 
 func TestDownloadXorbWithURLAcceptsExactRangeAsOK(t *testing.T) {
 	const body = "term"

--- a/cmd/xetd/main.go
+++ b/cmd/xetd/main.go
@@ -32,7 +32,7 @@ func main() {
 	s3Endpoint := flag.String("s3-endpoint", "", "Custom S3 endpoint URL, e.g. for MinIO (optional)")
 	s3Region := flag.String("s3-region", "", "S3 region (optional, falls back to AWS config chain)")
 	s3PathStyle := flag.Bool("s3-path-style", false, "Use path-style S3 addressing (required by MinIO and most self-hosted stores)")
-	s3Presign := flag.Bool("s3-presign", true, "Serve xorb downloads as presigned S3 GET URLs; disable when clients cannot reach the S3 endpoint")
+	s3Presign := flag.Bool("s3-presign", true, "Serve xorb downloads as presigned S3 GET URLs and redirect xorb uploads from clients that advertise direct-upload support to presigned S3 PUT URLs (verified at shard upload time); disable when clients cannot reach the S3 endpoint")
 	s3PresignExpiry := flag.Duration("s3-presign-expiry", time.Hour, "Validity of presigned xorb URLs")
 	s3PresignEndpoint := flag.String("s3-presign-endpoint", "", "Endpoint used in presigned xorb URLs when clients reach the object store at a different address than the server (optional, defaults to -s3-endpoint)")
 	flag.Parse()

--- a/hf/download.go
+++ b/hf/download.go
@@ -19,8 +19,11 @@ import (
 // CAS TokenProvider. The provider pre-populates the first token from the
 // response headers so no extra round-trip is needed on first use.
 func ResolveDownload(ctx context.Context, httpClient *http.Client, resolveURL string) (xet.FileHash, client.AuthProvider, error) {
-	if httpClient == nil {
-		httpClient = &http.Client{
+	// The resolve HEAD must surface the hub's first response: the 302 itself
+	// carries the xet Link headers, so redirects are never followed here.
+	headClient := httpClient
+	if headClient == nil {
+		headClient = &http.Client{
 			Timeout: 30 * time.Second,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse
@@ -33,7 +36,7 @@ func ResolveDownload(ctx context.Context, httpClient *http.Client, resolveURL st
 		return xet.FileHash{}, nil, fmt.Errorf("create resolve request: %w", err)
 	}
 
-	resp, err := httpClient.Do(req)
+	resp, err := headClient.Do(req)
 	if err != nil {
 		return xet.FileHash{}, nil, fmt.Errorf("resolve request: %w", err)
 	}
@@ -41,6 +44,8 @@ func ResolveDownload(ctx context.Context, httpClient *http.Client, resolveURL st
 		_ = resp.Body.Close()
 	}()
 
+	// Token fetches use the caller's client as-is; when none was provided the
+	// redirect-following token default applies instead of the HEAD client.
 	return ResolveResponse(ctx, httpClient, resp)
 }
 
@@ -148,6 +153,33 @@ type tokenResp struct {
 	Exp    int64  `json:"exp"`
 }
 
+// defaultTokenClient fetches CAS tokens the way xet-core's reqwest client
+// does: the hub may answer the xet token routes with a redirect (e.g. for a
+// moved or renamed repo) and it must be followed instead of failing.
+var defaultTokenClient = &http.Client{
+	Timeout:       30 * time.Second,
+	CheckRedirect: checkTokenRedirect,
+}
+
+// checkTokenRedirect mirrors reqwest's default redirect policy used by
+// xet-core: follow 10 hops and fail on the 11th, and drop credentials as soon
+// as the chain leaves the original host so the hub token cannot leak to other
+// hosts.
+func checkTokenRedirect(req *http.Request, via []*http.Request) error {
+	// via holds the requests already sent (initial plus followed hops).
+	if len(via) > 10 {
+		return fmt.Errorf("stopped after 10 redirects")
+	}
+	for _, prev := range via {
+		if prev.URL.Host != req.URL.Host {
+			req.Header.Del("Authorization")
+			req.Header.Del("Cookie")
+			break
+		}
+	}
+	return nil
+}
+
 func fetchXETAuthToken(ctx context.Context, httpClient *http.Client, tokenURL string, token string) (*tokenData, error) {
 	// Avoid caching issues by adding a timestamp query parameter
 	tokenURL += "?" + fmt.Sprint(time.Now().Unix())
@@ -162,12 +194,7 @@ func fetchXETAuthToken(ctx context.Context, httpClient *http.Client, tokenURL st
 	}
 
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Timeout: 30 * time.Second,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
+		httpClient = defaultTokenClient
 	}
 
 	resp, err := httpClient.Do(req)

--- a/hf/hf_test.go
+++ b/hf/hf_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -172,5 +174,164 @@ func TestResolveReadWithExplicitTarget(t *testing.T) {
 	}
 	if token != "cas-read-token" {
 		t.Fatalf("unexpected token: %s", token)
+	}
+}
+
+// TestWriteTokenProviderFollowsSameHostRedirect verifies the write-token route
+// may be redirected within the hub host (as huggingface.co does for moved
+// repos) and that the hub credential is kept on same-host hops, matching
+// xet-core's reqwest redirect policy.
+func TestWriteTokenProviderFollowsSameHostRedirect(t *testing.T) {
+	const oldPath = "/api/models/old-org/repo/xet-write-token/main"
+	const newPath = "/api/models/new-org/repo/xet-write-token/main"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(oldPath, func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer hf-token" {
+			t.Errorf("unexpected auth header on redirecting route: %s", auth)
+		}
+		http.Redirect(w, r, newPath, http.StatusTemporaryRedirect)
+	})
+	mux.HandleFunc(newPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET request, got %s", r.Method)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer hf-token" {
+			t.Errorf("same-host redirect must keep the hub token, got: %s", auth)
+		}
+		fmt.Fprint(w, `{"casUrl":"https://cas-upload.example.com","accessToken":"cas-write-token","exp":5678}`)
+	})
+	hubSrv := httptest.NewServer(mux)
+	defer hubSrv.Close()
+
+	target := Target{Endpoint: hubSrv.URL, RepoID: "old-org/repo"}
+
+	provider := NewWriteTokenProvider(nil, target, "hf-token")
+	baseURL, err := provider.BaseURL(context.Background())
+	if err != nil {
+		t.Fatalf("BaseURL returned error: %v", err)
+	}
+	if baseURL != "https://cas-upload.example.com" {
+		t.Fatalf("unexpected baseURL: %s", baseURL)
+	}
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token returned error: %v", err)
+	}
+	if token != "cas-write-token" {
+		t.Fatalf("unexpected token: %s", token)
+	}
+}
+
+// TestWriteTokenProviderCrossHostRedirectDropsAuth verifies that when the
+// write-token route redirects to a different host, the redirect is followed
+// but the hub credential is dropped, matching xet-core's reqwest policy of
+// removing sensitive headers once the chain leaves the original host.
+func TestWriteTokenProviderCrossHostRedirectDropsAuth(t *testing.T) {
+	const tokenPath = "/api/models/org/repo/xet-write-token/main"
+
+	newHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("cross-host redirect must drop the hub token, got: %s", auth)
+		}
+		fmt.Fprint(w, `{"casUrl":"https://cas-upload.example.com","accessToken":"cas-write-token","exp":5678}`)
+	}))
+	defer newHub.Close()
+
+	oldHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != tokenPath {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer hf-token" {
+			t.Errorf("unexpected auth header on redirecting route: %s", auth)
+		}
+		http.Redirect(w, r, newHub.URL+tokenPath, http.StatusTemporaryRedirect)
+	}))
+	defer oldHub.Close()
+
+	target := Target{Endpoint: oldHub.URL, RepoID: "org/repo"}
+
+	provider := NewWriteTokenProvider(nil, target, "hf-token")
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token returned error: %v", err)
+	}
+	if token != "cas-write-token" {
+		t.Fatalf("unexpected token: %s", token)
+	}
+}
+
+// TestWriteTokenProviderMultiHopRedirect verifies a chain that leaves the hub
+// host and later stays on the new host: once dropped, the credential must not
+// reappear on subsequent hops, matching reqwest's header carry-forward.
+func TestWriteTokenProviderMultiHopRedirect(t *testing.T) {
+	otherMux := http.NewServeMux()
+	otherHub := httptest.NewServer(otherMux)
+	defer otherHub.Close()
+
+	otherMux.HandleFunc("/hop", func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("cross-host hop must drop the hub token, got: %s", auth)
+		}
+		http.Redirect(w, r, "/final", http.StatusFound)
+	})
+	otherMux.HandleFunc("/final", func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("credential must stay dropped after leaving the hub host, got: %s", auth)
+		}
+		fmt.Fprint(w, `{"casUrl":"https://cas-upload.example.com","accessToken":"cas-write-token","exp":5678}`)
+	})
+
+	hubMux := http.NewServeMux()
+	hubSrv := httptest.NewServer(hubMux)
+	defer hubSrv.Close()
+
+	hubMux.HandleFunc("/api/", func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer hf-token" {
+			t.Errorf("unexpected auth header on hub route: %s", auth)
+		}
+		http.Redirect(w, r, "/relocated", http.StatusMovedPermanently)
+	})
+	hubMux.HandleFunc("/relocated", func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer hf-token" {
+			t.Errorf("same-host hop must keep the hub token, got: %s", auth)
+		}
+		http.Redirect(w, r, otherHub.URL+"/hop", http.StatusTemporaryRedirect)
+	})
+
+	target := Target{Endpoint: hubSrv.URL, RepoID: "org/repo"}
+
+	provider := NewWriteTokenProvider(nil, target, "hf-token")
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token returned error: %v", err)
+	}
+	if token != "cas-write-token" {
+		t.Fatalf("unexpected token: %s", token)
+	}
+}
+
+// TestWriteTokenProviderRedirectLimit verifies the token fetch gives up after
+// 10 hops, the same cap reqwest's default redirect policy enforces.
+func TestWriteTokenProviderRedirectLimit(t *testing.T) {
+	var hits atomic.Int64
+	hubSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		http.Redirect(w, r, r.URL.Path, http.StatusTemporaryRedirect)
+	}))
+	defer hubSrv.Close()
+
+	target := Target{Endpoint: hubSrv.URL, RepoID: "org/repo"}
+
+	provider := NewWriteTokenProvider(nil, target, "hf-token")
+	_, err := provider.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error from unbounded redirect chain")
+	}
+	if !strings.Contains(err.Error(), "stopped after 10 redirects") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := hits.Load(); got != 11 {
+		t.Fatalf("redirecting route hit %d times, want 11 (initial request + 10 followed hops)", got)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +19,7 @@ import (
 	"github.com/wzshiming/xet/shard"
 	"github.com/wzshiming/xet/storage"
 	"github.com/wzshiming/xet/upload"
+	"golang.org/x/sync/errgroup"
 )
 
 // Handler represents an XET CAS server
@@ -351,11 +354,6 @@ func (s *Handler) handleUploadXorb(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.ContentLength <= 0 {
-		http.Error(w, "Content-Length header required", http.StatusLengthRequired)
-		return
-	}
-
 	// Extract parameters from path using mux
 	vars := mux.Vars(r)
 	namespace := vars["namespace"]
@@ -366,6 +364,45 @@ func (s *Handler) handleUploadXorb(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, "Invalid xorb hash", http.StatusBadRequest)
 		return
+	}
+
+	if r.ContentLength <= 0 {
+		http.Error(w, "Content-Length header required", http.StatusLengthRequired)
+		return
+	}
+	if r.ContentLength > maxXorbUploadBytes {
+		http.Error(w, "Xorb too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Direct-upload storages answer before any body bytes are read: existing
+	// xorbs short-circuit, everything else is redirected to the object store.
+	// Only clients that advertise redirect support are redirected (xet-core
+	// auto-follows 307 as a re-POST, which presigned PUT URLs reject); others
+	// fall through to the streaming path below. Content verification happens
+	// at shard upload time instead.
+	if redirector, ok := s.storage.(storage.XorbUploadRedirector); ok &&
+		r.Header.Get(upload.HeaderDirectUpload) != "" {
+		exists, err := s.storage.HasXorb(r.Context(), namespace, xorbHash)
+		if err != nil {
+			http.Error(w, "Failed to check xorb", http.StatusInternalServerError)
+			return
+		}
+		if exists {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(upload.XorbUploadResponse{WasInserted: false})
+			return
+		}
+		uploadURL, err := redirector.XorbUploadURL(r.Context(), namespace, xorbHash, r.ContentLength)
+		if err != nil {
+			http.Error(w, "Failed to prepare xorb upload", http.StatusInternalServerError)
+			return
+		}
+		if uploadURL != "" {
+			w.Header().Set("Location", uploadURL)
+			w.WriteHeader(http.StatusTemporaryRedirect)
+			return
+		}
 	}
 
 	var body io.Reader = r.Body
@@ -458,10 +495,22 @@ func (s *Handler) storeUploadedShard(r *http.Request) (bool, int, error) {
 	if err := shardObj.Validate(); err != nil {
 		return false, http.StatusBadRequest, fmt.Errorf("invalid shard: %w", err)
 	}
-	for _, casBlock := range shardObj.CASInfos {
-		exists, err := s.storage.HasXorb(r.Context(), "default", casBlock.CASHash)
-		if err != nil || !exists {
+
+	g, gctx := errgroup.WithContext(r.Context())
+	g.SetLimit(xorbVerifyConcurrency)
+	for _, casHash := range referencedXorbs(shardObj) {
+		g.Go(func() error {
+			return s.verifyShardXorb(gctx, "default", casHash)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		switch {
+		case errors.Is(err, storage.ErrXorbNotFound):
 			return false, http.StatusBadRequest, fmt.Errorf("invalid shard: referenced xorb not uploaded")
+		case errors.Is(err, storage.ErrXorbInvalid):
+			return false, http.StatusBadRequest, fmt.Errorf("invalid shard: %w", err)
+		default:
+			return false, http.StatusInternalServerError, fmt.Errorf("failed to verify referenced xorb")
 		}
 	}
 
@@ -470,6 +519,58 @@ func (s *Handler) storeUploadedShard(r *http.Request) (bool, int, error) {
 		return false, http.StatusInternalServerError, fmt.Errorf("failed to store shard")
 	}
 	return wasInserted, http.StatusOK, nil
+}
+
+// xorbVerifyConcurrency bounds how many referenced xorbs a single shard
+// upload verifies in parallel.
+const xorbVerifyConcurrency = 4
+
+// maxXorbUploadBytes bounds a serialized xorb upload: MaxXorbSize of chunk
+// payload (compression never grows a chunk) plus 8 header and 40 footer
+// bytes per chunk, plus fixed footer overhead.
+const maxXorbUploadBytes = xet.MaxXorbSize + xet.MaxChunksPerXorb*48 + 1024
+
+// referencedXorbs returns every xorb hash the shard depends on, deduped:
+// CAS blocks plus file entries whose xorb is not in the shard (references
+// to previously uploaded data). Skipping the latter would let a shard
+// commit against an unverified direct-upload object.
+func referencedXorbs(shardObj *shard.Shard) []xet.XorbHash {
+	seen := make(map[xet.XorbHash]struct{}, len(shardObj.CASInfos))
+	var hashes []xet.XorbHash
+	add := func(h xet.XorbHash) {
+		if _, ok := seen[h]; ok {
+			return
+		}
+		seen[h] = struct{}{}
+		hashes = append(hashes, h)
+	}
+	for _, casBlock := range shardObj.CASInfos {
+		add(casBlock.CASHash)
+	}
+	for _, fileBlock := range shardObj.Files {
+		for _, entry := range fileBlock.Entries {
+			add(entry.CASHash)
+		}
+	}
+	return hashes
+}
+
+// verifyShardXorb ensures a CAS-referenced xorb has been uploaded. Storages
+// that accept unverified direct uploads validate the full content; for the
+// rest an existence check suffices since their PutXorb already validated the
+// bytes.
+func (s *Handler) verifyShardXorb(ctx context.Context, namespace string, xorbHash xet.XorbHash) error {
+	if validator, ok := s.storage.(storage.XorbValidator); ok {
+		return validator.ValidateXorb(ctx, namespace, xorbHash)
+	}
+	exists, err := s.storage.HasXorb(ctx, namespace, xorbHash)
+	if err != nil {
+		return fmt.Errorf("check xorb: %w", err)
+	}
+	if !exists {
+		return storage.ErrXorbNotFound
+	}
+	return nil
 }
 
 // handleQueryChunk handles GET /v1/chunks/{namespace}/{chunk_hash}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,19 +1,24 @@
 package server
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/wzshiming/xet"
 	"github.com/wzshiming/xet/shard"
 	"github.com/wzshiming/xet/storage"
+	"github.com/wzshiming/xet/upload"
 	"github.com/wzshiming/xet/xorb"
 )
 
@@ -143,5 +148,353 @@ func TestXetBridgeRejectsInvalidAndUnknownSHA256(t *testing.T) {
 		if rec.Code != test.want {
 			t.Errorf("GET %s: status = %d, want %d", test.path, rec.Code, test.want)
 		}
+	}
+}
+
+// encodeXorbForTest returns the encoded xorb bytes and hash for one chunk.
+func encodeXorbForTest(t *testing.T, chunk []byte) ([]byte, xet.XorbHash) {
+	t.Helper()
+	var encoded bytes.Buffer
+	encoder := xorb.NewEncoder(&encoded, true)
+	if _, err := encoder.Write(chunk); err != nil {
+		t.Fatal(err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return encoded.Bytes(), encoder.SummoryHash()
+}
+
+// buildSingleFileShard stores one single-chunk xorb per part in stor and
+// returns a shard describing the concatenation of parts as one file.
+func buildSingleFileShard(t *testing.T, ctx context.Context, stor storage.Storage, parts ...[]byte) *shard.Shard {
+	t.Helper()
+	shardObj := shard.NewShard()
+	fileBlock := shard.FileBlock{}
+	var chunkHashes []xet.ChunkHash
+	var chunkSizes []uint64
+	for _, part := range parts {
+		encoded, xorbHash := encodeXorbForTest(t, part)
+		if _, err := stor.PutXorb(ctx, "default", xorbHash, bytes.NewReader(encoded)); err != nil {
+			t.Fatal(err)
+		}
+		chunkHash := xet.ComputeChunkHash(part)
+		chunkHashes = append(chunkHashes, chunkHash)
+		chunkSizes = append(chunkSizes, uint64(len(part)))
+		fileBlock.Entries = append(fileBlock.Entries, shard.FileDataSequenceEntry{
+			CASHash: xorbHash, UnpackedSegBytes: uint32(len(part)), ChunkIndexEnd: 1,
+		})
+		shardObj.AddCASBlock(shard.CASBlock{
+			CASHash:       xorbHash,
+			NumBytesInCAS: uint32(len(part)),
+			Chunks:        []shard.CASChunkSequenceEntry{{ChunkHash: chunkHash, UnpackedSegBytes: uint32(len(part))}},
+		})
+	}
+	fileBlock.FileHash = xet.ComputeFileHash(chunkHashes, chunkSizes)
+	shardObj.AddFile(fileBlock)
+	return shardObj
+}
+
+func encodeShardForTest(t *testing.T, shardObj *shard.Shard) []byte {
+	t.Helper()
+	r, err := shardObj.Encode(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// directUploadStorage exposes a fixed direct-upload URL over a real storage.
+type directUploadStorage struct {
+	storage.Storage
+	uploadURL string
+}
+
+func (d *directUploadStorage) XorbUploadURL(context.Context, string, xet.XorbHash, int64) (string, error) {
+	return d.uploadURL, nil
+}
+
+// readTracker flags whether the request body was ever read.
+type readTracker struct{ read bool }
+
+func (r *readTracker) Read([]byte) (int, error) {
+	r.read = true
+	return 0, io.EOF
+}
+
+func TestUploadXorbRedirectsToDirectUploadURL(t *testing.T) {
+	ctx := context.Background()
+	stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const uploadURL = "https://s3.example/xorbs/ab/cd?X-Amz-Signature=sig"
+	handler := NewHandler(WithStorage(&directUploadStorage{Storage: stor, uploadURL: uploadURL}))
+
+	encoded, xorbHash := encodeXorbForTest(t, []byte("redirected xorb"))
+
+	body := &readTracker{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/xorbs/default/"+xorbHash.String(), body)
+	req.ContentLength = int64(len(encoded))
+	req.Header.Set(upload.HeaderDirectUpload, upload.DirectUploadAccept)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d (%s), want 307", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Location"); got != uploadURL {
+		t.Fatalf("Location = %q, want %q", got, uploadURL)
+	}
+	if body.read {
+		t.Fatal("request body was read before redirecting")
+	}
+
+	// An already stored xorb short-circuits to 200 was_inserted=false.
+	if _, err := stor.PutXorb(ctx, "default", xorbHash, bytes.NewReader(encoded)); err != nil {
+		t.Fatal(err)
+	}
+	req = httptest.NewRequest(http.MethodPost, "/v1/xorbs/default/"+xorbHash.String(), bytes.NewReader(encoded))
+	req.Header.Set(upload.HeaderDirectUpload, upload.DirectUploadAccept)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status for existing xorb = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		WasInserted bool `json:"was_inserted"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.WasInserted {
+		t.Fatal("was_inserted = true for existing xorb, want false")
+	}
+}
+
+func TestUploadXorbFallsBackToPutWhenDirectUploadUnavailable(t *testing.T) {
+	ctx := context.Background()
+	stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// XorbUploadURL returns "", e.g. S3 storage with presigning disabled.
+	handler := NewHandler(WithStorage(&directUploadStorage{Storage: stor}))
+
+	encoded, xorbHash := encodeXorbForTest(t, []byte("through the server"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/xorbs/default/"+xorbHash.String(), bytes.NewReader(encoded))
+	req.Header.Set(upload.HeaderDirectUpload, upload.DirectUploadAccept)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s), want 200", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		WasInserted bool `json:"was_inserted"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.WasInserted {
+		t.Fatal("was_inserted = false, want true")
+	}
+	if ok, err := stor.HasXorb(ctx, "default", xorbHash); err != nil || !ok {
+		t.Fatalf("HasXorb after fallback upload = %v, %v", ok, err)
+	}
+}
+
+// Clients that do not advertise redirect support (e.g. xet-core) must be
+// served by the streaming path even when the storage offers direct upload.
+func TestUploadXorbWithoutOptInStreamsThroughServer(t *testing.T) {
+	ctx := context.Background()
+	stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := NewHandler(WithStorage(&directUploadStorage{Storage: stor, uploadURL: "https://s3.example/xorbs/ab/cd?X-Amz-Signature=sig"}))
+
+	encoded, xorbHash := encodeXorbForTest(t, []byte("no opt-in"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/xorbs/default/"+xorbHash.String(), bytes.NewReader(encoded)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s), want 200", rec.Code, rec.Body.String())
+	}
+	if ok, err := stor.HasXorb(ctx, "default", xorbHash); err != nil || !ok {
+		t.Fatalf("HasXorb after streaming upload = %v, %v", ok, err)
+	}
+}
+
+// A shard may reference a xorb only from file entries (data uploaded
+// earlier, so no CAS block in this shard); those references must be
+// verified too, or direct uploads would commit unvalidated.
+func TestUploadShardVerifiesFileEntryReferencedXorbs(t *testing.T) {
+	stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	shardObj := shard.NewShard()
+	shardObj.AddFile(shard.FileBlock{
+		FileHash: xet.FileHash{1},
+		Entries:  []shard.FileDataSequenceEntry{{CASHash: xet.XorbHash{2}, UnpackedSegBytes: 4, ChunkIndexEnd: 1}},
+	})
+	body := encodeShardForTest(t, shardObj)
+	handler := NewHandler(WithStorage(&validateErrStorage{Storage: stor, validateErr: storage.ErrXorbNotFound}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/shards", bytes.NewReader(body)))
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "referenced xorb not uploaded") {
+		t.Fatalf("v1 status = %d (%s), want 400 not-uploaded", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v2/shards", bytes.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("v2 status = %d, want 200", rec.Code)
+	}
+	events := bufio.NewReader(rec.Body)
+	for {
+		event := readShardUploadWireEvent(t, events)
+		if event.Type == "result" {
+			t.Fatal("shard with unverified file-entry reference was accepted")
+		}
+		if event.Type == "error" {
+			if !strings.Contains(event.Message, "referenced xorb not uploaded") {
+				t.Fatalf("error message = %q, want not-uploaded", event.Message)
+			}
+			return
+		}
+	}
+}
+
+// validateErrStorage overrides shard-time xorb validation with a fixed error.
+type validateErrStorage struct {
+	storage.Storage
+	validateErr error
+}
+
+func (v *validateErrStorage) ValidateXorb(context.Context, string, xet.XorbHash) error {
+	return v.validateErr
+}
+
+func TestUploadShardVerifiesXorbsAtShardTime(t *testing.T) {
+	ctx := context.Background()
+	for _, test := range []struct {
+		name        string
+		validateErr error
+		wantStatus  int
+		wantBody    string
+	}{
+		{name: "valid", wantStatus: http.StatusOK},
+		{name: "missing", validateErr: storage.ErrXorbNotFound, wantStatus: http.StatusBadRequest, wantBody: "referenced xorb not uploaded"},
+		{name: "corrupt", validateErr: fmt.Errorf("%w: chunk 0 hash mismatch", storage.ErrXorbInvalid), wantStatus: http.StatusBadRequest, wantBody: "invalid xorb content"},
+		{name: "transient", validateErr: errors.New("connection reset"), wantStatus: http.StatusInternalServerError, wantBody: "failed to verify"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := encodeShardForTest(t, buildSingleFileShard(t, ctx, stor, []byte("shard time validation")))
+			handler := NewHandler(WithStorage(&validateErrStorage{Storage: stor, validateErr: test.validateErr}))
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/shards", bytes.NewReader(body)))
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d (%s), want %d", rec.Code, rec.Body.String(), test.wantStatus)
+			}
+			if test.wantBody != "" && !strings.Contains(rec.Body.String(), test.wantBody) {
+				t.Fatalf("body = %q, want containing %q", rec.Body.String(), test.wantBody)
+			}
+		})
+	}
+}
+
+func TestUploadShardV2ReportsXorbValidationFailure(t *testing.T) {
+	ctx := context.Background()
+	for _, test := range []struct {
+		name          string
+		validateErr   error
+		wantMessage   string
+		wantRetryable bool
+	}{
+		{name: "missing", validateErr: storage.ErrXorbNotFound, wantMessage: "referenced xorb not uploaded"},
+		{name: "corrupt", validateErr: fmt.Errorf("%w: chunk 0 hash mismatch", storage.ErrXorbInvalid), wantMessage: "invalid xorb content"},
+		{name: "transient", validateErr: errors.New("connection reset"), wantMessage: "failed to verify referenced xorb", wantRetryable: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := encodeShardForTest(t, buildSingleFileShard(t, ctx, stor, []byte("v2 validation")))
+			handler := NewHandler(WithStorage(&validateErrStorage{Storage: stor, validateErr: test.validateErr}))
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v2/shards", bytes.NewReader(body)))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+
+			events := bufio.NewReader(rec.Body)
+			for {
+				event := readShardUploadWireEvent(t, events)
+				if event.Type == "result" {
+					t.Fatal("shard was accepted despite failing xorb validation")
+				}
+				if event.Type != "error" {
+					continue
+				}
+				if !strings.Contains(event.Message, test.wantMessage) {
+					t.Fatalf("error message = %q, want containing %q", event.Message, test.wantMessage)
+				}
+				if event.Retryable != test.wantRetryable {
+					t.Fatalf("retryable = %v, want %v", event.Retryable, test.wantRetryable)
+				}
+				return
+			}
+		})
+	}
+}
+
+func TestUploadShardV2FullyValidatesXorbs(t *testing.T) {
+	ctx := context.Background()
+	stor, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	shardObj := buildSingleFileShard(t, ctx, stor, []byte("part one "), []byte("and part two"))
+	body := encodeShardForTest(t, shardObj)
+	handler := NewHandler(WithStorage(stor))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v2/shards", bytes.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	events := bufio.NewReader(rec.Body)
+	var lastValidating shardUploadWireEvent
+	for {
+		event := readShardUploadWireEvent(t, events)
+		if event.Type == "validating" {
+			lastValidating = event
+			continue
+		}
+		if event.Type == "error" {
+			t.Fatalf("error frame: %+v", event)
+		}
+		if event.Type == "result" {
+			break
+		}
+	}
+	if lastValidating.Verified != 2 || lastValidating.Total != 2 {
+		t.Fatalf("last validating frame = %+v, want verified=2 total=2", lastValidating)
+	}
+	if _, err := stor.GetShard(ctx, shardObj.Files[0].FileHash); err != nil {
+		t.Fatalf("shard not stored: %v", err)
 	}
 }

--- a/server/shard_v2.go
+++ b/server/shard_v2.go
@@ -9,7 +9,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/wzshiming/xet"
 	"github.com/wzshiming/xet/shard"
+	"github.com/wzshiming/xet/storage"
+	"golang.org/x/sync/errgroup"
 )
 
 const shardUploadHeartbeatInterval = 20 * time.Second
@@ -162,37 +165,80 @@ func (s *Handler) handleUploadShardV2(w http.ResponseWriter, r *http.Request) {
 
 	body := io.LimitReader(r.Body, r.ContentLength)
 	shardObj := shard.NewShard()
+
+	// Referenced xorbs are verified with bounded concurrency while the shard
+	// is still streaming in; every verified xorb advances the progress frames.
+	verify, verifyCtx := errgroup.WithContext(r.Context())
+	verify.SetLimit(xorbVerifyConcurrency)
+	errVerifyAborted := errors.New("xorb verification failed")
+	seen := make(map[xet.XorbHash]struct{})
+	var progressMut sync.Mutex
 	var verified, total uint64
-	var callbackMessage string
-	var callbackRetryable bool
-	if err := shardObj.DecodeWithCASBlockCallback(body, false, func(casBlock shard.CASBlock) error {
+
+	enqueueVerify := func(casHash xet.XorbHash) error {
+		progressMut.Lock()
+		if _, ok := seen[casHash]; ok {
+			progressMut.Unlock()
+			return nil
+		}
+		seen[casHash] = struct{}{}
 		total++
-		if err := stream.validating(verified, total); err != nil {
-			return err
-		}
-
-		exists, err := s.storage.HasXorb(r.Context(), "default", casBlock.CASHash)
+		err := stream.validating(verified, total)
+		progressMut.Unlock()
 		if err != nil {
-			callbackMessage = "failed to check referenced xorb"
-			callbackRetryable = true
-			return errors.New(callbackMessage)
-		}
-		if !exists {
-			callbackMessage = "invalid shard: referenced xorb not uploaded"
-			return errors.New(callbackMessage)
-		}
-
-		verified++
-		if err := stream.validating(verified, total); err != nil {
 			return err
 		}
+		verify.Go(func() error {
+			if err := s.verifyShardXorb(verifyCtx, "default", casHash); err != nil {
+				return err
+			}
+			progressMut.Lock()
+			defer progressMut.Unlock()
+			verified++
+			return stream.validating(verified, total)
+		})
 		return nil
-	}); err != nil {
-		if callbackMessage != "" {
-			finishWithError(callbackMessage, callbackRetryable)
+	}
+
+	decodeErr := shardObj.DecodeWithCASBlockCallback(body, false, func(casBlock shard.CASBlock) error {
+		if verifyCtx.Err() != nil {
+			// A verification already failed; stop decoding early. The real
+			// error is reported from verify.Wait below.
+			return errVerifyAborted
+		}
+		return enqueueVerify(casBlock.CASHash)
+	})
+	if decodeErr == nil {
+		// File entries may reference xorbs outside the shard's CAS blocks
+		// (previously uploaded data); they need the same verification.
+	enqueueFileRefs:
+		for _, fileBlock := range shardObj.Files {
+			for _, entry := range fileBlock.Entries {
+				if verifyCtx.Err() != nil || enqueueVerify(entry.CASHash) != nil {
+					break enqueueFileRefs
+				}
+			}
+		}
+	}
+	if verifyErr := verify.Wait(); verifyErr != nil {
+		switch {
+		case errors.Is(verifyErr, storage.ErrXorbNotFound):
+			finishWithError("invalid shard: referenced xorb not uploaded", false)
+		case errors.Is(verifyErr, storage.ErrXorbInvalid):
+			finishWithError(fmt.Sprintf("invalid shard: %v", verifyErr), false)
+		default:
+			finishWithError("failed to verify referenced xorb", true)
+		}
+		return
+	}
+	if decodeErr != nil {
+		if errors.Is(decodeErr, errVerifyAborted) {
+			// Verification succeeded (Wait returned nil), so the early stop
+			// came from the request context being canceled while decoding.
+			finishWithError("request canceled", true)
 			return
 		}
-		finishWithError(fmt.Sprintf("invalid shard format: %v", err), false)
+		finishWithError(fmt.Sprintf("invalid shard format: %v", decodeErr), false)
 		return
 	}
 

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -46,17 +46,19 @@ type S3Storage struct {
 	presignExpiry   time.Duration
 	presignEndpoint string
 
-	fileIndex    *lru.Cache // bounded file hash -> shard hash
-	shardIndex   *lru.Cache // bounded shard hash -> shard cache
-	chunkIndex   *lru.Cache // bounded chunk hash -> shard hash
-	sha256Index  *lru.Cache // bounded SHA-256 -> shard hash
-	offsetsIndex *lru.Cache // bounded xorb hash -> []uint64 packed chunk end-offsets
+	fileIndex      *lru.Cache // bounded file hash -> shard hash
+	shardIndex     *lru.Cache // bounded shard hash -> shard cache
+	chunkIndex     *lru.Cache // bounded chunk hash -> shard hash
+	sha256Index    *lru.Cache // bounded SHA-256 -> shard hash
+	offsetsIndex   *lru.Cache // bounded xorb hash -> []uint64 packed chunk end-offsets
+	validatedIndex *lru.Cache // bounded xorb hash -> content-validated marker
 
-	fileMut    sync.Mutex // guards fileIndex
-	shardMut   sync.Mutex // guards shardIndex
-	chunkMut   sync.Mutex // guards chunkIndex
-	sha256Mut  sync.Mutex // guards sha256Index
-	offsetsMut sync.Mutex // guards offsetsIndex
+	fileMut      sync.Mutex // guards fileIndex
+	shardMut     sync.Mutex // guards shardIndex
+	chunkMut     sync.Mutex // guards chunkIndex
+	sha256Mut    sync.Mutex // guards sha256Index
+	offsetsMut   sync.Mutex // guards offsetsIndex
+	validatedMut sync.Mutex // guards validatedIndex
 
 	// endpoint, region and pathStyle configure the lazily created client
 	// when one is not injected directly.
@@ -120,9 +122,12 @@ func WithS3PathStyle(pathStyle bool) S3Option {
 	}
 }
 
-// WithS3Presign controls whether xorb download URLs are presigned S3 GET
-// URLs (default) or relative paths served through the CAS server. Disable
-// it when clients cannot reach the S3 endpoint directly.
+// WithS3Presign controls whether xorb transfers go straight to the object
+// store (default): downloads use presigned S3 GET URLs and uploads from
+// clients that advertise direct-upload support are redirected to presigned
+// S3 PUT URLs, verified at shard upload time. When disabled, transfers
+// stream through the CAS server; use this when clients cannot reach the S3
+// endpoint directly.
 func WithS3Presign(presign bool) S3Option {
 	return func(ss *S3Storage) {
 		ss.presign = presign
@@ -155,13 +160,14 @@ func WithS3PresignEndpoint(endpoint string) S3Option {
 // shared config, IAM roles) unless a client is injected with WithS3Client.
 func NewS3Storage(ctx context.Context, opts ...S3Option) (*S3Storage, error) {
 	ss := &S3Storage{
-		presign:       true,
-		presignExpiry: defaultPresignExpiry,
-		fileIndex:     lru.New(defaultFileCacheSize),
-		shardIndex:    lru.New(defaultShardCacheSize),
-		chunkIndex:    lru.New(defaultChunkCacheSize),
-		sha256Index:   lru.New(defaultSHA256CacheSize),
-		offsetsIndex:  lru.New(defaultOffsetsCacheSize),
+		presign:        true,
+		presignExpiry:  defaultPresignExpiry,
+		fileIndex:      lru.New(defaultFileCacheSize),
+		shardIndex:     lru.New(defaultShardCacheSize),
+		chunkIndex:     lru.New(defaultChunkCacheSize),
+		sha256Index:    lru.New(defaultSHA256CacheSize),
+		offsetsIndex:   lru.New(defaultOffsetsCacheSize),
+		validatedIndex: lru.New(defaultValidatedCacheSize),
 	}
 
 	for _, opt := range opts {
@@ -188,15 +194,18 @@ func NewS3Storage(ctx context.Context, opts ...S3Option) (*S3Storage, error) {
 			o.UsePathStyle = ss.pathStyle
 		})
 	}
+	// The presign client never sends requests; it only shapes and signs
+	// URLs, so a client copy is enough. Checksum calculation must be
+	// when_required: the default folds x-amz-checksum-* headers into
+	// presigned PUT signatures, which plain HTTP clients and most
+	// S3-compatible stores do not handle.
+	presignOpts := ss.client.Options()
 	if ss.presignEndpoint != "" {
-		// The presign client never sends requests; it only shapes and signs
-		// the URL, so a client copy with the public endpoint is enough.
-		presignOpts := ss.client.Options()
+		// Presign against the public endpoint clients actually reach.
 		presignOpts.BaseEndpoint = aws.String(ss.presignEndpoint)
-		ss.presignClient = s3.NewPresignClient(s3.New(presignOpts))
-	} else {
-		ss.presignClient = s3.NewPresignClient(ss.client)
 	}
+	presignOpts.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+	ss.presignClient = s3.NewPresignClient(s3.New(presignOpts))
 
 	return ss, nil
 }
@@ -329,7 +338,119 @@ func (ss *S3Storage) PutXorb(ctx context.Context, _ string, xorbHash xet.XorbHas
 	if err := ss.putObject(ctx, key, f); err != nil {
 		return false, fmt.Errorf("upload xorb: %w", err)
 	}
+	ss.markXorbValidated(xorbHash)
 	return true, nil
+}
+
+// xorbValidated reports whether this process already validated the xorb's
+// content, via PutXorb or an earlier ValidateXorb.
+func (ss *S3Storage) xorbValidated(xorbHash xet.XorbHash) bool {
+	ss.validatedMut.Lock()
+	defer ss.validatedMut.Unlock()
+	_, ok := ss.validatedIndex.Get(xorbHash)
+	return ok
+}
+
+func (ss *S3Storage) markXorbValidated(xorbHash xet.XorbHash) {
+	ss.validatedMut.Lock()
+	defer ss.validatedMut.Unlock()
+	ss.validatedIndex.Add(xorbHash, struct{}{})
+}
+
+// errTrackingReader records the first error the underlying reader returns so
+// a failed validation can be told apart from a failed transfer.
+type errTrackingReader struct {
+	r   io.Reader
+	err error
+}
+
+func (t *errTrackingReader) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+	if err != nil && err != io.EOF && t.err == nil {
+		t.err = err
+	}
+	return n, err
+}
+
+// ValidateXorb streams the stored xorb back from S3 through full content
+// validation, covering xorbs uploaded directly with presigned PUT URLs.
+// With presigning disabled there is no direct-upload ingress (every object
+// passed PutXorb validation), so only existence is checked. Hashes already
+// validated by this process are skipped, so shard retries do not re-read
+// the bytes. Invalid content is deleted: it has never validated, so nothing
+// references it, and leaving it would poison the key (existence checks make
+// clients skip re-uploading the valid bytes).
+func (ss *S3Storage) ValidateXorb(ctx context.Context, _ string, xorbHash xet.XorbHash) error {
+	if ss.xorbValidated(xorbHash) {
+		return nil
+	}
+
+	key := ss.objectKey("xorbs", xorbHash.String())
+	if !ss.presign {
+		_, exists, err := ss.headObject(ctx, key)
+		if err != nil {
+			return fmt.Errorf("check xorb object: %w", err)
+		}
+		if !exists {
+			return ErrXorbNotFound
+		}
+		return nil
+	}
+
+	out, err := ss.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(ss.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if isS3NotFound(err) {
+			return ErrXorbNotFound
+		}
+		return fmt.Errorf("read xorb object: %w", err)
+	}
+	defer out.Body.Close()
+
+	body := &errTrackingReader{r: out.Body}
+	if err := xorb.Validate(body, xorbHash); err != nil {
+		// A failed read is a transport problem, not proof of bad content;
+		// report it as retryable instead of rejecting the shard for good.
+		if body.err != nil {
+			return fmt.Errorf("read xorb object: %w", err)
+		}
+		ss.deleteObjectIfMatch(ctx, key, aws.ToString(out.ETag))
+		return fmt.Errorf("%w: %v", ErrXorbInvalid, err)
+	}
+
+	ss.markXorbValidated(xorbHash)
+	return nil
+}
+
+// deleteObjectIfMatch best-effort deletes an object; the ETag condition keeps
+// a concurrent valid re-upload from being deleted along with the bad bytes.
+// Stores without conditional-delete support get an unconditional retry:
+// leaving the object would poison the key for good, while the delete race is
+// only the narrow window after another deletion of the same bad bytes.
+func (ss *S3Storage) deleteObjectIfMatch(ctx context.Context, key, etag string) {
+	in := &s3.DeleteObjectInput{
+		Bucket: aws.String(ss.bucket),
+		Key:    aws.String(key),
+	}
+	if etag != "" {
+		in.IfMatch = aws.String(etag)
+	}
+	_, err := ss.client.DeleteObject(ctx, in)
+	if err == nil || in.IfMatch == nil || isS3PreconditionFailed(err) {
+		return
+	}
+	in.IfMatch = nil
+	_, _ = ss.client.DeleteObject(ctx, in)
+}
+
+// isS3PreconditionFailed reports a failed If-Match/If-None-Match condition:
+// the object changed, as opposed to the store rejecting the conditional
+// request itself.
+func isS3PreconditionFailed(err error) bool {
+	var respErr *awshttp.ResponseError
+	return errors.As(err, &respErr) && respErr.HTTPStatusCode() == http.StatusPreconditionFailed
 }
 
 // GetXorbReadSeekCloser returns a ReadSeekCloser over the xorb object; reads
@@ -762,6 +883,28 @@ func (ss *S3Storage) GetXorbURL(namespace string, xorbHash xet.XorbHash) (string
 	return fmt.Sprintf("%s/v1/xorbs/%s/%s", ss.baseURL, namespace, xorbHash.String()), nil
 }
 
+// XorbUploadURL returns a presigned PUT URL so clients upload xorb bytes
+// straight to the object store, or "" when presigning is disabled. Bytes
+// accepted this way are unverified until ValidateXorb runs at shard time.
+// Content-Length and If-None-Match: * are folded into the signature, so the
+// URL creates an object of exactly size bytes and cannot overwrite an
+// existing one (e.g. a replayed URL after the xorb was committed).
+func (ss *S3Storage) XorbUploadURL(ctx context.Context, _ string, xorbHash xet.XorbHash, size int64) (string, error) {
+	if !ss.presign {
+		return "", nil
+	}
+	req, err := ss.presignClient.PresignPutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(ss.bucket),
+		Key:           aws.String(ss.objectKey("xorbs", xorbHash.String())),
+		ContentLength: aws.Int64(size),
+		IfNoneMatch:   aws.String("*"),
+	}, s3.WithPresignExpires(ss.presignExpiry))
+	if err != nil {
+		return "", fmt.Errorf("presign xorb upload URL: %w", err)
+	}
+	return req.URL, nil
+}
+
 // s3Opener adapts an S3 object to httpseek.Opener: each open is served with
 // an S3 range GET, and the ETag reported on every open lets the OpenSeeker
 // detect content changes across reopens.
@@ -811,3 +954,5 @@ func (o *s3Opener) Size(string) (httpseek.SizeResult, error) {
 }
 
 var _ Storage = (*S3Storage)(nil)
+var _ XorbUploadRedirector = (*S3Storage)(nil)
+var _ XorbValidator = (*S3Storage)(nil)

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -142,6 +143,227 @@ func TestS3StorageXorbRoundTrip(t *testing.T) {
 
 	if _, err := ss.GetXorbReadSeekCloser(ctx, "default", xet.XorbHash{9}); err == nil {
 		t.Fatal("GetXorbReadSeekCloser() found a missing xorb")
+	}
+}
+
+// putToPresignedURL PUTs raw bytes to a presigned URL like a redirected
+// client would: plain HTTP, no SDK, no extra headers.
+func putToPresignedURL(t *testing.T, url string, data []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("direct PUT status %s: %s", resp.Status, body)
+	}
+}
+
+func TestS3StorageDirectXorbUploadAndValidate(t *testing.T) {
+	ctx := context.Background()
+	ss := newTestS3Storage(t)
+
+	encoded, xorbHash := encodeTestXorb(t, true, []byte("direct upload chunk"))
+
+	uploadURL, err := ss.XorbUploadURL(ctx, "default", xorbHash, int64(len(encoded)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uploadURL == "" {
+		t.Fatal("XorbUploadURL returned no URL with presign enabled")
+	}
+	// Plain PUT clients (and gofakes3/MinIO) cannot supply SDK checksum
+	// headers, so none may be folded into the signature.
+	if strings.Contains(strings.ToLower(uploadURL), "checksum") {
+		t.Fatalf("presigned PUT URL requires checksum headers: %s", uploadURL)
+	}
+
+	if err := ss.ValidateXorb(ctx, "default", xorbHash); !errors.Is(err, ErrXorbNotFound) {
+		t.Fatalf("ValidateXorb before upload = %v, want ErrXorbNotFound", err)
+	}
+
+	putToPresignedURL(t, uploadURL, encoded)
+
+	if ok, err := ss.HasXorb(ctx, "default", xorbHash); err != nil || !ok {
+		t.Fatalf("HasXorb after direct PUT = %v, %v", ok, err)
+	}
+	if err := ss.ValidateXorb(ctx, "default", xorbHash); err != nil {
+		t.Fatalf("ValidateXorb after direct PUT: %v", err)
+	}
+
+	// Corrupt bytes are only caught at validation time.
+	bad := append([]byte(nil), encoded...)
+	bad[10] ^= 0xff
+	badHash := xet.XorbHash{42}
+	badURL, err := ss.XorbUploadURL(ctx, "default", badHash, int64(len(bad)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	putToPresignedURL(t, badURL, bad)
+	if err := ss.ValidateXorb(ctx, "default", badHash); !errors.Is(err, ErrXorbInvalid) {
+		t.Fatalf("ValidateXorb of corrupt xorb = %v, want ErrXorbInvalid", err)
+	}
+	// Invalid bytes are deleted so the key is not poisoned: the next upload
+	// attempt sees the xorb as absent instead of skipping it as stored.
+	if ok, err := ss.HasXorb(ctx, "default", badHash); err != nil || ok {
+		t.Fatalf("HasXorb after failed validation = %v, %v; want false", ok, err)
+	}
+
+	// Validated hashes are cached, so a shard retry does not re-read the
+	// object. gofakes3 ignores the signed If-None-Match condition, so this
+	// replay overwrite succeeds here; real S3 rejects it with 412.
+	putToPresignedURL(t, uploadURL, bad)
+	if err := ss.ValidateXorb(ctx, "default", xorbHash); err != nil {
+		t.Fatalf("ValidateXorb after successful validation = %v, want nil (cached)", err)
+	}
+}
+
+func TestS3StoragePutXorbMarksValidated(t *testing.T) {
+	ctx := context.Background()
+	ss := newTestS3Storage(t)
+
+	encoded, xorbHash := encodeTestXorb(t, true, []byte("validated by put"))
+	if inserted, err := ss.PutXorb(ctx, "default", xorbHash, bytes.NewReader(encoded)); err != nil || !inserted {
+		t.Fatalf("PutXorb() = %v, %v", inserted, err)
+	}
+
+	// PutXorb already validated the stream; ValidateXorb must not re-read,
+	// so corrupting the object behind the storage's back goes unnoticed.
+	if err := ss.putObject(ctx, ss.objectKey("xorbs", xorbHash.String()), bytes.NewReader([]byte("garbage"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := ss.ValidateXorb(ctx, "default", xorbHash); err != nil {
+		t.Fatalf("ValidateXorb after PutXorb = %v, want nil (cached)", err)
+	}
+}
+
+func TestS3StorageXorbUploadURLDisabledWithoutPresign(t *testing.T) {
+	ss := newTestS3Storage(t, WithS3Presign(false))
+	url, err := ss.XorbUploadURL(context.Background(), "default", xet.XorbHash{1}, 1)
+	if err != nil || url != "" {
+		t.Fatalf("XorbUploadURL with presign off = %q, %v; want empty", url, err)
+	}
+}
+
+// With presigning disabled nothing reaches the store unvalidated, so
+// shard-time verification degrades to an existence check instead of a full
+// object read.
+func TestS3StorageValidateXorbWithoutPresignChecksExistenceOnly(t *testing.T) {
+	ctx := context.Background()
+	ss := newTestS3Storage(t, WithS3Presign(false))
+
+	if err := ss.ValidateXorb(ctx, "default", xet.XorbHash{1}); !errors.Is(err, ErrXorbNotFound) {
+		t.Fatalf("ValidateXorb missing = %v, want ErrXorbNotFound", err)
+	}
+
+	// Bytes that would fail content validation pass: they can only have been
+	// stored through PutXorb, which validated them on ingress.
+	xorbHash := xet.XorbHash{2}
+	if err := ss.putObject(ctx, ss.objectKey("xorbs", xorbHash.String()), bytes.NewReader([]byte("garbage"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := ss.ValidateXorb(ctx, "default", xorbHash); err != nil {
+		t.Fatalf("ValidateXorb = %v, want nil (existence only)", err)
+	}
+}
+
+// deleteObjectIfMatch must fall back to an unconditional delete when the
+// store rejects the conditional request (leaving the object would poison the
+// key), but must respect a failed condition: 412 means the object changed.
+func TestS3StorageDeleteObjectIfMatchFallback(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		condStatus  int
+		wantIfMatch []string
+	}{
+		{name: "unsupported falls back", condStatus: http.StatusNotImplemented, wantIfMatch: []string{`"etag"`, ""}},
+		{name: "changed object is kept", condStatus: http.StatusPreconditionFailed, wantIfMatch: []string{`"etag"`}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var gotIfMatch []string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete {
+					t.Errorf("unexpected %s request", r.Method)
+					http.Error(w, "unexpected method", http.StatusBadRequest)
+					return
+				}
+				mu.Lock()
+				gotIfMatch = append(gotIfMatch, r.Header.Get("If-Match"))
+				mu.Unlock()
+				if r.Header.Get("If-Match") != "" {
+					w.WriteHeader(test.condStatus)
+					return
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			t.Cleanup(srv.Close)
+
+			client := s3.New(s3.Options{
+				BaseEndpoint:               aws.String(srv.URL),
+				Region:                     "us-east-1",
+				Credentials:                credentials.NewStaticCredentialsProvider("test", "test", ""),
+				UsePathStyle:               true,
+				RequestChecksumCalculation: aws.RequestChecksumCalculationWhenRequired,
+				ResponseChecksumValidation: aws.ResponseChecksumValidationWhenRequired,
+			})
+			ss, err := NewS3Storage(context.Background(), WithS3Client(client), WithS3Bucket("test-bucket"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ss.deleteObjectIfMatch(context.Background(), "xorbs/ab/cd", `"etag"`)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(gotIfMatch) != len(test.wantIfMatch) {
+				t.Fatalf("DELETE If-Match sequence = %q, want %q", gotIfMatch, test.wantIfMatch)
+			}
+			for i, want := range test.wantIfMatch {
+				if gotIfMatch[i] != want {
+					t.Fatalf("DELETE If-Match sequence = %q, want %q", gotIfMatch, test.wantIfMatch)
+				}
+			}
+		})
+	}
+}
+
+// A transfer that dies mid-stream must not be reported as invalid content:
+// invalid is terminal for the shard upload while transport errors retry.
+func TestS3StorageValidateXorbTransientReadErrorIsRetryable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Promise more bytes than are sent, then close the connection.
+		w.Header().Set("Content-Length", "4096")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte{0})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := s3.New(s3.Options{
+		BaseEndpoint:               aws.String(srv.URL),
+		Region:                     "us-east-1",
+		Credentials:                credentials.NewStaticCredentialsProvider("test", "test", ""),
+		UsePathStyle:               true,
+		RequestChecksumCalculation: aws.RequestChecksumCalculationWhenRequired,
+		ResponseChecksumValidation: aws.ResponseChecksumValidationWhenRequired,
+	})
+	ss, err := NewS3Storage(context.Background(), WithS3Client(client), WithS3Bucket("test-bucket"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ss.ValidateXorb(context.Background(), "default", xet.XorbHash{1})
+	if err == nil {
+		t.Fatal("ValidateXorb succeeded on a truncated transfer")
+	}
+	if errors.Is(err, ErrXorbInvalid) || errors.Is(err, ErrXorbNotFound) {
+		t.Fatalf("ValidateXorb = %v, want a retryable transport error", err)
 	}
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -54,6 +54,33 @@ type Storage interface {
 	GetFileHashBySHA256(ctx context.Context, namespace string, sha256 [32]byte) (xet.FileHash, error)
 }
 
+// ErrXorbNotFound reports a referenced xorb that has not been uploaded.
+var ErrXorbNotFound = errors.New("xorb not found")
+
+// ErrXorbInvalid reports stored xorb bytes that fail content validation.
+var ErrXorbInvalid = errors.New("invalid xorb content")
+
+// XorbUploadRedirector is implemented by storages that can accept xorb
+// uploads directly at a client-reachable URL, bypassing the CAS server.
+type XorbUploadRedirector interface {
+	// XorbUploadURL returns a URL that accepts exactly size bytes of raw
+	// xorb data via HTTP PUT, or "" when direct upload is currently
+	// unavailable.
+	XorbUploadURL(ctx context.Context, namespace string, xorbHash xet.XorbHash, size int64) (string, error)
+}
+
+// XorbValidator is implemented by storages whose data may arrive without
+// passing through PutXorb validation (direct uploads). Servers use it at
+// shard upload time to verify referenced xorbs; storages where every write
+// is validated on ingress should not implement it, an existence check is
+// cheaper and sufficient for them.
+type XorbValidator interface {
+	// ValidateXorb streams the stored xorb through full content validation.
+	// It returns ErrXorbNotFound when the xorb does not exist and an error
+	// wrapping ErrXorbInvalid when the content does not match the hash.
+	ValidateXorb(ctx context.Context, namespace string, xorbHash xet.XorbHash) error
+}
+
 // FileStorage implements Storage using the filesystem
 type FileStorage struct {
 	basePath     string
@@ -87,6 +114,7 @@ const defaultChunkCacheSize = 4096
 const defaultSHA256CacheSize = 4096
 const defaultXorbCacheSize = 512
 const defaultOffsetsCacheSize = 512
+const defaultValidatedCacheSize = 4096
 
 type Option func(*FileStorage)
 

--- a/test/conformance/matrix/hf_redirect_test.go
+++ b/test/conformance/matrix/hf_redirect_test.go
@@ -1,0 +1,250 @@
+package matrix_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wzshiming/xet"
+	"github.com/wzshiming/xet/client"
+	"github.com/wzshiming/xet/hf"
+	"github.com/wzshiming/xet/test/conformance/rustref"
+	"github.com/wzshiming/xet/test/conformance/utils"
+)
+
+// redirectingHub is a fake Hugging Face hub whose xet token routes answer with
+// a redirect before handing out the CAS endpoint and token, mimicking the
+// hub's behavior for moved or renamed repos.
+type redirectingHub struct {
+	url       string
+	entryHits atomic.Int64 // requests that were answered with a redirect
+	tokenHits atomic.Int64 // requests that reached the final token route
+}
+
+// startRedirectingHub starts a hub whose token routes redirect with the given
+// status code. With crossHost the redirect target lives on a second host,
+// where the hub credential must have been dropped, matching xet-core's
+// reqwest policy; a same-host hop must keep it.
+func startRedirectingHub(t *testing.T, casEndpoint string, code int, crossHost bool) *redirectingHub {
+	t.Helper()
+
+	hub := &redirectingHub{}
+	exp := time.Now().Add(time.Hour).Unix()
+	serveToken := func(w http.ResponseWriter, r *http.Request, wantAuth string) {
+		hub.tokenHits.Add(1)
+		if auth := r.Header.Get("Authorization"); auth != wantAuth {
+			t.Errorf("token route auth = %q, want %q", auth, wantAuth)
+		}
+		var mode string
+		switch {
+		case strings.Contains(r.URL.Path, "xet-write-token"):
+			mode = "write"
+		case strings.Contains(r.URL.Path, "xet-read-token"):
+			mode = "read"
+		default:
+			t.Errorf("unexpected token path: %s", r.URL.Path)
+		}
+		fmt.Fprintf(w, `{"casUrl":%q,"accessToken":"cas-%s-token","exp":%d}`, casEndpoint, mode, exp)
+	}
+	redirect := func(w http.ResponseWriter, r *http.Request, location string) {
+		hub.entryHits.Add(1)
+		if auth := r.Header.Get("Authorization"); auth != "Bearer hf-token" {
+			t.Errorf("redirecting route auth = %q, want %q", auth, "Bearer hf-token")
+		}
+		http.Redirect(w, r, location, code)
+	}
+
+	if crossHost {
+		final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			serveToken(w, r, "") // the chain left the hub host, credential dropped
+		}))
+		t.Cleanup(final.Close)
+		entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			redirect(w, r, final.URL+r.URL.Path)
+		}))
+		t.Cleanup(entry.Close)
+		hub.url = entry.URL
+		return hub
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/moved/", func(w http.ResponseWriter, r *http.Request) {
+		serveToken(w, r, "Bearer hf-token") // same-host hop keeps the credential
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		redirect(w, r, "/moved"+r.URL.Path)
+	})
+	entry := httptest.NewServer(mux)
+	t.Cleanup(entry.Close)
+	hub.url = entry.URL
+	return hub
+}
+
+// newHFClient returns a client without a static base URL, so the CAS endpoint
+// can only come from the token response handed out after the redirect.
+func newHFClient(t *testing.T) *client.Client {
+	t.Helper()
+	c, err := client.NewClient(client.WithCacheDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("create Go client: %v", err)
+	}
+	return c
+}
+
+func uploadFileWithProvider(ctx context.Context, c *client.Client, protocol rustref.ProtocolVersion, provider client.AuthProvider, r io.ReadSeeker) (xet.FileHash, error) {
+	if protocol == rustref.ProtocolV2 {
+		return c.UploadFileV2WithAuthProvider(ctx, provider, r)
+	}
+	return c.UploadFileV1WithAuthProvider(ctx, provider, r)
+}
+
+func downloadFileWithProvider(ctx context.Context, c *client.Client, protocol rustref.ProtocolVersion, provider client.AuthProvider, hash xet.FileHash, w io.WriteSeeker) error {
+	if protocol == rustref.ProtocolV2 {
+		return c.DownloadFileV2WithAuthProvider(ctx, provider, hash, w)
+	}
+	return c.DownloadFileV1WithAuthProvider(ctx, provider, hash, w)
+}
+
+// TestHFUploadRedirectMatrix runs the full Hugging Face flow — write-token
+// upload followed by read-token download — with both the xet-core client and
+// the Go client, against every server kind and protocol version, for every
+// redirect status code the hub may answer the token routes with, on both
+// same-host and cross-host topologies. xet-core resolves the CAS endpoint and
+// token through its real hub token refresher, so the Go client's redirect
+// handling is verified against the reference behavior, not assumptions.
+func TestHFUploadRedirectMatrix(t *testing.T) {
+	redirectCodes := []int{
+		http.StatusMovedPermanently,  // 301
+		http.StatusFound,             // 302
+		http.StatusSeeOther,          // 303
+		http.StatusTemporaryRedirect, // 307
+		http.StatusPermanentRedirect, // 308
+	}
+	topologies := []struct {
+		name      string
+		crossHost bool
+	}{
+		{name: "same_host", crossHost: false},
+		{name: "cross_host", crossHost: true},
+	}
+	clients := []clientKind{xetCoreClient, goClient}
+
+	runServerProtocolMatrix(t, func(t *testing.T, server serverKind, protocol rustref.ProtocolVersion) {
+		running := server.start(t)
+		for _, code := range redirectCodes {
+			for _, topo := range topologies {
+				t.Run(fmt.Sprintf("redirect_%d_%s", code, topo.name), func(t *testing.T) {
+					for _, kind := range clients {
+						t.Run(string(kind), func(t *testing.T) {
+							hub := startRedirectingHub(t, running.endpoint, code, topo.crossHost)
+
+							// Unique content per cell so a shared server cannot
+							// satisfy a cell from another cell's upload.
+							label := fmt.Sprintf("%s/%s/%d/%s/%s", server.name, protocol, code, topo.name, kind)
+							data := append([]byte(label+": "), utils.MakeRandData(256*1024)...)
+
+							if kind == xetCoreClient {
+								xetCoreHFRoundTrip(t, hub, protocol, label, data)
+							} else {
+								goHFRoundTrip(t, hub, protocol, label, data)
+							}
+
+							// Both token modes must have traversed the redirect.
+							if hub.entryHits.Load() < 2 {
+								t.Errorf("redirecting route hit %d times, want >= 2 (write and read token)", hub.entryHits.Load())
+							}
+							if hub.tokenHits.Load() < 2 {
+								t.Errorf("token route hit %d times, want >= 2 (write and read token)", hub.tokenHits.Load())
+							}
+						})
+					}
+				})
+			}
+		}
+	})
+}
+
+const (
+	hubWriteTokenPath = "/api/models/org/repo/xet-write-token/main"
+	hubReadTokenPath  = "/api/models/org/repo/xet-read-token/main"
+)
+
+// xetCoreHFRoundTrip uploads and downloads with the real xet-core client,
+// resolving CAS endpoint and tokens through the redirecting hub routes.
+func xetCoreHFRoundTrip(t *testing.T, hub *redirectingHub, protocol rustref.ProtocolVersion, label string, data []byte) {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "upload")
+	if err := os.WriteFile(src, data, 0o600); err != nil {
+		t.Fatalf("write upload fixture: %v", err)
+	}
+
+	results, err := rustref.UploadFilesViaTokenRefresh([]string{src}, hub.url+hubWriteTokenPath, "hf-token", protocol)
+	if err != nil {
+		t.Fatalf("hf upload with xet-core client: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("uploaded %d files, want 1", len(results))
+	}
+	if results[0].FileSize != uint64(len(data)) {
+		t.Errorf("reported size = %d, want %d", results[0].FileSize, len(data))
+	}
+
+	dest := filepath.Join(dir, "download")
+	if _, err := rustref.DownloadFilesViaTokenRefresh([]rustref.DownloadRequest{{
+		DestinationPath: dest,
+		Hash:            results[0].Hash,
+		FileSize:        int64(len(data)),
+	}}, hub.url+hubReadTokenPath, "hf-token", protocol); err != nil {
+		t.Fatalf("hf download with xet-core client: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read download file: %v", err)
+	}
+	checkContent(t, label, got, data)
+}
+
+// goHFRoundTrip uploads and downloads with the Go client through the hf
+// token providers pointed at the redirecting hub.
+func goHFRoundTrip(t *testing.T, hub *redirectingHub, protocol rustref.ProtocolVersion, label string, data []byte) {
+	t.Helper()
+	target := hf.Target{Endpoint: hub.url, RepoType: "model", RepoID: "org/repo", Revision: "main"}
+
+	writeProvider := hf.NewWriteTokenProvider(nil, target, "hf-token")
+	hash, err := uploadFileWithProvider(context.Background(), newHFClient(t), protocol, writeProvider, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("hf upload with Go client: %v", err)
+	}
+
+	// Fresh client and cache so the download cannot be served from
+	// client-local state; the read token route is redirected the same way.
+	readProvider := hf.NewReadTokenProvider(nil, target, "hf-token")
+	path := filepath.Join(t.TempDir(), "download")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create download file: %v", err)
+	}
+	err = downloadFileWithProvider(context.Background(), newHFClient(t), protocol, readProvider, hash, file)
+	closeErr := file.Close()
+	if err != nil {
+		t.Fatalf("hf download with Go client: %v", err)
+	}
+	if closeErr != nil {
+		t.Fatalf("close download file: %v", closeErr)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read download file: %v", err)
+	}
+	checkContent(t, label, got, data)
+}

--- a/test/conformance/matrix/s3_test.go
+++ b/test/conformance/matrix/s3_test.go
@@ -18,18 +18,20 @@ import (
 )
 
 // startGoServerS3 starts the Go server backed by S3Storage so the matrix also
-// covers the S3 read/write paths. Xorb downloads are presigned S3 URLs that
-// bypass the recording proxy for both clients alike, so wire comparisons stay
-// symmetric.
+// covers the S3 read/write paths. Presigning is disabled: presigned transfers
+// go straight to the object store and would bypass the recording proxy. This
+// keeps every request on the recorded wire for both clients alike, so
+// comparisons stay symmetric; the presigned paths are covered by
+// TestCompatibilityS3PresignedDownload.
 func startGoServerS3(t *testing.T) runningServer {
 	t.Helper()
-	running, _ := newS3BackedServer(t)
+	running, _ := newS3BackedServer(t, false)
 	return running
 }
 
 // newS3BackedServer returns a recording Go server over an in-process gofakes3
-// plus the fake S3 endpoint that presigned fetch-info URLs must point at.
-func newS3BackedServer(t *testing.T) (runningServer, string) {
+// plus the fake S3 endpoint that presigned URLs must point at.
+func newS3BackedServer(t *testing.T, presign bool) (runningServer, string) {
 	t.Helper()
 
 	const bucket = "conformance"
@@ -52,6 +54,7 @@ func newS3BackedServer(t *testing.T) (runningServer, string) {
 	stor, err := storage.NewS3Storage(context.Background(),
 		storage.WithS3Client(s3Client),
 		storage.WithS3Bucket(bucket),
+		storage.WithS3Presign(presign),
 	)
 	if err != nil {
 		t.Fatalf("create S3 storage: %v", err)
@@ -65,15 +68,14 @@ func newS3BackedServer(t *testing.T) (runningServer, string) {
 
 // TestCompatibilityS3PresignedDownload proves the xet-core client follows the
 // presigned S3 fetch-info URLs the S3-backed Go server hands out: uploads go
-// through the Go client, the reconstruction is asserted to reference only
-// presigned object-store URLs, and the download runs with the reference
-// client for both protocol versions.
+// through the Go client (which handles the direct-upload redirect to S3), the
+// reconstruction is asserted to reference only presigned object-store URLs,
+// and the download runs with the reference client for both protocol versions.
 func TestCompatibilityS3PresignedDownload(t *testing.T) {
 	fixtures := wireFixtures()
 	for _, protocol := range []rustref.ProtocolVersion{rustref.ProtocolV1, rustref.ProtocolV2} {
 		t.Run(protocol.String(), func(t *testing.T) {
-			running, s3Endpoint := newS3BackedServer(t)
-
+			running, s3Endpoint := newS3BackedServer(t, true)
 			hashes := upload(t, goClient, protocol, running.endpoint, fixtures)
 			if len(hashes) != len(fixtures) {
 				t.Fatalf("uploaded %d files, want %d", len(hashes), len(fixtures))

--- a/test/conformance/rustref/reference.go
+++ b/test/conformance/rustref/reference.go
@@ -52,19 +52,23 @@ func (v ProtocolVersion) String() string {
 }
 
 type uploadRequest struct {
-	FilePaths  []string         `json:"file_paths"`
-	Endpoint   string           `json:"endpoint"`
-	Token      *TokenInfo       `json:"token,omitempty"`
-	SHA256s    []string         `json:"sha256s,omitempty"`
-	SkipSHA256 bool             `json:"skip_sha256"`
-	APIVersion *ProtocolVersion `json:"api_version,omitempty"`
+	FilePaths       []string         `json:"file_paths"`
+	Endpoint        string           `json:"endpoint"`
+	Token           *TokenInfo       `json:"token,omitempty"`
+	SHA256s         []string         `json:"sha256s,omitempty"`
+	SkipSHA256      bool             `json:"skip_sha256"`
+	APIVersion      *ProtocolVersion `json:"api_version,omitempty"`
+	TokenRefreshURL string           `json:"token_refresh_url,omitempty"`
+	HubToken        string           `json:"hub_token,omitempty"`
 }
 
 type downloadRequest struct {
-	Files      []DownloadRequest `json:"files"`
-	Endpoint   string            `json:"endpoint"`
-	Token      *TokenInfo        `json:"token,omitempty"`
-	APIVersion *ProtocolVersion  `json:"api_version,omitempty"`
+	Files           []DownloadRequest `json:"files"`
+	Endpoint        string            `json:"endpoint"`
+	Token           *TokenInfo        `json:"token,omitempty"`
+	APIVersion      *ProtocolVersion  `json:"api_version,omitempty"`
+	TokenRefreshURL string            `json:"token_refresh_url,omitempty"`
+	HubToken        string            `json:"hub_token,omitempty"`
 }
 
 var (
@@ -291,6 +295,40 @@ func downloadFiles(files []DownloadRequest, endpoint string, token *TokenInfo, v
 		Endpoint:   endpoint,
 		Token:      token,
 		APIVersion: version,
+	}, &result)
+	return result, err
+}
+
+// UploadFilesViaTokenRefresh uploads through xet-core's Hugging Face hub
+// flow: the CAS endpoint and access token are resolved by an authenticated
+// GET to refreshURL (following any redirects the hub answers with), exactly
+// as a real hf upload does.
+func UploadFilesViaTokenRefresh(filePaths []string, refreshURL, hubToken string, version ProtocolVersion) ([]UploadResult, error) {
+	if err := validateProtocolVersion(version); err != nil {
+		return nil, err
+	}
+	var result []UploadResult
+	err := runJSON("upload-files", uploadRequest{
+		FilePaths:       filePaths,
+		APIVersion:      &version,
+		TokenRefreshURL: refreshURL,
+		HubToken:        hubToken,
+	}, &result)
+	return result, err
+}
+
+// DownloadFilesViaTokenRefresh downloads through the same hub token-refresh
+// flow as UploadFilesViaTokenRefresh, using the read token route.
+func DownloadFilesViaTokenRefresh(files []DownloadRequest, refreshURL, hubToken string, version ProtocolVersion) ([]string, error) {
+	if err := validateProtocolVersion(version); err != nil {
+		return nil, err
+	}
+	var result []string
+	err := runJSON("download-files", downloadRequest{
+		Files:           files,
+		APIVersion:      &version,
+		TokenRefreshURL: refreshURL,
+		HubToken:        hubToken,
 	}, &result)
 	return result, err
 }

--- a/test/conformance/src/main.rs
+++ b/test/conformance/src/main.rs
@@ -1,8 +1,12 @@
 use std::io::{Cursor, Read, Write};
+use std::sync::Arc;
 
 use anyhow::{Context, Result, bail, ensure};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use xet_client::cas_client::LocalTestServerBuilder;
+use xet_client::cas_client::auth::{DirectRefreshRouteTokenRefresher, TokenRefresher};
+use xet_client::cas_client::build_http_client;
+use xet_client::cas_client::exports::reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use xet_core_structures::merklehash::{MerkleHash, compute_data_hash, file_hash, xorb_hash};
 use xet_core_structures::metadata_shard::chunk_verification::range_hash_from_chunks;
 use xet_core_structures::xorb_object::{
@@ -27,6 +31,8 @@ struct UploadRequest {
     sha256s: Option<Vec<String>>,
     skip_sha256: bool,
     api_version: Option<u32>,
+    token_refresh_url: Option<String>,
+    hub_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -35,6 +41,8 @@ struct DownloadRequest {
     endpoint: String,
     token: Option<TokenInfo>,
     api_version: Option<u32>,
+    token_refresh_url: Option<String>,
+    hub_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -96,17 +104,23 @@ fn run() -> Result<()> {
         "upload-files" => {
             let request: UploadRequest = read_json()?;
             let policies = sha256_policies(&request)?;
-            let token = request.token.map(|value| (value.token, value.expiry));
+            let mut token = request.token.map(|value| (value.token, value.expiry));
             let context = context_for_api_version(request.api_version)?;
+            let mut endpoint = (!request.endpoint.is_empty()).then(|| request.endpoint.clone());
+            let mut refresher: Option<Arc<dyn TokenRefresher>> = None;
+            if let Some(refresh_url) = request.token_refresh_url.as_deref() {
+                (endpoint, token, refresher) =
+                    resolve_hub_auth(&context, refresh_url, request.hub_token.as_deref(), endpoint, token)?;
+            }
             let runtime = context.runtime.clone();
             let result = runtime.bridge_sync(async move {
                 data_client::upload_async(
                     &context,
                     request.file_paths,
                     policies,
-                    Some(request.endpoint),
+                    endpoint,
                     token,
-                    None,
+                    refresher,
                     None,
                     None,
                 )
@@ -128,16 +142,22 @@ fn run() -> Result<()> {
                     (info, value.destination_path)
                 })
                 .collect();
-            let token = request.token.map(|value| (value.token, value.expiry));
+            let mut token = request.token.map(|value| (value.token, value.expiry));
             let context = context_for_api_version(request.api_version)?;
+            let mut endpoint = (!request.endpoint.is_empty()).then(|| request.endpoint.clone());
+            let mut refresher: Option<Arc<dyn TokenRefresher>> = None;
+            if let Some(refresh_url) = request.token_refresh_url.as_deref() {
+                (endpoint, token, refresher) =
+                    resolve_hub_auth(&context, refresh_url, request.hub_token.as_deref(), endpoint, token)?;
+            }
             let runtime = context.runtime.clone();
             let result = runtime.bridge_sync(async move {
                 data_client::download_async(
                     &context,
                     files,
-                    Some(request.endpoint),
+                    endpoint,
                     token,
-                    None,
+                    refresher,
                     None,
                     None,
                 )
@@ -190,6 +210,41 @@ fn context_for_api_version(api_version: Option<u32>) -> Result<XetContext> {
     config.client.reconstruction_api_version = api_version;
     config.client.shard_api_version = api_version;
     Ok(XetContext::with_config(config)?)
+}
+
+/// Hub-style auth: build a `DirectRefreshRouteTokenRefresher` for the
+/// (possibly redirected) token route and, when no endpoint is given, resolve
+/// the CAS endpoint and initial token from it, mirroring xet-core's real
+/// Hugging Face upload/download flow.
+fn resolve_hub_auth(
+    context: &XetContext,
+    refresh_url: &str,
+    hub_token: Option<&str>,
+    endpoint: Option<String>,
+    token: Option<(String, u64)>,
+) -> Result<(Option<String>, Option<(String, u64)>, Option<Arc<dyn TokenRefresher>>)> {
+    let mut headers = HeaderMap::new();
+    if let Some(hub_token) = hub_token {
+        headers.insert(AUTHORIZATION, HeaderValue::from_str(&format!("Bearer {hub_token}"))?);
+    }
+    let client = build_http_client(context, "", None, Some(Arc::new(headers)))?;
+    let refresher = Arc::new(DirectRefreshRouteTokenRefresher::new(
+        context.clone(),
+        refresh_url.to_owned(),
+        client,
+        None,
+    ));
+
+    let (endpoint, token) = if let Some(endpoint) = endpoint {
+        (endpoint, token)
+    } else {
+        let eager = refresher.clone();
+        let runtime = context.runtime.clone();
+        let jwt = runtime.bridge_sync(async move { eager.get_cas_jwt().await })??;
+        (jwt.cas_url, token.or(Some((jwt.access_token, jwt.exp))))
+    };
+
+    Ok((Some(endpoint), token, Some(refresher)))
 }
 
 fn read_stdin() -> Result<Vec<u8>> {

--- a/test/e2e/hf_upload_redirect_test.go
+++ b/test/e2e/hf_upload_redirect_test.go
@@ -1,0 +1,121 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wzshiming/xet/client"
+	"github.com/wzshiming/xet/hf"
+	"github.com/wzshiming/xet/server"
+	"github.com/wzshiming/xet/storage"
+)
+
+// TestHFUploadFollowsWriteTokenRedirect verifies the hf upload flow when the
+// hub redirects the xet-write-token route (as huggingface.co does for moved or
+// renamed repos). Aligned with xet-core's reqwest client, the token GET must
+// follow the redirect — dropping the hub credential on the cross-host hop —
+// and the upload then proceeds against the CAS endpoint named in the token
+// response using the token it carried.
+func TestHFUploadFollowsWriteTokenRedirect(t *testing.T) {
+	casStorage, err := storage.NewFileStorage(storage.WithBasePath(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	casHandler := server.NewHandler(server.WithStorage(casStorage))
+	var casAuthOK atomic.Bool
+	casAuthOK.Store(true)
+	casServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer cas-write-token" {
+			casAuthOK.Store(false)
+		}
+		casHandler.ServeHTTP(w, r)
+	}))
+	defer casServer.Close()
+
+	const tokenPath = "/api/models/org/repo/xet-write-token/main"
+	exp := time.Now().Add(time.Hour).Unix()
+
+	var newHubHits atomic.Int64
+	newHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		newHubHits.Add(1)
+		if r.URL.Path != tokenPath {
+			t.Errorf("new hub: unexpected path: %s", r.URL.Path)
+		}
+		// The hop left the original host, so the hub token must be dropped.
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("new hub: cross-host redirect must drop the hub token, got: %s", auth)
+		}
+		fmt.Fprintf(w, `{"casUrl":%q,"accessToken":"cas-write-token","exp":%d}`, casServer.URL, exp)
+	}))
+	defer newHub.Close()
+
+	var oldHubHits atomic.Int64
+	oldHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		oldHubHits.Add(1)
+		if r.URL.Path != tokenPath {
+			t.Errorf("old hub: unexpected path: %s", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer hf-token" {
+			t.Errorf("old hub: unexpected auth header: %s", auth)
+		}
+		http.Redirect(w, r, newHub.URL+tokenPath, http.StatusTemporaryRedirect)
+	}))
+	defer oldHub.Close()
+
+	target := hf.Target{Endpoint: oldHub.URL, RepoType: "model", RepoID: "org/repo", Revision: "main"}
+	provider := hf.NewWriteTokenProvider(nil, target, "hf-token")
+
+	uploadClient, err := client.NewClient(client.WithCacheDir(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := deterministicData(3*128*1024 + 7919)
+	fileHash, err := uploadClient.UploadFileWithAuthProvider(context.Background(), provider, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("upload through redirected write-token route: %v", err)
+	}
+
+	if oldHubHits.Load() == 0 {
+		t.Error("old hub token route was never called")
+	}
+	if newHubHits.Load() == 0 {
+		t.Error("redirect target token route was never called")
+	}
+	if !casAuthOK.Load() {
+		t.Error("CAS requests did not carry the redirected write token")
+	}
+
+	// Round-trip through the CAS server to prove the upload landed intact.
+	downloadClient, err := client.NewClient(
+		client.WithBaseURL(casServer.URL),
+		client.WithToken("cas-write-token"),
+		client.WithCacheDir(t.TempDir()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := os.Create(filepath.Join(t.TempDir(), "out"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+	if err := downloadClient.DownloadFile(context.Background(), fileHash, out); err != nil {
+		t.Fatalf("download uploaded file: %v", err)
+	}
+	got, err := os.ReadFile(out.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("round-trip mismatch: got %d bytes, want %d", len(got), len(data))
+	}
+}

--- a/test/e2e/s3_storage_test.go
+++ b/test/e2e/s3_storage_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,14 +20,25 @@ import (
 	"github.com/wzshiming/xet"
 	"github.com/wzshiming/xet/client"
 	"github.com/wzshiming/xet/server"
+	"github.com/wzshiming/xet/shard"
 	"github.com/wzshiming/xet/storage"
+	"github.com/wzshiming/xet/upload"
+	"github.com/wzshiming/xet/xorb"
 )
 
 // TestS3StorageUploadRestartAndDownload runs the full upload/download cycle
 // against an in-process S3 double (gofakes3) through the production option
-// path. Both storage instances share one backend, so the restart below
-// proves nothing is served from memory.
+// path, with presigned transfers on and off. Both storage instances share one
+// backend, so the restart below proves nothing is served from memory.
 func TestS3StorageUploadRestartAndDownload(t *testing.T) {
+	for _, presign := range []bool{true, false} {
+		t.Run(fmt.Sprintf("presign=%t", presign), func(t *testing.T) {
+			testS3StorageUploadRestartAndDownload(t, presign)
+		})
+	}
+}
+
+func testS3StorageUploadRestartAndDownload(t *testing.T, presign bool) {
 	ctx := context.Background()
 
 	const bucket = "xet-e2e"
@@ -54,6 +66,7 @@ func TestS3StorageUploadRestartAndDownload(t *testing.T) {
 			storage.WithS3Prefix("xet-data"),
 			storage.WithS3Endpoint(endpoint),
 			storage.WithS3PathStyle(true),
+			storage.WithS3Presign(presign),
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -68,6 +81,45 @@ func TestS3StorageUploadRestartAndDownload(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if !presign {
+		// With presigning off there is no direct-upload URL: an opt-in xorb
+		// POST must be served by the streaming path, not redirected.
+		var encoded bytes.Buffer
+		enc := xorb.NewEncoder(&encoded, true)
+		if _, err := enc.Write([]byte("streamed through the server")); err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.Close(); err != nil {
+			t.Fatal(err)
+		}
+		req, err := http.NewRequest(http.MethodPost, uploadServer.URL+"/v1/xorbs/default/"+enc.SummoryHash().String(), bytes.NewReader(encoded.Bytes()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set(upload.HeaderDirectUpload, upload.DirectUploadAccept)
+		noRedirect := &http.Client{
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		}
+		resp, err := noRedirect.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("opt-in xorb POST with presign off = %d, want 200 (streaming)", resp.StatusCode)
+		}
+		var uploadResp struct {
+			WasInserted bool `json:"was_inserted"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&uploadResp); err != nil {
+			t.Fatal(err)
+		}
+		if !uploadResp.WasInserted {
+			t.Fatal("was_inserted = false, want true for streamed upload")
+		}
 	}
 
 	files := []struct {
@@ -101,8 +153,9 @@ func TestS3StorageUploadRestartAndDownload(t *testing.T) {
 
 	for _, file := range files {
 		t.Run(file.name, func(t *testing.T) {
-			// Reconstruction must hand out presigned S3 URLs pointing at the
-			// object store, not at the CAS server.
+			// Reconstruction hands out presigned S3 URLs with presigning on,
+			// and CAS-server routes (resolved against the request host) with
+			// presigning off.
 			var reconstruction struct {
 				FetchInfo map[string][]struct {
 					URL string `json:"url"`
@@ -121,8 +174,12 @@ func TestS3StorageUploadRestartAndDownload(t *testing.T) {
 			}
 			for _, entries := range reconstruction.FetchInfo {
 				for _, entry := range entries {
-					if !strings.HasPrefix(entry.URL, endpoint+"/") || !strings.Contains(entry.URL, "X-Amz-Signature") {
-						t.Fatalf("fetch URL = %q, want presigned URL at %s", entry.URL, endpoint)
+					if presign {
+						if !strings.HasPrefix(entry.URL, endpoint+"/") || !strings.Contains(entry.URL, "X-Amz-Signature") {
+							t.Fatalf("fetch URL = %q, want presigned URL at %s", entry.URL, endpoint)
+						}
+					} else if !strings.HasPrefix(entry.URL, downloadServer.URL+"/v1/xorbs/") {
+						t.Fatalf("fetch URL = %q, want CAS xorb route at %s", entry.URL, downloadServer.URL)
 					}
 				}
 			}
@@ -157,5 +214,170 @@ func TestS3StorageUploadRestartAndDownload(t *testing.T) {
 				assertResponse(t, resp, http.StatusPartialContent, file.data[start:end+1])
 			}
 		})
+	}
+}
+
+// TestS3DirectXorbUploadAndShardTimeValidation drives the direct-upload
+// contract over raw HTTP: the xorb POST redirects to a presigned S3 PUT URL
+// without consuming the body, the shard is rejected while the xorb is missing
+// or corrupt, and accepted once valid bytes are in the object store.
+func TestS3DirectXorbUploadAndShardTimeValidation(t *testing.T) {
+	ctx := context.Background()
+
+	const bucket = "xet-direct"
+	backend := s3mem.New()
+	if err := backend.CreateBucket(bucket); err != nil {
+		t.Fatal(err)
+	}
+	s3Server := httptest.NewServer(gofakes3.New(backend).Server())
+	defer s3Server.Close()
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_REQUEST_CHECKSUM_CALCULATION", "when_required")
+	t.Setenv("AWS_RESPONSE_CHECKSUM_VALIDATION", "when_required")
+
+	stor, err := storage.NewS3Storage(ctx,
+		storage.WithS3Bucket(bucket),
+		storage.WithS3Endpoint(s3Server.URL),
+		storage.WithS3PathStyle(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	casServer := httptest.NewServer(server.NewHandler(server.WithStorage(stor)))
+	defer casServer.Close()
+
+	// One single-chunk xorb and a shard referencing it.
+	data := []byte("direct upload payload")
+	var encoded bytes.Buffer
+	encoder := xorb.NewEncoder(&encoded, true)
+	if _, err := encoder.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatal(err)
+	}
+	xorbHash := encoder.SummoryHash()
+	chunkHash := xet.ComputeChunkHash(data)
+	shardObj := shard.NewShard()
+	shardObj.AddCASBlock(shard.CASBlock{
+		CASHash:       xorbHash,
+		NumBytesInCAS: uint32(len(data)),
+		Chunks:        []shard.CASChunkSequenceEntry{{ChunkHash: chunkHash, UnpackedSegBytes: uint32(len(data))}},
+	})
+	shardObj.AddFile(shard.FileBlock{
+		FileHash: xet.ComputeFileHash([]xet.ChunkHash{chunkHash}, []uint64{uint64(len(data))}),
+		Entries:  []shard.FileDataSequenceEntry{{CASHash: xorbHash, UnpackedSegBytes: uint32(len(data)), ChunkIndexEnd: 1}},
+	})
+	shardReader, err := shardObj.Encode(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shardBody, err := io.ReadAll(shardReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	postShard := func() *http.Response {
+		t.Helper()
+		resp, err := http.Post(casServer.URL+"/v1/shards", "application/octet-stream", bytes.NewReader(shardBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { resp.Body.Close() })
+		return resp
+	}
+	putDirect := func(uploadURL string, payload []byte) {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPut, uploadURL, bytes.NewReader(payload))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Mirror the Go client: the presigned URL is signed as create-only.
+		req.Header.Set("If-None-Match", "*")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("direct PUT status %s: %s", resp.Status, body)
+		}
+	}
+	postXorb := func() *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, casServer.URL+"/v1/xorbs/default/"+xorbHash.String(), bytes.NewReader(encoded.Bytes()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set(upload.HeaderDirectUpload, upload.DirectUploadAccept)
+		resp, err := noRedirect.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	// A shard referencing a never-uploaded xorb is rejected.
+	resp := postShard()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadRequest || !strings.Contains(string(body), "referenced xorb not uploaded") {
+		t.Fatalf("shard status before xorb upload = %d (%s), want 400 not-uploaded", resp.StatusCode, body)
+	}
+
+	// The xorb POST answers 307 with a presigned PUT URL at the object store.
+	resp = postXorb()
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("xorb POST status = %d, want 307", resp.StatusCode)
+	}
+	uploadURL := resp.Header.Get("Location")
+	if !strings.HasPrefix(uploadURL, s3Server.URL+"/") || !strings.Contains(uploadURL, "X-Amz-Signature") {
+		t.Fatalf("Location = %q, want presigned URL at %s", uploadURL, s3Server.URL)
+	}
+
+	// Corrupt bytes are accepted by S3 but rejected at shard time.
+	bad := append([]byte(nil), encoded.Bytes()...)
+	bad[10] ^= 0xff
+	putDirect(uploadURL, bad)
+	resp = postShard()
+	body, _ = io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadRequest || !strings.Contains(string(body), "invalid xorb content") {
+		t.Fatalf("shard status with corrupt xorb = %d (%s), want 400 invalid content", resp.StatusCode, body)
+	}
+	// The rejected bytes were deleted, so the key is not poisoned for retries.
+	if ok, err := stor.HasXorb(ctx, "default", xorbHash); err != nil || ok {
+		t.Fatalf("HasXorb after rejected shard = %v, %v; want false", ok, err)
+	}
+
+	// Valid bytes make the shard acceptable.
+	putDirect(uploadURL, encoded.Bytes())
+	resp = postShard()
+	body, _ = io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("shard status with valid xorb = %d (%s), want 200", resp.StatusCode, body)
+	}
+
+	// Re-posting the stored xorb short-circuits without a redirect.
+	resp = postXorb()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("xorb POST for stored xorb = %d, want 200", resp.StatusCode)
+	}
+	var uploadResp struct {
+		WasInserted bool `json:"was_inserted"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&uploadResp); err != nil {
+		t.Fatal(err)
+	}
+	if uploadResp.WasInserted {
+		t.Fatal("was_inserted = true for already stored xorb, want false")
 	}
 }

--- a/upload/types.go
+++ b/upload/types.go
@@ -9,3 +9,12 @@ type XorbUploadResponse struct {
 type ShardUploadResponse struct {
 	Result int `json:"result"` // 0 = already exists, 1 = was registered
 }
+
+// HeaderDirectUpload is the xorb upload POST header a client sends to
+// advertise it can follow a 307 redirect to a direct-upload PUT URL.
+// Servers must not redirect without it: xet-core auto-follows the redirect
+// as a re-POST, which presigned PUT URLs reject.
+const HeaderDirectUpload = "X-Xet-Direct-Upload"
+
+// DirectUploadAccept is the HeaderDirectUpload value sent by capable clients.
+const DirectUploadAccept = "accept"

--- a/xorb/decoder.go
+++ b/xorb/decoder.go
@@ -71,7 +71,7 @@ func (d *Decoder) Read(p []byte) (int, error) {
 
 		tmp := pool.GetChunkBuf()
 		defer pool.PutChunkBuf(tmp)
-		err := validateWithFooter(d.r, tmp[:], headerBuf, d.SummoryHash(), d.chunkHashes)
+		err := validateWithFooter(d.r, tmp[:], headerBuf, d.SummoryHash(), d.chunkHashes, d.chunkSizes)
 		if err != nil {
 			d.err = fmt.Errorf("validate footer: %w", err)
 			return 0, d.err

--- a/xorb/validate.go
+++ b/xorb/validate.go
@@ -29,7 +29,11 @@ func Validate(r io.Reader, xorbHash xet.XorbHash) error {
 	for {
 		n, err := io.ReadFull(r, headerBuf[:])
 		if err == io.EOF {
-			// Chunk-only format: structural validation passed.
+			// Chunk-only format: no trusted footer, so bind the decoded
+			// content to the expected hash directly.
+			if computed := xet.ComputeXorbHash(chunkHashes, chunkSizes); computed != xorbHash {
+				return fmt.Errorf("xorb hash mismatch: computed %x, expected %x", computed, xorbHash)
+			}
 			return nil
 		}
 		if err == io.ErrUnexpectedEOF {
@@ -40,7 +44,7 @@ func Validate(r io.Reader, xorbHash xet.XorbHash) error {
 		}
 
 		if n >= 7 && bytes.Equal(headerBuf[:7], xorbIdentifier[:]) {
-			return validateWithFooter(r, tmp[:], headerBuf, xorbHash, chunkHashes)
+			return validateWithFooter(r, tmp[:], headerBuf, xorbHash, chunkHashes, chunkSizes)
 		}
 
 		version := headerBuf[0]
@@ -85,6 +89,7 @@ func validateWithFooter(
 	r io.Reader, buf []byte, headerBuf [8]byte,
 	xorbHash xet.XorbHash,
 	chunkHashes []xet.ChunkHash,
+	chunkSizes []uint64,
 ) error {
 	// Validate main header version.
 	if headerBuf[7] != 1 {
@@ -136,6 +141,12 @@ func validateWithFooter(
 
 	if numChunks != uint32(len(chunkHashes)) {
 		return fmt.Errorf("chunk count mismatch: footer has %d, stream has %d", numChunks, len(chunkHashes))
+	}
+
+	// The footer's claimed hashes are writer-controlled (direct uploads bypass
+	// the server), so recompute the xorb hash from the decoded chunks.
+	if computed := xet.ComputeXorbHash(chunkHashes, chunkSizes); computed != xorbHash {
+		return fmt.Errorf("xorb hash mismatch: computed %x, expected %x", computed, xorbHash)
 	}
 
 	// Parse per-chunk hashes from the hash section (first 32*N bytes of remaining).

--- a/xorb/validate_test.go
+++ b/xorb/validate_test.go
@@ -132,6 +132,40 @@ func TestEncoderEnforcesDraft05XorbLimits(t *testing.T) {
 	})
 }
 
+func TestValidateBindsContentToExpectedHash(t *testing.T) {
+	var chunkOnly bytes.Buffer
+	encoder := NewEncoder(&chunkOnly, false)
+	if _, err := encoder.Write([]byte("chunk-only content")); err != nil {
+		t.Fatal(err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Validate(bytes.NewReader(chunkOnly.Bytes()), encoder.SummoryHash()); err != nil {
+		t.Fatalf("Validate() with correct hash: %v", err)
+	}
+	err := Validate(bytes.NewReader(chunkOnly.Bytes()), xet.XorbHash{42})
+	if err == nil || !strings.Contains(err.Error(), "hash mismatch") {
+		t.Fatalf("Validate() chunk-only wrong hash error = %v, want hash mismatch", err)
+	}
+}
+
+func TestValidateRejectsForgedFooterHash(t *testing.T) {
+	// An internally consistent footer claiming the wrong xorb hash must not
+	// validate: the hash has to be recomputed from the chunks themselves.
+	data, _ := encodeXorbForTest(t, [4]byte{}, []byte("first"), []byte("second"))
+	claimed := xet.XorbHash{7}
+	footerLen := binary.LittleEndian.Uint32(data[len(data)-4:])
+	footerStart := len(data) - int(footerLen) - 4
+	copy(data[footerStart+8:footerStart+40], claimed[:])
+
+	err := Validate(bytes.NewReader(data), claimed)
+	if err == nil || !strings.Contains(err.Error(), "hash mismatch") {
+		t.Fatalf("Validate() forged footer error = %v, want hash mismatch", err)
+	}
+}
+
 func encodeXorbForTest(t *testing.T, nonce [4]byte, chunks ...[]byte) ([]byte, xet.XorbHash) {
 	t.Helper()
 


### PR DESCRIPTION
With S3 storage every xorb upload still streamed through xetd: the client POSTed to `/v1/xorbs/{namespace}/{hash}` and `PutXorb` spooled, validated and re-uploaded the bytes to S3. Downloads already bypass the server via presigned GET URLs, but uploads paid the bandwidth twice and pinned server CPU and disk for spooling, making xetd the bottleneck for bulk uploads.

With presign enabled (`-s3-presign`, on by default) the xorb POST no longer carries data through the server:

- **Server**: `handleUploadXorb` answers a `HasXorb` hit with `200 {"was_inserted": false}`, otherwise `307` with a presigned PUT `Location` — without reading the request body (new `storage.XorbUploadRedirector` capability). The redirect is only offered to clients that opt in with `X-Xet-Direct-Upload: accept`; everyone else (xet-core auto-follows 307 as a re-POST, which presigned PUT URLs reject) keeps the streaming `PutXorb` path, as do file storage and presign-off S3.
- **Shard-time verification**: the v1 and v2 shard handlers replace the `HasXorb` reference check with full validation — every referenced xorb (`CASInfos` entries **and** file-entry references to xorbs outside the shard) is streamed back from storage through `xorb.Validate` (`storage.XorbValidator`) with bounded concurrency. Missing xorb → "referenced xorb not uploaded"; corrupt xorb → non-retryable validation error; a failed S3 read → retryable error, not a shard rejection. A validated-hash LRU avoids re-reading on shard retries; `PutXorb` marks it too. The v2 `validating` progress frames advance per verified xorb.
- **Content binding**: `xorb.Validate` recomputes the xorb hash from the decoded chunks for both the footer and chunk-only formats, so bytes stored under a hash they do not derive to are rejected regardless of what the (writer-controlled) footer claims.
- **Upload URL hardening**: presigned PUT URLs sign the exact `Content-Length` and `If-None-Match: *`, so a URL uploads exactly the announced bytes (the server also caps announced sizes at the protocol maximum) and can never overwrite an already stored xorb, e.g. via a replayed URL after commit. Invalid direct-uploaded bytes are deleted at validation time so the content-addressed key is not poisoned for re-uploads.
- **Client**: the xorb POST sends `X-Xet-Direct-Upload: accept` plus `Expect: 100-continue` and no longer auto-follows redirects (Go re-POSTs on 307 while the presigned URL signs PUT); it PUTs the bytes to `Location` with `If-None-Match: *` and without the `Authorization` header. 2xx reports `was_inserted: true`; a 412 means another uploader stored the same content-addressed xorb first and reports `was_inserted: false`. Shard upload is unchanged.
- **Presigning**: the presign client is built with `RequestChecksumCalculation = when_required`, so presigned PUT URLs do not fold SDK checksum headers into the signature (plain PUT clients, gofakes3/MinIO).

The conformance matrix S3 server runs presign-off so both clients' transfers stay on the recorded wire for symmetric comparison; `TestCompatibilityS3PresignedDownload` keeps presign-on coverage with Go-client uploads through the redirect and xet-core downloads via presigned GETs. Thanks to the opt-in header, presign-on servers remain fully compatible with xet-core uploads (they stream through the server).

### Hub token-route redirects (hf flow)

The hub can answer the `xet-read/write-token` routes with a redirect (e.g. moved or renamed repos). xet-core's reqwest-based token refresher follows these (up to 10 hops, dropping `Authorization`/`Cookie` once the chain leaves the previous host), while the Go token fetch used `ErrUseLastResponse` and failed on any 3xx — so an hf upload against a redirecting hub broke where xet-core works. Token fetches now default to a client mirroring reqwest's policy; the resolve HEAD keeps redirects disabled (the xet Link headers ride on the 302 itself) and caller-provided HTTP clients are respected unchanged.

Verified against the reference implementation rather than assumptions: the conformance harness gains a hub token-refresh mode (xet-core's real `DirectRefreshRouteTokenRefresher` resolving `casUrl` through the redirected route), and `TestHFUploadRedirectMatrix` round-trips **both clients** (xet-core and Go) across every server kind (file, S3, xet-core reference) x V1/V2 x 301/302/303/307/308 x same/cross-host, asserting the hub credential is kept on same-host hops and dropped after cross-host ones. Edge cases (multi-hop chains, the 10-redirect cap) are covered in the hf package tests.

Fixes #181

